### PR TITLE
feat: 预览图压缩参数 quality 和 maxWidth 支持配置

### DIFF
--- a/hono/settings.ts
+++ b/hono/settings.ts
@@ -14,7 +14,10 @@ app.get('/get-custom-info', async (c) => {
     'custom_favicon_url',
     'custom_author',
     'rss_feed_id',
-    'rss_user_id'
+    'rss_user_id',
+    'preview_max_width_limit',
+    'preview_max_width_limit_switch',
+    'preview_quality',
   ]);
   return c.json(data)
 })
@@ -88,9 +91,18 @@ app.put('/update-s3-info', async (c) => {
 })
 
 app.put('/update-custom-info', async (c) => {
-  const query = await c.req.json()
+  const query = await c.req.json() satisfies {
+    title: string
+    customFaviconUrl: string
+    customAuthor: string
+    feedId: string
+    userId: string
+    enablePreviewImageMaxWidthLimit: boolean
+    previewImageMaxWidth: number
+    previewQuality: number
+  }
   try {
-    await updateCustomInfo(query.title, query.customFaviconUrl, query.customAuthor, query.feedId, query.userId);
+    await updateCustomInfo(query);
     return c.json({
       code: 200,
       message: '更新成功！'

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -43,6 +43,9 @@ export async function register() {
             { config_key: 'custom_author', config_value: '', detail: '网站归属者名称' },
             { config_key: 'rss_feed_id', config_value: '', detail: 'Follow feedId' },
             { config_key: 'rss_user_id', config_value: '', detail: 'Follow userId' },
+            { config_key: 'preview_max_width_limit', config_value: '0', detail: '预览图最大宽度限制' },
+            { config_key: 'preview_max_width_limit_switch', config_value: '0', detail: '预览图最大宽度限制开关' },
+            { config_key: 'preview_quality', config_value: '0.2', detail: '预览图压缩质量' },
           ],
           skipDuplicates: true,
         })

--- a/server/db/operate.ts
+++ b/server/db/operate.ts
@@ -374,7 +374,26 @@ export async function updateCopyrightShow(id: string, show: number) {
   })
 }
 
-export async function updateCustomInfo(title: string, customFaviconUrl: string, customAuthor: string, feedId: string, userId: string) {
+export async function updateCustomInfo(payload: {
+  title: string
+  customFaviconUrl: string
+  customAuthor: string
+  feedId: string
+  userId: string
+  enablePreviewImageMaxWidthLimit?: boolean
+  previewImageMaxWidth?: number
+  previewQuality?: number
+}) {
+  const {
+    title,
+    customFaviconUrl,
+    customAuthor,
+    feedId,
+    userId,
+    enablePreviewImageMaxWidthLimit,
+    previewImageMaxWidth,
+    previewQuality,
+  } = payload
   await db.$transaction(async (tx) => {
     await tx.configs.update({
       where: {
@@ -421,6 +440,39 @@ export async function updateCustomInfo(title: string, customFaviconUrl: string, 
         updatedAt: new Date()
       }
     })
+    if (typeof enablePreviewImageMaxWidthLimit === 'boolean') {
+      await tx.configs.update({
+        where: {
+          config_key: 'preview_max_width_limit_switch'
+        },
+        data: {
+          config_value: enablePreviewImageMaxWidthLimit ? '1' : '0',
+          updatedAt: new Date(),
+        }
+      })
+    }
+    if (typeof previewImageMaxWidth === 'number' && previewImageMaxWidth > 0) {
+      await tx.configs.update({
+        where: {
+          config_key: 'preview_max_width_limit'
+        },
+        data: {
+          config_value: previewImageMaxWidth.toString(),
+          updatedAt: new Date(),
+        }
+      })
+    }
+    if (typeof previewQuality === 'number' && previewQuality > 0) {
+      await tx.configs.update({
+        where: {
+          config_key: 'preview_quality'
+        },
+        data: {
+          config_value: previewQuality.toString(),
+          updatedAt: new Date(),
+        }
+      })
+    }
   })
 }
 


### PR DESCRIPTION
目前预览图的压缩配置，对于高像素相机的原图来说，压缩之后的文件依旧偏大，预览图片加载偏慢，首页访问的时候体验会比较差。

这个修改开放了压缩过程的 quality 和 maxWidth 两个参数的配置，可以根据个人的需求进行配置，通过调整压缩图片的最大宽度和质量，进一步减小预览图片文件大小。(实际网页上能够访问到原始尺寸的预览图的情况应该很少，需要非常高分辨率的显示器）

默认 quality 是 0.2，和原来保持一致，默认不开启图片尺寸压缩，图片尺寸压缩有独立的开关和最大宽度设置

图片尺寸的压缩对画质有比较大的影响，具体策略可以再讨论一下？

默认值：
![image](https://github.com/user-attachments/assets/23448267-a19e-46a4-9e26-eae8c604307b)

配置效果：
![image](https://github.com/user-attachments/assets/5c91a77e-a506-41ee-8ec9-de9d972e8704)

