### PR TITLE
feat: add close button to photo preview page

### DIFF
--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -16,6 +16,7 @@ import { ApertureIcon } from '~/components/icons/aperture'
 import { TimerIcon } from '~/components/icons/timer'
 import { CrosshairIcon } from '~/components/icons/crosshair'
 import { GaugeIcon } from '~/components/icons/gauge'
+import { XIcon } from '~/components/icons/x'
 import 'react-lazy-load-image-component/src/effects/blur.css'
 import { Badge } from '~/components/ui/badge'
 import { LanguagesIcon } from '~/components/icons/languages'
@@ -42,22 +43,30 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   }
   const { data: configData } = useSwrHydrated(configProps)
 
+  const handleClose = () => {
+    if (props.data?.album) {
+      router.push(`/${props.data.album}`)
+    } else {
+      router.push('/')
+    }
+  }
+
   async function downloadImg() {
     setDownload(true)
     try {
       let msg = '开始下载，原图较大，请耐心等待！'
-      if (props.data.album_license != null) {
+      if (props.data?.album_license != null) {
         msg += '图片版权归作者所有, 分享转载需遵循 ' + props.data.album_license + ' 许可协议！'
       }
 
       toast.warning(msg, { duration: 1500 })
-      await fetch(`/api/open/get-image-blob?imageUrl=${props.data.url}`)
+      await fetch(`/api/open/get-image-blob?imageUrl=${props.data?.url}`)
         .then((response) => response.blob())
         .then((blob) => {
           const url = window.URL.createObjectURL(new Blob([blob]));
           const link = document.createElement("a");
           link.href = url;
-          const parsedUrl = new URL(props.data.url);
+          const parsedUrl = new URL(props.data?.url ?? '');
           const filename = parsedUrl.pathname.split('/').pop();
           link.download = filename || "downloaded-file";
           document.body.appendChild(link);
@@ -71,9 +80,24 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
     }
   }
 
+  if (!props.data) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <p className="text-gray-500">加载中...</p>
+      </div>
+    )
+  }
+
   return (
     <div className="flex flex-col overflow-y-auto scrollbar-hide h-full !rounded-none max-w-none gap-0 p-2">
-      <div className="h-full flex flex-col space-y-2 sm:grid sm:gap-2 sm:grid-cols-3 w-full">
+      <div className="relative h-full flex flex-col space-y-2 sm:grid sm:gap-2 sm:grid-cols-3 w-full">
+        <button 
+          onClick={handleClose}
+          className="absolute right-2 top-2 z-50 p-2 rounded-full bg-gray-800/50 hover:bg-gray-700/50 transition-colors"
+          aria-label="返回"
+        >
+          <XIcon className="text-white" size={24} />
+        </button>
         <div className="show-up-motion sm:col-span-2 sm:flex sm:justify-center sm:max-h-[90vh] select-none">
           {
             props.data.type === 1 ?

--- a/components/icons/x.tsx
+++ b/components/icons/x.tsx
@@ -1,0 +1,21 @@
+import { IconProps } from '~/types/props'
+
+export const XIcon = ({ size = 24, className }: IconProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  )
+} 


### PR DESCRIPTION
- Add close button in the top-right corner of photo preview
- Implement smart navigation logic based on photo's album
- Return to album page when closing from album view
- Return to homepage when closing from direct access
- Add loading state for better UX

Signed-off-by: Manjusaka <me@manjusaka.me>