### PR TITLE
fix: The method of removing pictures by clearing AlistMountPath and StorageSelect results in the inability to upload again.

### DIFF
--- a/components/admin/upload/livephoto-file-upload.tsx
+++ b/components/admin/upload/livephoto-file-upload.tsx
@@ -296,8 +296,6 @@ export default function LivephotoFileUpload() {
   }
 
   function onRemoveFile() {
-    setStorageSelect(false)
-    setAlistMountPath('')
     setExif({} as ExifType)
     setUrl('')
     setTitle('')

--- a/components/admin/upload/multiple-file-upload.tsx
+++ b/components/admin/upload/multiple-file-upload.tsx
@@ -240,8 +240,6 @@ export default function MultipleFileUpload() {
   }
 
   function onRemoveFile() {
-    setStorageSelect(false)
-    setAlistMountPath('')
     setLat('')
     setLon('')
   }

--- a/components/admin/upload/simple-file-upload.tsx
+++ b/components/admin/upload/simple-file-upload.tsx
@@ -289,8 +289,6 @@ export default function SimpleFileUpload() {
   }
 
   function onRemoveFile() {
-    setStorageSelect(false)
-    setAlistMountPath('')
     setExif({} as ExifType)
     setUrl('')
     setTitle('')


### PR DESCRIPTION
修改了移除上传图片按钮的  onRemoveFile 逻辑，之前的逻辑会导致点击移除某个图片列表导致无法继续选择图片。

Modified the onRemoveFile logic for removing the upload picture button, the previous logic would cause clicking to remove a picture from the list to prevent further picture selection.