### PR TITLE
将卡片高度设为最小高度以防止显示溢出

### DIFF
--- a/components/admin/dashboard/card-list.tsx
+++ b/components/admin/dashboard/card-list.tsx
@@ -72,7 +72,7 @@ export default function CardList(props: Readonly<AnalysisDataProps>) {
   return (
     <div className="flex flex-col space-y-2">
       <div className="w-full grid grid-cols-1 gap-4 lg:grid-cols-3 lg:gap-6">
-        <Card className="h-80 w-full border">
+        <Card className="min-h-80 w-full border">
           <CardHeader>
             <CardTitle>{t('Dashboard.picData')}</CardTitle>
           </CardHeader>


### PR DESCRIPTION
用于防止如图所示的情况

![image](https://github.com/user-attachments/assets/f5a00357-c6b4-443f-a7d3-f5a723108611)
