### PR TITLE
fix: missing comma in daily homepage migration CTE

### DIFF
--- a/prisma/migrations/20260322000000_add_daily_homepage/migration.sql
+++ b/prisma/migrations/20260322000000_add_daily_homepage/migration.sql
@@ -42,7 +42,7 @@ ranked_images AS (
   INNER JOIN "images_albums_relation" iar ON i.id = iar."imageId"
   INNER JOIN album_quotas aq ON iar.album_value = aq.album_value
   WHERE i.del = 0 AND i.show = 0
-)
+),
 deduped_images AS (
   SELECT DISTINCT ON (id)
     id, image_name, url, preview_url, video_url, blurhash, exif, labels,


### PR DESCRIPTION
## Summary

- Fix SQL syntax error (PostgreSQL 42601) in `20260322000000_add_daily_homepage` migration
- Missing comma between `ranked_images` and `deduped_images` CTEs caused deploy failure

## Recovery steps

On the production database, before re-deploying:

```bash
pnpm prisma migrate resolve --rolled-back 20260322000000_add_daily_homepage
pnpm prisma migrate deploy
```

## Test plan

- [ ] Verify migration applies cleanly on a fresh database (`pnpm prisma migrate deploy`)
- [ ] Verify `daily_images` materialized view is created with correct data
- [ ] Confirm production recovery with `migrate resolve` + `migrate deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)