### PR TITLE
feat: 图片上传压缩预览功能

### DIFF
--- a/components/Masonry.tsx
+++ b/components/Masonry.tsx
@@ -39,7 +39,7 @@ export default function Masonry(props : Readonly<ImageHandleProps>) {
         layout="masonry"
         photos={
           dataList?.map((item: ImageType) => ({
-            src: item.url,
+            src: item.preview_url || item.url,
             alt: item.detail,
             ...item
           })) || []

--- a/components/admin/list/ImageEditSheet.tsx
+++ b/components/admin/list/ImageEditSheet.tsx
@@ -67,6 +67,18 @@ export default function ImageEditSheet(props : Readonly<ImageServerHandleProps &
               }}
             />
             <Textarea
+              value={image?.preview_url}
+              onValueChange={(value) => setImageEditData({ ...image, preview_url: value })}
+              label="链接"
+              variant="bordered"
+              placeholder="输入预览链接"
+              disableAnimation
+              disableAutosize
+              classNames={{
+                input: "resize-y min-h-[40px]",
+              }}
+            />
+            <Textarea
               value={image?.detail}
               onValueChange={(value) => setImageEditData({ ...image, detail: value })}
               label="详情"

--- a/components/admin/list/ListProps.tsx
+++ b/components/admin/list/ListProps.tsx
@@ -209,7 +209,7 @@ export default function ListProps(props : Readonly<ImageServerHandleProps>) {
                   isBlurred
                   isZoomed
                   height={140}
-                  src={image.url}
+                  src={image.preview_url || image.url}
                   alt={image.detail}
                 />
               </CardBody>

--- a/components/layout/DynamicDropMenu.tsx
+++ b/components/layout/DynamicDropMenu.tsx
@@ -12,8 +12,6 @@ export default function DynamicDropMenu(props: Readonly<HandleProps>) {
   const pathname = usePathname()
   const { data } = useSWRHydrated(props)
 
-  console.log(data)
-
   return (
     <Dropdown shadow="sm" backdrop="blur">
       <DropdownTrigger>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "compressorjs": "^1.2.1",
     "crypto-js": "^4.2.0",
     "cuid": "^3.0.0",
     "dayjs": "^1.11.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   clsx:
     specifier: ^2.1.1
     version: 2.1.1
+  compressorjs:
+    specifier: ^1.2.1
+    version: 1.2.1
   crypto-js:
     specifier: ^4.2.0
     version: 4.2.0
@@ -5644,6 +5647,10 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  /blueimp-canvas-to-blob@3.29.0:
+    resolution: {integrity: sha512-0pcSSGxC0QxT+yVkivxIqW0Y4VlO2XSDPofBAqoJ1qJxgH9eiUDLv50Rixij2cDuEfx4M6DpD9UGZpRhT5Q8qg==}
+    dev: false
+
   /bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
     dev: false
@@ -5793,6 +5800,13 @@ packages:
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  /compressorjs@1.2.1:
+    resolution: {integrity: sha512-+geIjeRnPhQ+LLvvA7wxBQE5ddeLU7pJ3FsKFWirDw6veY3s9iLxAQEw7lXGHnhCJvBujEQWuNnGzZcvCvdkLQ==}
+    dependencies:
+      blueimp-canvas-to-blob: 3.29.0
+      is-blob: 2.1.0
+    dev: false
 
   /compute-scroll-into-view@3.1.0:
     resolution: {integrity: sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg==}
@@ -6768,6 +6782,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.3.0
+
+  /is-blob@2.1.0:
+    resolution: {integrity: sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==}
+    engines: {node: '>=6'}
+    dev: false
 
   /is-boolean-object@1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}

--- a/prisma/migrations/20240505105925_v3/migration.sql
+++ b/prisma/migrations/20240505105925_v3/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Images" ADD COLUMN     "preview_url" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ model VerificationToken {
 model Images {
   id               Int                @id @default(autoincrement())
   url              String?            @db.Text
+  preview_url      String?            @db.Text
   exif             Json?              @db.Json
   width            Int                @default(0)
   height           Int                @default(0)

--- a/server/lib/operate.ts
+++ b/server/lib/operate.ts
@@ -78,6 +78,7 @@ export async function insertImage(image: ImageType) {
     const resultRow = await tx.images.create({
       data: {
         url: image.url,
+        preview_url: image.preview_url,
         exif: image.exif,
         width: image.width,
         height: image.height,
@@ -133,6 +134,7 @@ export async function updateImage(image: ImageType) {
     },
     data: {
       url: image.url,
+      preview_url: image.preview_url,
       exif: image.exif,
       detail: image.detail,
       sort: image.sort,

--- a/types/index.ts
+++ b/types/index.ts
@@ -52,6 +52,7 @@ export type ExifType = {
 export type ImageType = {
   id: number;
   url: string;
+  preview_url: string;
   exif: ExifType;
   width: number;
   height: number;


### PR DESCRIPTION
- 图片上传时压缩图片并上传，生成预览链接
- 客户端相册瀑布流展示优先用预览图片展示

![image](https://github.com/besscroft/PicImpact/assets/33775809/0f749963-e597-418f-bd7e-c9236e686861)
图片从 9.8MB 压缩到 429.2KB，小卡片上预览时观感几乎不会有差距，同时也能降低渲染压力。点击图片后，仍保留原图查看。