### PR TITLE
fix: Enhance header navigation buttons with tooltips and accessibility

### DIFF
--- a/components/layout/header-icon-group.tsx
+++ b/components/layout/header-icon-group.tsx
@@ -8,9 +8,12 @@ import { useButtonStore } from '~/app/providers/button-store-providers'
 import Command from '~/components/layout/command'
 import type { AlbumDataProps } from '~/types/props'
 import { useEffect } from 'react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip'
+import { useTranslations } from 'next-intl'
 
 export default function HeaderIconGroup(props: Readonly<AlbumDataProps>) {
   const router = useRouter()
+  const t = useTranslations()
   const { setCommand } = useButtonStore(
     (state) => state,
   )
@@ -30,10 +33,52 @@ export default function HeaderIconGroup(props: Readonly<AlbumDataProps>) {
   return (
     <>
       <div className="flex items-center space-x-1">
-        <LoaderPinwheelIcon size={18} onClick={() => router.push('/')} />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <LoaderPinwheelIcon 
+                size={18} 
+                onClick={() => router.push('/')}
+                aria-label={t('Link.home')}
+              />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{t('Link.home')}</p>
+          </TooltipContent>
+        </Tooltip>
+        
         {Array.isArray(props.data) && props.data.length > 0 &&
-          <GalleryThumbnailsIcon onClick={() => router.push(props.data[0].album_value ?? '/')} size={18} />}
-        <CompassIcon onClick={() => setCommand(true)} size={18} />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div>
+                <GalleryThumbnailsIcon 
+                  onClick={() => router.push(props.data[0].album_value ?? '/')} 
+                  size={18}
+                  aria-label={t('Words.album')}
+                />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>{t('Words.album')}</p>
+            </TooltipContent>
+          </Tooltip>
+        }
+        
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <CompassIcon 
+                onClick={() => setCommand(true)} 
+                size={18}
+                aria-label={t('Link.settings')}
+              />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{t('Link.settings')}</p>
+          </TooltipContent>
+        </Tooltip>
       </div>
       <Command {...props} />
     </>


### PR DESCRIPTION
## 相关 Issue

- #307

## 变更内容

为首页右侧的三个按钮添加了鼠标悬浮显示文字。

- WAI-ARIA 无障碍支持。
- 参照现有的 i18n 相关代码进行实现以保持一致性。

## 参考效果

<img width="140" alt="截屏2025-06-02 00 50 26" src="https://github.com/user-attachments/assets/7af53cd4-048b-419d-b323-21d2de0a4440" />