### PR TITLE
自动聚焦在用户账户认证的文本框上

### DIFF
--- a/components/admin/dashboard/card-list.tsx
+++ b/components/admin/dashboard/card-list.tsx
@@ -109,7 +109,7 @@ export default function CardList(props: Readonly<AnalysisDataProps>) {
             <Progress value={(props.data?.showTotal ?? 0) / (props.data?.total ?? 1) * 100} className="w-full h-2"/>
           </CardContent>
         </Card>
-        <Card className="h-80 w-full border">
+        <Card className="min-h-80 w-full border">
           <CardHeader>
             <CardTitle>{t('Dashboard.albumData')}</CardTitle>
           </CardHeader>
@@ -134,7 +134,7 @@ export default function CardList(props: Readonly<AnalysisDataProps>) {
             </Table>
           </CardContent>
         </Card>
-        <Card className="h-80 w-full border">
+        <Card className="min-h-80 w-full border">
           <CardHeader>
             <CardTitle>{t('Dashboard.how')}</CardTitle>
           </CardHeader>

--- a/components/login/user-from.tsx
+++ b/components/login/user-from.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useRouter } from 'next-nprogress-bar'
 import { toast } from 'sonner'
 import { SafeParseReturnType, z } from 'zod'
@@ -39,6 +39,32 @@ export const UserFrom = ({
   const [password, setPassword] = useState('')
   const [token, setToken] = useState<string>('')
   const [otp, setOtp] = useState(false)
+
+  const emailRef = React.useRef<HTMLInputElement>(null)
+  const passwordRef = React.useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    emailRef.current?.focus()
+  }, [])
+
+  const emailKeyPressHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      passwordRef.current?.focus()
+    }
+  }
+
+  const passwordKeyPressHandler = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      passwordRef.current?.blur()
+      if (otp) {
+        await verifyTotp()
+      } else {
+        await handleLogin()
+      }
+    }
+  }
 
   const { setLoginHelp } = useButtonStore(
     (state) => state,
@@ -124,8 +150,10 @@ export const UserFrom = ({
                 <Input
                   id="email"
                   type="email"
+                  ref={emailRef}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
+                  onKeyDown={emailKeyPressHandler}
                   required
                 />
               </div>
@@ -142,8 +170,10 @@ export const UserFrom = ({
                 <Input
                   id="password"
                   type="password"
+                  ref={passwordRef}
                   required
                   value={password}
+                  onKeyDown={passwordKeyPressHandler}
                   onChange={(e) => setPassword(e.target.value)}
                 />
               </div>

--- a/components/sign-up/sign-up-from.tsx
+++ b/components/sign-up/sign-up-from.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useRouter } from 'next-nprogress-bar'
 import { toast } from 'sonner'
 import { SafeParseReturnType, z } from 'zod'
@@ -29,6 +29,28 @@ export const SignUpForm = ({
 
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+
+  const emailRef = React.useRef<HTMLInputElement>(null)
+    const passwordRef = React.useRef<HTMLInputElement>(null)
+  
+    useEffect(() => {
+      emailRef.current?.focus()
+    }, [])
+  
+    const emailKeyPressHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        passwordRef.current?.focus()
+      }
+    }
+  
+    const passwordKeyPressHandler = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        passwordRef.current?.blur()
+        handleSignUp()
+      }
+    }
 
   function zHandle(): SafeParseReturnType<string | any, string | any> {
     const parsedCredentials = z
@@ -95,6 +117,8 @@ export const SignUpForm = ({
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
+                  ref={emailRef}
+                  onKeyDown={emailKeyPressHandler}
                   required
                 />
               </div>
@@ -105,6 +129,8 @@ export const SignUpForm = ({
                   type="password"
                   required
                   value={password}
+                  ref={passwordRef}
+                  onKeyDown={passwordKeyPressHandler}
                   onChange={(e) => setPassword(e.target.value)}
                 />
               </div>


### PR DESCRIPTION
页面加载时：自动聚焦到邮箱
在邮箱处按下回车：自动聚焦到密码
在密码处按下回车：自动按下对应按钮，并取消聚焦

未测试的部分：与OTP的协同
