### PR TITLE
新增加载原图的功能

### DIFF
--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import type { HandleProps, ImageDataProps, PreviewImageHandleProps } from '~/types/props'
-import { LazyLoadImage } from 'react-lazy-load-image-component'
 import LivePhoto from '~/components/album/live-photo'
 import { toast } from 'sonner'
 import { LinkIcon } from '~/components/icons/link'
@@ -24,19 +23,17 @@ import { RefreshCWIcon } from '~/components/icons/refresh-cw'
 import { cn } from '~/lib/utils'
 import PreviewImageExif from '~/components/album/preview-image-exif'
 import { useSwrHydrated } from '~/hooks/use-swr-hydrated'
-import Lightbox from 'yet-another-react-lightbox'
 import 'yet-another-react-lightbox/styles.css'
-import { useRef, useState } from 'react'
-import { Zoom } from 'yet-another-react-lightbox/plugins'
+import { useState } from 'react'
 import { ExpandIcon } from '~/components/icons/expand'
 import { useTranslations } from 'next-intl'
+import ProgressiveImage from '~/components/album/progressive-image.tsx'
 
 export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   const router = useRouter()
   const t = useTranslations()
   const { data: download = false, mutate: setDownload } = useSWR(['masonry/download', props.data?.url ?? ''], null)
-  const [lightboxPhoto, setLightboxPhoto] = useState<any>(undefined)
-  const zoomRef = useRef(null)
+  const [lightboxPhoto, setLightboxPhoto] = useState<boolean>(false)
 
   const exifIconClass = 'dark:text-gray-50 text-gray-500'
   const exifTextClass = 'text-tiny text-sm select-none items-center dark:text-gray-50 text-gray-500'
@@ -137,15 +134,11 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
         <div className="show-up-motion sm:col-span-2 sm:flex sm:justify-center sm:max-h-[90vh] select-none">
           {
             props.data.type === 1 ?
-              <LazyLoadImage
-                width={props.data.width}
-                src={props.data.preview_url || props.data.url}
-                alt={props.data.detail}
-                className="object-contain md:max-h-[90vh]"
-                effect="blur"
-                wrapperProps={{
-                  style: { transitionDelay: '0.5s' },
-                }}
+              <ProgressiveImage 
+                imageUrl={props.data.url } 
+                previewUrl={props.data.preview_url}
+                showLightbox={lightboxPhoto}
+                onShowLightboxChange={(value)=>setLightboxPhoto(value)}
               />
               : <LivePhoto
                 url={props.data.preview_url || props.data.url}
@@ -269,10 +262,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
               className={exifIconClass}
               size={20}
               onClick={() => {
-                setLightboxPhoto({
-                  src: props.data.preview_url || props.data.url,
-                  alt: props.data.detail,
-                })
+                setLightboxPhoto(true)
               }}
             />
           </div>
@@ -301,17 +291,6 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
           }
         </div>
       </div>
-      <Lightbox
-        open={Boolean(lightboxPhoto)}
-        close={() => setLightboxPhoto(undefined)}
-        slides={lightboxPhoto ? [lightboxPhoto] : undefined}
-        plugins={[Zoom]}
-        zoom={{ ref: zoomRef }}
-        carousel={{ finite: true }}
-        render={{ buttonPrev: () => null, buttonNext: () => null }}
-        styles={{ root: { '--yarl__color_backdrop': 'rgba(0, 0, 0, .8)' } }}
-        controller={{ closeOnBackdropClick: true, closeOnPullUp: true, closeOnPullDown: true }}
-      />
     </div>
   )
 }

--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import { ProgressiveImageProps } from '~/types/props.ts'
+import { LazyLoadImage } from 'react-lazy-load-image-component'
+import { useEffect, useRef, useState } from 'react'
+import Lightbox from 'yet-another-react-lightbox'
+import { Zoom } from 'yet-another-react-lightbox/plugins'
+import { useTranslations } from 'next-intl'
+
+/**
+ * 渐进式图片展示组件，首先显示预览图，后台加载原始图片，当原始图片加载成功后替换预览图
+ */
+export default function ProgressiveImage(
+  props: Readonly<ProgressiveImageProps>,
+) {
+  const t = useTranslations()
+  
+  const [loadingProgress, setLoadingProgress] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [highDipImageUrl, setHighDipImageUrl] = useState<string | null>(null)
+  const [showLightbox,setShowLightbox] = useState(Boolean(props.showLightbox))
+  const zoomRef = useRef(null)
+
+  useEffect(() => {
+    setShowLightbox(Boolean(props.showLightbox))
+  }, [props.showLightbox])
+  
+  useEffect(() => {
+    loadHighResolutionImage()
+    return () => {
+      if (highDipImageUrl) {
+        // clean blob
+        URL.revokeObjectURL(highDipImageUrl)
+      }
+    }
+  }, [])
+
+  const loadHighResolutionImage = () => {
+    setIsLoading(true)
+    setLoadingProgress(0)
+    setError(null)
+
+    const xhr = new XMLHttpRequest()
+    xhr.open('GET', props.imageUrl, true)
+    xhr.responseType = 'blob'
+
+    xhr.onprogress = (e) => {
+      if (e.lengthComputable) {
+        const percentComplete = Math.round((e.loaded / e.total) * 100)
+        setLoadingProgress(percentComplete)
+      }
+    }
+
+    xhr.onload = () => {
+      if (xhr.status === 200) {
+        const imgBlob = xhr.response
+        const imgUrl = URL.createObjectURL(imgBlob)
+        setHighDipImageUrl(imgUrl)
+        setIsLoading(false)
+      } else {
+        console.log(`image load error: ${xhr.status}`)
+        setError(t('Tips.imageLoadFailed'))
+        setIsLoading(false)
+      }
+    }
+    xhr.onerror = () => {
+      setError(t('Tips.imageLoadFailed'))
+      setIsLoading(false)
+    }
+    xhr.send()
+  }
+
+  return (
+    <div className="relative">
+      {!highDipImageUrl ? (
+        <LazyLoadImage
+          width={props.width}
+          src={props.previewUrl}
+          alt={props.alt}
+          className="object-contain md:max-h-[90vh]"
+          effect="blur"
+          wrapperProps={{
+            style: { transitionDelay: '0.5s' },
+          }}
+        />
+      ) : (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={highDipImageUrl!}
+          width={props.width}
+          className="object-contain md:max-h-[90vh]"
+          alt={props.alt || 'img'}
+        />
+      )}
+
+      {isLoading && (
+        <div className="absolute bottom-0 left-0 w-full">
+          <div
+            className="h-1 bg-blue-500"
+            style={{ width: `${loadingProgress}%` }}
+          ></div>
+          <div className="absolute bottom-2 right-2 bg-black/60 text-white text-xs px-2 py-1 rounded">
+            {loadingProgress}%
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="absolute bottom-0 left-0 w-full">
+          <div className="absolute bottom-2 right-2 text-white bg-black/60 text-w text-xs px-2 py-1 rounded  ">
+            {error}
+          </div>
+        </div>
+      )}
+
+      <Lightbox
+        open={showLightbox}
+        close={() => {
+          setShowLightbox(false)
+          if (props.onShowLightboxChange) {
+            props.onShowLightboxChange(false)
+          }
+        }}
+        slides={showLightbox ? [{
+          src: highDipImageUrl ? highDipImageUrl :props.previewUrl,
+          alt: props.alt,
+        }] : undefined}
+        plugins={[Zoom]}
+        zoom={{ ref: zoomRef }}
+        carousel={{ finite: true }}
+        render={{ buttonPrev: () => null, buttonNext: () => null }}
+        styles={{ root: { '--yarl__color_backdrop': 'rgba(0, 0, 0, .8)' } }}
+        controller={{
+          closeOnBackdropClick: true,
+          closeOnPullUp: true,
+          closeOnPullDown: true,
+        }}
+      />
+    </div>
+  )
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -80,7 +80,8 @@
     "updateSuccess": "Update successful!",
     "updateFailed": "Update failed!",
     "addSuccess": "Add successful!",
-    "addFailed": "Add failed!"
+    "addFailed": "Add failed!",
+    "imageLoadFailed": "Load image failed"
   },
   "Button": {
     "login": "Login",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -80,7 +80,8 @@
     "updateSuccess": "更新に成功しました！",
     "updateFailed": "更新に失敗しました！",
     "addSuccess": "追加に成功しました！",
-    "addFailed": "追加に失敗しました！"
+    "addFailed": "追加に失敗しました！",
+    "imageLoadFailed": "画像の読み込みに失敗しました"
   },
   "Button": {
     "login": "ログイン",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -80,7 +80,8 @@
     "updateSuccess": "更新成功！",
     "updateFailed": "更新失敗！",
     "addSuccess": "添加成功！",
-    "addFailed": "添加失敗！"
+    "addFailed": "添加失敗！",
+    "imageLoadFailed": "原圖加載失敗"
   },
   "Button": {
     "login": "登入",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -80,7 +80,8 @@
     "updateSuccess": "更新成功！",
     "updateFailed": "更新失败！",
     "addSuccess": "添加成功！",
-    "addFailed": "添加失败！"
+    "addFailed": "添加失败！",
+    "imageLoadFailed": "原图加载失败"
   },
   "Button": {
     "login": "登录",

--- a/types/props.ts
+++ b/types/props.ts
@@ -32,6 +32,15 @@ export type PreviewImageHandleProps = {
   configHandle: () => any
 }
 
+export type ProgressiveImageProps = {
+  imageUrl: string, // 原始图片
+  previewUrl: string, // 预览图
+  width?: number,
+  alt?: string,
+  showLightbox?:boolean
+  onShowLightboxChange?: (value: boolean) => void
+}
+
 export type LinkProps = {
   handle: () => any
   args: string


### PR DESCRIPTION
默认详情界面显示的是预览图，在首页这种瀑布流很合适，但是详情界面本来就是想看高清的图片才会点进去，显得太糊了，此外全屏按钮同样是这个情况。
<img width="1487" height="932" alt="b5eb01875298f35a71e6e840e17a8473" src="https://github.com/user-attachments/assets/01cd3ffa-5e0c-4d16-8330-3e7d07352950" />

目前的修改，详情界面先加载预览图，由于首页已经加载了，一般会有缓存秒开。然后xhr去加载原图，显示进度条，原图加载成功后替换原先图片，同时全屏按钮也是显示原图。

预览网页： https://gallery.thetbw.xyz/