### PR TITLE
fix: update R2 configuration handling in response generation

### DIFF
--- a/hono/file.ts
+++ b/hono/file.ts
@@ -194,14 +194,13 @@ app.post('/getObjectUrl', async (c) => {
 
       const r2PublicDomain = configs.find((item: Config) => item.config_key === 'r2_public_domain')?.config_value || ''
       const r2Endpoint = configs.find((item: Config) => item.config_key === 'r2_endpoint')?.config_value || ''
-      const r2Bucket = configs.find((item: Config) => item.config_key === 'r2_bucket')?.config_value || ''
 
       return Response.json({
         code: 200, data: `${
           r2PublicDomain ?
             r2PublicDomain.includes('https://') ? r2PublicDomain : `https://${r2PublicDomain}`
             : r2Endpoint.includes('https://') ? r2Endpoint : `https://${r2Endpoint}`
-        }/${r2Bucket}/${key}`
+        }/${key}`
       })
     }
   }


### PR DESCRIPTION
这里本质上的一个问题是 bucket 的domain specific 和 path specific

这里会存在一个问题是假如我的 Bucket 叫 a，我的 storage 有个前缀叫 a/ 我上传的文件叫 b.jpg，同时我有自定义的域名叫 abc.com 

那么会存在一个问题。上传文件的时候传的位置是 a/b.jpg 但是构造的 URL 却是 a/a/b.jpg 这里建议简化处理，统一要求 R2 需要自定义域名，保持逻辑和 S3 一致