### PR TITLE
相册支持设置相册内图片排序规则

### DIFF
--- a/components/admin/album/AlbumAddSheet.tsx
+++ b/components/admin/album/AlbumAddSheet.tsx
@@ -9,6 +9,7 @@ import { useSWRHydrated } from '~/hooks/useSWRHydrated'
 import { ReloadIcon } from '@radix-ui/react-icons'
 import { Button } from '~/components/ui/button'
 import { Switch } from '~/components/ui/switch'
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
 
 export default function AlbumAddSheet(props : Readonly<HandleProps>) {
   const { isLoading, mutate, error } = useSWRHydrated(props)
@@ -164,6 +165,30 @@ export default function AlbumAddSheet(props : Readonly<HandleProps>) {
                   setData({...data, show: value ? 0 : 1})
                 }}
               />
+            </div>
+            <div className="flex flex-col gap-1 rounded-lg border p-3 shadow-sm">
+              <div className="text-medium">相册内图片排序规则</div>
+              <Select
+                value={typeof data.image_sorting === 'number' ? data.image_sorting.toString() : '1'}
+                onValueChange={(value) => {
+                  setData({
+                    ...data,
+                    image_sorting: parseInt(value),
+                  })
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="选择排序规则" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectItem value="1">上传时间从新到旧</SelectItem>
+                    <SelectItem value="2">拍摄时间从新到旧</SelectItem>
+                    <SelectItem value="3">上传时间从旧到新</SelectItem>
+                    <SelectItem value="4">拍摄时间从旧到新</SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
             </div>
             <Button
               disabled={loading}

--- a/components/admin/album/AlbumEditSheet.tsx
+++ b/components/admin/album/AlbumEditSheet.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner'
 import { ReloadIcon } from '@radix-ui/react-icons'
 import { Button } from '~/components/ui/button'
 import { Switch } from '~/components/ui/switch'
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
 
 export default function AlbumEditSheet(props : Readonly<HandleProps>) {
   const { mutate } = useSWRHydrated(props)
@@ -174,6 +175,30 @@ export default function AlbumEditSheet(props : Readonly<HandleProps>) {
               }}
             />
           </div>
+          <div className="flex flex-col gap-1 rounded-lg border p-3 shadow-sm">
+              <div className="text-medium">相册内图片排序规则</div>
+              <Select
+                value={typeof album.image_sorting === 'number' ? album.image_sorting.toString() : '1'}
+                onValueChange={(value) => {
+                  setAlbumEditData({
+                    ...album,
+                    image_sorting: parseInt(value),
+                  })
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="选择排序规则" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectItem value="1">上传时间从新到旧</SelectItem>
+                    <SelectItem value="2">拍摄时间从新到旧</SelectItem>
+                    <SelectItem value="3">上传时间从旧到新</SelectItem>
+                    <SelectItem value="4">拍摄时间从旧到新</SelectItem>
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </div>
           <Button
             disabled={loading}
             onClick={() => submit()}

--- a/prisma/migrations/20250106024234_images_sorting_in_album/migration.sql
+++ b/prisma/migrations/20250106024234_images_sorting_in_album/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "albums" ADD COLUMN     "image_sorting" SMALLINT NOT NULL DEFAULT 1;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,6 +124,7 @@ model Albums {
   updatedAt            DateTime?              @updatedAt @map("updated_at") @db.Timestamp()
   del                  Int                    @default(0) @db.SmallInt
   imagesAlbumsRelation ImagesAlbumsRelation[]
+  image_sorting        Int                    @default(1) @db.SmallInt
 
   @@map("albums")
 }

--- a/server/db/operate.ts
+++ b/server/db/operate.ts
@@ -16,7 +16,8 @@ export async function insertAlbums(album: AlbumType) {
       show: album.show,
       allow_download: album.allow_download,
       license: album.license,
-      del: 0
+      del: 0,
+      image_sorting: album.image_sorting,
     }
   })
 }
@@ -59,6 +60,7 @@ export async function updateAlbum(album: AlbumType) {
         allow_download: album.allow_download,
         license: album.license,
         updatedAt: new Date(),
+        image_sorting: album.image_sorting,
       }
     })
     await tx.imagesAlbumsRelation.updateMany({
@@ -149,7 +151,7 @@ export async function insertImage(image: ImageType) {
         type: image.type,
         show: 1,
         sort: image.sort,
-        del: 0
+        del: 0,
       }
     })
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -35,6 +35,7 @@ export type AlbumType = {
   sort: number;
   allow_download: number;
   license: string;
+  image_sorting: number;
 }
 
 export type ExifType = {


### PR DESCRIPTION
## 功能描述

支持单个相册设置相册内的图片排序规则，影响这个相册在主页面展示时的图片排序。

现在可以选择以下排序方式：
- 上传时间从新到旧（默认，现在的主线版本逻辑）
- 拍摄时间从新到旧
- 上传时间从旧到新
- 拍摄时间从旧到新

拍摄时间排序基于 exif 的 data_time

## 迁移问题

新功能需要对数据库数据做迁移，新增 exif 的 data_time，由于 prisma 不支持自动数据迁移，需要额外执行迁移脚本，脚本已经编写

prisma/migrations/20250103094031_images_sorting_in_album/data-migration.js

执行方式类似：
```
docker compose exec picimpact_web npm run data-migration:images_sorting_in_albums
```

迁移方式可以进一步讨论。

后续可能可以像 issue #72   ##讨论的那样，将排序的选择增加到主页面浏览的地方由访客选择排序规则。

![image](https://github.com/user-attachments/assets/b78427ad-362b-47e4-93f0-5f313d60fac1)

![image](https://github.com/user-attachments/assets/e2a12fd4-fbf7-4066-9ba4-cbca004957ea)
