### PR TITLE
refactor: Update type definitions and imports for improved type safety

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,6 @@
 import { fetchImagesAnalysis } from '~/server/db/query'
 import CardList from '~/components/admin/dashboard/CardList'
-import { DataProps } from '~/types'
+import { AnalysisDataProps } from '~/types'
 
 export default async function Admin() {
   const getData = async (): Promise<{
@@ -8,6 +8,11 @@ export default async function Admin() {
     showTotal: number
     crTotal: number
     tagsTotal: number
+    cameraStats: Array<{
+      camera: string;
+      lens: string;
+      count: number;
+    }>;
     result: any[]
   }> => {
     'use server'
@@ -17,7 +22,7 @@ export default async function Admin() {
 
   const data = await getData()
 
-  const props: DataProps = {
+  const props: AnalysisDataProps = {
     data: data,
   }
 

--- a/components/admin/dashboard/CardList.tsx
+++ b/components/admin/dashboard/CardList.tsx
@@ -8,7 +8,7 @@ import {
 } from '~/components/ui/card'
 import { Button } from '~/components/ui/button'
 import { Progress } from '~/components/ui/progress'
-import { DataProps } from '~/types'
+import { AnalysisDataProps } from '~/types'
 import Link from 'next/link'
 import { MessageSquareHeart, Star } from 'lucide-react'
 import Counter from '~/components/animata/text/counter'
@@ -23,7 +23,7 @@ import {
 import { useTranslations } from 'next-intl'
 import { ScrollArea } from "~/components/ui/scroll-area"
 
-export default function CardList(props: Readonly<DataProps>) {
+export default function CardList(props: Readonly<AnalysisDataProps>) {
   const t = useTranslations()
 
   return (

--- a/components/admin/list/ImageBatchDeleteSheet.tsx
+++ b/components/admin/list/ImageBatchDeleteSheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { DataProps, ImageServerHandleProps, ImageType } from '~/types'
+import { ImageListDataProps, ImageServerHandleProps, ImageType } from '~/types'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '~/components/ui/sheet'
 import React, { useState } from 'react'
 import { useButtonStore } from '~/app/providers/button-store-Providers'
@@ -24,7 +24,7 @@ import {
 } from '~/components/ui/dialog'
 import { Label } from '~/components/ui/label.tsx'
 
-export default function ImageBatchDeleteSheet(props : Readonly<ImageServerHandleProps & { dataProps: DataProps } & { pageNum: number } & { album: string }>) {
+export default function ImageBatchDeleteSheet(props : Readonly<ImageServerHandleProps & { dataProps: ImageListDataProps } & { pageNum: number } & { album: string }>) {
   const { dataProps, pageNum, album, ...restProps } = props
   const { mutate } = useSWRInfiniteServerHook(restProps, pageNum, album)
   const { imageBatchDelete, setImageBatchDelete } = useButtonStore(

--- a/components/admin/list/ImageView.tsx
+++ b/components/admin/list/ImageView.tsx
@@ -2,7 +2,7 @@
 
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '~/components/ui/sheet'
 import { useButtonStore } from '~/app/providers/button-store-Providers'
-import { DataProps, ImageType } from '~/types'
+import { ImageDataProps, ImageType } from '~/types'
 import React from 'react'
 import { fetcher } from '~/lib/utils/fetcher'
 import useSWR from 'swr'
@@ -17,7 +17,7 @@ export default function ImageView() {
   )
   const { data } = useSWR('/api/v1/copyrights/get', fetcher)
 
-  const props: DataProps = {
+  const props: ImageDataProps = {
     data: imageViewData,
   }
 

--- a/components/admin/list/ListProps.tsx
+++ b/components/admin/list/ListProps.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import { DataProps, ImageServerHandleProps, ImageType, AlbumType } from '~/types'
+import { ImageListDataProps, ImageServerHandleProps, ImageType, AlbumType } from '~/types'
 import { useSWRInfiniteServerHook } from '~/hooks/useSWRInfiniteServerHook'
 import { useSWRPageTotalServerHook } from '~/hooks/useSWRPageTotalServerHook'
 import { ConfigProvider, Pagination } from 'antd'
@@ -64,7 +64,7 @@ export default function ListProps(props : Readonly<ImageServerHandleProps>) {
   const { data: albums, isLoading: albumsLoading } = useSWR('/api/v1/albums/get', fetcher)
   const t = useTranslations()
 
-  const dataProps: DataProps = {
+  const dataProps: ImageListDataProps = {
     data: data,
   }
 

--- a/components/album/ExifView.tsx
+++ b/components/album/ExifView.tsx
@@ -10,13 +10,13 @@ import {
 } from "~/components/ui/table"
 import { Card } from '~/components/ui/card'
 import React from 'react'
-import { DataProps } from '~/types'
+import { ImageDataProps } from '~/types'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
 
 dayjs.extend(customParseFormat)
 
-export default function ExifView(props: Readonly<DataProps>) {
+export default function ExifView(props: Readonly<ImageDataProps>) {
   return (
     <Card className="show-up-motion">
       <Table aria-label="照片 Exif 信息">

--- a/components/album/MasonryItem.tsx
+++ b/components/album/MasonryItem.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useButtonStore } from '~/app/providers/button-store-Providers'
-import { CopyrightType, DataProps, ImageType } from '~/types'
+import { CopyrightType, ImageType, ImageDataProps } from '~/types'
 import {
   Aperture,
   Camera,
@@ -56,7 +56,7 @@ export default function MasonryItem() {
   )
   const { data: download = false, mutate: setDownload } = useSWR(['masonry/download', MasonryViewData.url], null)
 
-  const props: DataProps = {
+  const props: ImageDataProps = {
     data: MasonryViewData,
   }
   const tabsListRef = React.useRef<HTMLDivElement>(null);

--- a/components/layout/AlbumDrawer.tsx
+++ b/components/layout/AlbumDrawer.tsx
@@ -2,12 +2,12 @@
 
 import {BookImage, Home, Images} from 'lucide-react'
 import { Drawer } from 'vaul'
-import { AlbumType, DataProps } from '~/types'
+import { AlbumType, AlbumListProps } from '~/types'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next-nprogress-bar'
 import { usePathname } from 'next/navigation'
 
-export default function AlbumDrawer(props: Readonly<DataProps>) {
+export default function AlbumDrawer(props: Readonly<AlbumListProps>) {
   const { data: session } = useSession()
   const router = useRouter()
   const pathname = usePathname()

--- a/components/layout/DynamicNavbar.tsx
+++ b/components/layout/DynamicNavbar.tsx
@@ -1,7 +1,7 @@
 import VaulDrawer from '~/components/layout/VaulDrawer'
 import { DropMenu } from '~/components/layout/DropMenu'
 import { fetchAlbumsShow } from '~/server/db/query'
-import { DataProps } from '~/types'
+import { AlbumListProps } from '~/types'
 import AlbumDrawer from '~/components/layout/AlbumDrawer'
 
 export default async function DynamicNavbar() {
@@ -12,7 +12,7 @@ export default async function DynamicNavbar() {
 
   const data = await getData()
 
-  const props: DataProps = {
+  const props: AlbumListProps = {
     data: data
   }
 

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -2,7 +2,7 @@ import Logo from '~/components/layout/Logo'
 import DynamicNavbar from '~/components/layout/DynamicNavbar'
 import HeaderLink from '~/components/layout/HeaderLink'
 import { fetchAlbumsShow,fetchAlbumsShowOptions } from '~/server/db/query'
-import { DataProps } from '~/types'
+import { AlbumDataProps } from '~/types'
 
 export default async function Header() {
   const getData = async () => {
@@ -18,7 +18,7 @@ export default async function Header() {
   const data = await getData()
   const customFoldAlbumEnable = await getCustomFoldAlbumEnable()
 
-  const props: DataProps = {
+  const props: AlbumDataProps = {
     data: data,
     customFoldAlbumEnable: customFoldAlbumEnable.enabled,
     customFoldAlbumCount: customFoldAlbumEnable.count

--- a/components/layout/HeaderLink.tsx
+++ b/components/layout/HeaderLink.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { AlbumType } from '~/types'
+import { AlbumType, AlbumDataProps } from '~/types'
 import { usePathname } from 'next/navigation'
 import { useRouter } from 'next-nprogress-bar'
-import { DataProps } from '~/types'
 import { useTranslations } from 'next-intl'
 import {
   NavigationMenu,
@@ -17,7 +16,7 @@ import { cn } from '~/lib/utils'
 import React from 'react'
 import { Button } from '~/components/ui/button'
 
-export default function HeaderLink(props: Readonly<DataProps>) {
+export default function HeaderLink(props: Readonly<AlbumDataProps>) {
   const pathname = usePathname()
   const router = useRouter()
   const t = useTranslations()

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,5 +1,5 @@
-export type DataProps = {
-  data: any
+export type AlbumDataProps = {
+  data: AlbumType[]
   customFoldAlbumEnable: boolean
   customFoldAlbumCount: number
 }
@@ -33,12 +33,15 @@ export type AlbumType = {
   id: string;
   name: string;
   album_value: string;
-  detail: string;
+  detail: string | null;
   show: number;
   sort: number;
   allow_download: number;
-  license: string;
+  license: string | null;
   image_sorting: number;
+  del?: number;
+  createdAt?: Date;
+  updatedAt?: Date | null;
 }
 
 export type ExifType = {
@@ -101,4 +104,36 @@ export type Config = {
   config_key: string;
   config_value: string;
   detail: string;
+}
+
+export type AlbumListProps = {
+  data: AlbumType[]
+}
+
+export type ImageDataProps = {
+  data: ImageType
+}
+
+export type ImageListDataProps = {
+  data: ImageType[]
+}
+
+export type AnalysisDataProps = {
+  data: {
+    total: number;
+    showTotal: number;
+    crTotal: number;
+    tagsTotal: number;
+    cameraStats: Array<{
+      camera: string;
+      lens: string;
+      count: number;
+    }>;
+    result: Array<{
+      name: string;
+      value: string;
+      total: number;
+      show_total: number;
+    }>;
+  }
 }


### PR DESCRIPTION
- Renamed generic DataProps to more specific type names (e.g., AlbumDataProps, ImageDataProps)
- Added new type definitions like AnalysisDataProps for dashboard statistics
- Updated imports across multiple components to use new type definitions
- Improved type specificity in admin, album, and layout components

Signed-off-by: Manjusaka <me@manjusaka.me>