### PR TITLE
fix(exif): preserve image capture time on upload

### DIFF
--- a/hono/images.ts
+++ b/hono/images.ts
@@ -10,6 +10,9 @@ import {
 import { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import dayjs from 'dayjs'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
+
+dayjs.extend(customParseFormat)
 
 const app = new Hono()
 
@@ -32,7 +35,7 @@ app.post('/', async (c) => {
 
   try {
     // 验证可能存在的时间信息
-    if (body?.exif?.data_time && !dayjs(body?.exif?.data_time).isValid()) {
+    if (body?.exif?.data_time && !dayjs(body?.exif?.data_time, 'YYYY:MM:DD HH:mm:ss', true).isValid()) {
       body.exif.data_time = ''
     }
     // 保存图片信息

--- a/server/tasks/metadata-refresh.ts
+++ b/server/tasks/metadata-refresh.ts
@@ -1,9 +1,12 @@
 import 'server-only'
 
 import dayjs from 'dayjs'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
 import ExifReader from 'exifreader'
 import sharp from 'sharp'
 import { DOMParser } from '@xmldom/xmldom'
+
+dayjs.extend(customParseFormat)
 
 import type { ExifType } from '~/types'
 import type { AdminTaskIssue, AdminTaskStage } from '~/types/admin-tasks'
@@ -162,7 +165,7 @@ function normalizeExif(input: Partial<ExifType> | null | undefined): ExifType | 
     white_balance: cleanString(input?.white_balance),
   }
 
-  if (exif.data_time && !dayjs(exif.data_time).isValid()) {
+  if (exif.data_time && !dayjs(exif.data_time, 'YYYY:MM:DD HH:mm:ss', true).isValid()) {
     exif.data_time = ''
   }
 


### PR DESCRIPTION
## Summary

- Fix `hono/images.ts` create-image endpoint silently clearing valid EXIF `data_time` values
- Fix the same copy-pasted bug in the `server/tasks/metadata-refresh.ts` metadata refresh task

## Background

EXIF `DateTimeOriginal` uses the format `YYYY:MM:DD HH:mm:ss` (colons in the date portion, e.g. `2025:03:22 14:30:00`). dayjs only understands ISO 8601 by default; parsing this format requires loading the `customParseFormat` plugin and passing an explicit format string.

`hono/images.ts` validated the value with bare `dayjs(body.exif.data_time).isValid()`. Result:

- `dayjs('2025:03:22 14:30:00').isValid()` → `false`
- Triggers `body.exif.data_time = ''`
- Every newly uploaded image is persisted with an empty capture time

Every other reader of this field already handles it correctly (`components/admin/album/exif-view.tsx` extends `customParseFormat` and passes the format; `server/db/query/images.ts` orders via `TO_TIMESTAMP(... 'YYYY:MM:DD HH24:MI:SS')`). Only this validator and the metadata refresh task were broken.

Introduced in 7b5794d9 (2025-08-01, "fix(upload): valid exif data_time") — broken for ~9 months.

## Fix

In both call sites:

1. `import customParseFormat from 'dayjs/plugin/customParseFormat'` and `dayjs.extend(customParseFormat)`
2. Validate with `dayjs(value, 'YYYY:MM:DD HH:mm:ss', true).isValid()` (strict mode, so unexpected formats still get rejected)

Behavior verified:
- `'2025:03:22 14:30:00'` → valid ✓
- empty string, random text, ISO 8601 → invalid (cleared) ✓

## Test plan

- [ ] Upload a JPEG that has an EXIF capture time; confirm `image.exif->>'data_time'` is populated and the preview page / admin list show the capture time
- [ ] Upload an image with no capture time; confirm it still saves cleanly (empty `data_time`, no error)
- [ ] Run the admin "image metadata maintenance" task; confirm historical images get their `data_time` backfilled from storage
- [ ] Sorting by capture time (asc/desc) works in all entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)