### PR TITLE
fix: 当焦点存在于 Tablist中 方向键切换造成的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dist
 
 # local env files
 .env
+
+# nextjs --experimental-https cert file
+certificates

--- a/components/MasonryItem.tsx
+++ b/components/MasonryItem.tsx
@@ -54,6 +54,7 @@ export default function MasonryItem() {
   const props: DataProps = {
     data: MasonryViewData,
   }
+  const tabsListRef = React.useRef<HTMLDivElement>(null);
 
   const loadingHandle = React.useCallback(async (handle: string) => {
     const idx = MasonryViewDataList.findIndex((item: ImageType) => MasonryViewData.id === item.id)
@@ -96,6 +97,10 @@ export default function MasonryItem() {
 
   React.useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
+      if (tabsListRef.current && tabsListRef.current.contains(e.target as Node)) {
+        return;
+      }
+
       if (MasonryView) {
         if (e.key === "ArrowLeft") {
           loadingHandle("prev");
@@ -171,7 +176,7 @@ export default function MasonryItem() {
                 </Button>
               </div>
             }
-            <Tabs defaultValue="detail" className="w-full" aria-label="图片预览选择项">
+            <Tabs defaultValue="detail" className="w-full" ref={tabsListRef} aria-label="图片预览选择项">
               <TabsList className="grid w-full grid-cols-3">
                 <TabsTrigger value="detail">
                   <div className="flex items-center space-x-2 select-none">


### PR DESCRIPTION
当鼠标焦点位于 详情/Exif/版权 中时, 方向键切换将同时作用于 切换 Tabs 以及图片

此 Commit 通过增加一个 Tab Ref, 如果事件目标在 TabsList 内部，则不执行后续的键盘事件处理逻辑