### PR TITLE
feat(i18n): add localized description text for sign-in and sign-up pages

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,7 +4,7 @@ import favicon from '~/public/favicon.svg'
 import { getTranslations } from 'next-intl/server'
 
 export default async function Login() {
-  const t = await getTranslations()
+  const t = await getTranslations('Login')
 
   return (
     <div className="flex min-h-screen">
@@ -33,7 +33,7 @@ export default async function Login() {
               </div>
               <h1 className="font-display text-3xl font-semibold">PicImpact</h1>
             </div>
-            <p className="text-sm text-muted-foreground">{t('Login.signInDescription') || 'Sign in to continue'}</p>
+            <p className="text-sm text-muted-foreground">{t('signInDescription', { defaultValue: 'Sign in to continue' })}</p>
           </div>
 
           <UserFrom />

--- a/app/sign-up/page.tsx
+++ b/app/sign-up/page.tsx
@@ -12,7 +12,7 @@ export default async function SignUp() {
     redirect('/login')
   }
 
-  const t = await getTranslations()
+  const t = await getTranslations('Login')
 
   return (
     <div className="flex min-h-screen">
@@ -41,7 +41,7 @@ export default async function SignUp() {
               </div>
               <h1 className="font-display text-3xl font-semibold">PicImpact</h1>
             </div>
-            <p className="text-sm text-muted-foreground">{t('Login.signUpDescription') || 'Create your account to get started'}</p>
+            <p className="text-sm text-muted-foreground">{t('signUpDescription', { defaultValue: 'Create your account to get started' })}</p>
           </div>
 
           <SignUpForm />

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,6 +22,8 @@
     "logout": "Logout",
     "signUp": "SignUp",
     "signIn": "SignIn",
+    "signInDescription": "Sign in to continue",
+    "signUpDescription": "Create your account to get started",
     "passkeyLogin": "Sign in with Passkey",
     "or": "or"
   },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -22,6 +22,8 @@
     "logout": "ログアウト",
     "signUp": "登録する",
     "signIn": "ログイン",
+    "signInDescription": "続行するにはログインしてください",
+    "signUpDescription": "アカウントを作成して始めましょう",
     "passkeyLogin": "Passkey でログイン",
     "or": "または"
   },

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -22,6 +22,8 @@
     "logout": "登出",
     "signUp": "註冊",
     "signIn": "登入",
+    "signInDescription": "登入後繼續",
+    "signUpDescription": "建立你的帳戶以開始使用",
     "passkeyLogin": "使用 Passkey 登入",
     "or": "或者"
   },

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -22,6 +22,8 @@
     "logout": "退出登录",
     "signUp": "注册",
     "signIn": "登录",
+    "signInDescription": "登录后继续",
+    "signUpDescription": "创建你的账户以开始使用",
     "passkeyLogin": "使用 Passkey 登录",
     "or": "或者"
   },


### PR DESCRIPTION
Add descriptive text below the titles on the sign-in and sign-up pages, with multilingual support implemented via next-intl. Add new `signInDescription` and `signUpDescription` keys to the English, Simplified Chinese, Traditional Chinese, and Japanese locale files. Also update the page components to use `getTranslations('Login')` to correctly access translations within the namespace, and provide default fallback values to ensure a smooth user experience.