### PR TITLE
fix: add metadataBase for Telegram OG thumbnails

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -49,6 +49,7 @@ export async function generateMetadata(): Promise<Metadata> {
     : 'A photography portfolio powered by PicImpact'
 
   return {
+    metadataBase: process.env.BETTER_AUTH_URL ? new URL(process.env.BETTER_AUTH_URL) : null,
     title,
     description,
     icons: { icon: data?.find((item: ConfigItem) => item.config_key === 'custom_favicon_url')?.config_value || './favicon.ico' },


### PR DESCRIPTION
## Summary
- Add `metadataBase` to root layout using `BETTER_AUTH_URL` env var
- Without this, Next.js cannot resolve OG URLs to absolute URLs, causing Telegram to fail to display thumbnails when sharing links
- Falls back to `null` when env var is unset (dev environment)

## Test plan
- [ ] Deploy and share a `/preview/{id}` link in Telegram
- [ ] Verify thumbnail appears in Telegram chat preview
- [ ] Use [@webpagebot](https://t.me/webpagebot) to force refresh if Telegram has cached the old (broken) OG data

🤖 Generated with [Claude Code](https://claude.com/claude-code)