### PR TITLE
refactor(api): foundation for API refactor — helpers, session ctx, doc sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,38 @@ All API responses MUST follow this envelope format:
 **Rules:**
 - GET endpoints: return `{ code: 200, message: 'Success', data: <result> }`
 - Mutation endpoints (POST/PUT/DELETE): return `{ code: 200, message: 'Success' }`
-- Errors: throw `HTTPException(statusCode, { message })`, handled by global `onError`
-- Binary endpoints (image blob, file download): return raw binary with appropriate Content-Type header
+- Errors: throw via helpers in `hono/_lib/errors.ts` (`badRequest`, `notFound`, `conflict`, `serverError`); the global `onError` in `hono/index.ts` shapes the response into the envelope.
+- Binary endpoints (image blob, file download): return raw binary with appropriate Content-Type header.
+
+### API Helpers (`hono/_lib/`)
+
+Use these in every Hono handler instead of writing `c.json(...)` by hand:
+
+```ts
+import { ok, okEmpty } from '~/hono/_lib/response'
+import { badRequest, notFound, conflict, serverError } from '~/hono/_lib/errors'
+
+app.get('/things', async (c) => {
+  const data = await fetchThings()
+  return ok(c, data)                       // { code: 200, message: 'Success', data }
+})
+
+app.put('/things', async (c) => {
+  await updateThing(await c.req.json())
+  return okEmpty(c)                        // { code: 200, message: 'Success' }
+})
+
+app.post('/things', async (c) => {
+  const body = await c.req.json()
+  if (!body.name) throw badRequest('name is required')
+  // ...
+})
+```
+
+The `sessionMiddleware` in `hono/_lib/context.ts` is mounted on the `/api/v1` chain;
+handlers can read `c.get('session')` to access the better-auth session (or `null`
+when unauthenticated). `requireAuth` is exported but **not yet mounted** — opt-in
+per module is tracked in the API refactor plan.
 
 ### URL Naming Convention
 
@@ -217,15 +247,15 @@ All API responses MUST follow this envelope format:
 
 ### Known Deviations from Target Standard
 
-These endpoints currently deviate from the above specification and should be migrated:
+Tracked in `docs/plans/2026-05-19-api-refactor-design.md`. Snapshot:
 
-1. **GET endpoints returning raw arrays** — Settings, Albums, Daily config GETs return unwrapped arrays instead of `{ code, data }` envelope. Migration requires updating all frontend `useSWR` consumers.
-2. **`/api/v1/images/update-Album`** — PascalCase, should be `/api/v1/images/update-album`.
-3. ~~`/api/v1/file/getObjectUrl`~~ — **DONE:** Renamed to `/api/v1/file/object-url`.
-4. **`/api/v1/settings/get-custom-info`** — Verb prefix on GET, should be `/api/v1/settings/custom-info`.
-5. **`/api/v1/settings/get-admin-config`** — Same issue, should be `/api/v1/settings/admin-config`.
-6. **Request body snake_case** — Some endpoints accept `album_value`, `image_name` in snake_case instead of camelCase.
-7. **`/api/public/download/:id`** — Returns either binary or JSON depending on config, should be consistent.
+1. **snake_case data model leak** — `Config.config_key/config_value`, `Album.album_value`, `Image.image_name`, `image_sorting`, `show_on_mainpage`, `Exif.data_time` are exposed in API responses and request bodies. Server-side mapping layer pending. (PR-07, PR-08, PR-09.)
+2. **`/api/public/download/:id` dual return type** — Returns binary blob OR `{ url, filename }` JSON depending on direct-download config. To be split into `/download/:id` (binary) and `/download/:id/presigned` (JSON envelope). (PR-01.)
+3. **`/api/public/images/image-blob` SSRF** — Accepts arbitrary `imageUrl` query parameter and fetches server-side with no allowlist. Recommended action: remove (no in-repo consumers). (PR-02.)
+4. **`/api/v1/images/camera-lens-list` & `/api/public/camera-lens-list`** — Still Next.js route handlers instead of Hono; public variant lacks `show=true` album filtering. (PR-04.)
+5. **Settings PUT body shape** — `/settings/{r2,s3,open-list}-info` PUT accepts `Config[]` array with snake_case `config_key/config_value` instead of a flat camelCase object. (PR-07.)
+6. **Per-handler auth & admin layout server check** — `/api/v1/*` auth is enforced only in `proxy.ts` middleware; no defense-in-depth. `app/admin/layout.tsx` has no server-side session check. (PR-10.)
+7. **Tasks advisory lock scope** — `kickMetadataTaskRun` holds `withTaskLock` across the entire 10-image batch (~200s worst case). (PR-05.)
 
 ## Environment Variables
 

--- a/docs/plans/2026-05-19-api-refactor-design.md
+++ b/docs/plans/2026-05-19-api-refactor-design.md
@@ -1,0 +1,301 @@
+# API & Architecture Refactor — Design
+
+**Date:** 2026-05-19
+**Status:** Proposed
+**Scope:** API spec compliance, snake_case data model cleanup, auth hardening, upload pipeline correctness
+
+---
+
+## Overview
+
+A multi-issue audit (Auth/Middleware, Upload pipeline, Backup+Tasks, Type system, Public API) surfaced 18 problems clustered into 6 themes. CLAUDE.md's "Known Deviations" list is largely **out of date** — 4 of the 7 documented deviations are already fixed, but new debt has accumulated.
+
+This plan splits remediation into **13 PRs across 4 waves**, optimized for parallel execution by independent agents with minimal file-level merge conflict.
+
+### Audit Source Material
+
+Five parallel Explore agents audited the codebase on 2026-05-19. Their findings are summarized below.
+
+---
+
+## Goals
+
+- Standardize all API responses on the documented envelope (`{ code, message, data? }`).
+- Eliminate database snake_case from the public API contract and frontend types.
+- Add defense-in-depth auth (per-handler `requireAuth` middleware, server-side admin layout check).
+- Close the SSRF hole on `/api/public/images/image-blob`.
+- Centralize upload validation; deduplicate three near-identical upload components.
+- Reduce advisory-lock scope around long-running task batches.
+- Keep CLAUDE.md as the living source-of-truth — sync it with reality.
+
+### Explicit Non-Goals (YAGNI)
+
+- Backup format V2 versioning — defer until V2 is actually needed.
+- CSRF tokens and per-user rate limiting — separate spike, requires threat model.
+- Migrating better-auth `/api/auth/*` under Hono — works fine as-is.
+- Renaming Prisma columns in the database — schema stays snake_case; remap at server boundary.
+
+---
+
+## Issue Inventory
+
+### A. API envelope & status codes (low risk)
+- A1. `/api/v1/file/{presigned-url,upload,object-url}` returns `{ code, data }` without `message`; `data` shape inconsistent (string vs object).
+- A2. `hono/images.ts` lines 27/30/32/74/78/80 and `hono/file.ts:144` throw HTTP 500 for client-input validation errors that should be 400.
+- A3. `hono/backup.ts` `/export` returns raw JSON via `c.body()`, bypassing the envelope.
+- A4. `hono/tasks.ts:105` returns HTTP 201 with `code: 200` in the body — contradictory.
+- A5. CLAUDE.md "Known Deviations" entries 1–5 are already fixed but still documented.
+
+### B. Public API correctness & security (mixed risk)
+- B1. **SSRF**: `/api/public/images/image-blob` (`hono/open/images.ts:8-20`) accepts arbitrary `imageUrl` and fetches server-side with no allowlist or private-IP check.
+- B2. `/api/public/download/:id` returns binary blob OR JSON `{ url, filename }` depending on direct-download config — same endpoint, two contracts.
+- B3. `/api/public/camera-lens-list` (Next route handler) and `/api/v1/images/camera-lens-list` (Next route handler) duplicate logic; public variant lacks album filtering.
+- B4. No `Cache-Control` headers on public endpoints, RSS feed, or sitemap.
+- B5. Next.js route handlers under `app/api/{public,v1}/.../route.ts` for camera-lens-list inconsistent with Hono pattern used elsewhere.
+
+### C. snake_case data model leak (large blast radius)
+- C1. `Config.config_key` / `config_value` appear in ~42 files (all layouts, admin settings, gallery themes).
+- C2. `ExifType.data_time` appears in 8 files; isolated, easiest to migrate.
+- C3. `Album.album_value`, `Image.image_name`, `image_sorting`, `show_on_mainpage` appear in ~25–30 files combined.
+- C4. Settings PUT endpoints (`/r2-info`, `/s3-info`, `/open-list-info`) accept `Config[]` array bodies with snake_case keys instead of camelCase objects.
+
+### D. Auth architecture (high risk)
+- D1. `/api/v1/*` auth is enforced **only** in `proxy.ts` middleware. Hono handlers never re-check the session. If the middleware matcher breaks, endpoints are open.
+- D2. `app/admin/layout.tsx` has no server-side auth check — the layout renders before the proxy redirect resolves; UI structure leaks on direct hits.
+- D3. better-auth session is not propagated into Hono context (`c.set('session', ...)`), so handlers can't do user-scoped logic or audit logging.
+
+### E. Upload pipeline (medium risk)
+- E1. No file-size limit, MIME validation, or filename path-traversal check (`hono/file.ts`, `server/lib/file-upload.ts`).
+- E2. Three upload components (`simple-file-upload.tsx`, `livephoto-file-upload.tsx`, `multiple-file-upload.tsx`) duplicate ~80% of upload/EXIF/HEIC logic.
+- E3. `openListUpload` returns `undefined` on success instead of throwing; caller can't distinguish success from silent failure.
+
+### F. Tasks correctness (high risk)
+- F1. `kickMetadataTaskRun` (`server/tasks/service.ts:661-738`) holds the advisory lock for the entire 10-image batch including ~20s-per-image fetch timeouts → lock held ~200s worst case, blocking concurrent lease attempts.
+
+---
+
+## PR Plan
+
+### Wave 0 — Foundation (1 PR, blocks all others)
+
+#### PR-00 ｜ `chore(api): foundation refactor — helpers, session context, doc sync`
+
+**Touches every `hono/*.ts` once so subsequent PRs don't need to.** Heavy by design.
+
+**Changes:**
+1. New `hono/_lib/response.ts`:
+   ```ts
+   export const ok = <T>(c, data?: T) =>
+     c.json({ code: 200, message: 'Success', data })
+   export const okEmpty = (c) =>
+     c.json({ code: 200, message: 'Success' })
+   ```
+2. New `hono/_lib/errors.ts`: `BadRequestError`, `NotFoundError`, `ConflictError` wrapping `HTTPException`. Updated `onError` in `hono/index.ts`.
+3. New `hono/_lib/context.ts`: in `app/api/[[...route]]/route.ts`, parse better-auth session once and `c.set('session', session)`. Export a `requireAuth()` middleware **but do not mount it yet** — PR-10 opts in per module.
+4. Mechanical replacement across all `hono/*.ts`: every `c.json({ code: 200, ... })` → `ok(c, ...)` / `okEmpty(c)`. Fills in the missing `message` field everywhere.
+5. Same pass fixes A4 (tasks POST `/runs` 201/200 conflict) by either returning 201 with `code: 201` or 200 — pick one.
+6. CLAUDE.md sync: delete already-fixed deviations 1–5; replace with the inventory above; add `## API Helpers` section explaining `ok`/`okEmpty` convention.
+
+**Files:** `hono/_lib/{response,errors,context}.ts` (new); `hono/index.ts`; `app/api/[[...route]]/route.ts`; `hono/{settings,images,albums,daily,file,tasks,backup,storage/open-list,open/download,open/images}.ts`; `CLAUDE.md`.
+
+**Risk:** Medium — large mechanical diff. Mitigation: smoke-test admin panel + gallery + single upload locally before merge.
+
+**Validation:**
+- `pnpm run lint` clean.
+- `pnpm run build` succeeds.
+- Manual: log in to admin, browse gallery, upload one image, edit one album.
+
+**Verification:** `curl /api/v1/albums` and `/api/v1/settings/custom-info` both return `{ code: 200, message: 'Success', data: [...] }`.
+
+---
+
+### Wave 1 — Leaf PRs (6 PRs, fully parallel after PR-00)
+
+File sets are disjoint; agents can grab any task in any order.
+
+#### PR-01 ｜ `feat(api): split public/download into binary vs presigned endpoints`
+
+Split `/api/public/download/:id` into two endpoints with single contracts:
+- `GET /api/public/download/:id` → always binary blob with `Content-Disposition`.
+- `GET /api/public/download/:id/presigned` → always JSON `{ code, data: { url, filename } }`.
+
+Frontend (`components/album/preview-image.tsx`) picks endpoint by `direct-download` config flag fetched alongside other settings, not by inferring from response shape.
+
+**Files:** `hono/open/download.ts`; `components/album/preview-image.tsx`. **Risk:** Medium.
+
+#### PR-02 ｜ `fix(security): remove image-blob SSRF surface`
+
+**Recommended:** delete `GET /api/public/images/image-blob` entirely — `grep` shows no frontend consumer. If the route must be kept, add a host allowlist sourced from configured S3/R2/Open List endpoints and reject everything else.
+
+**Files:** `hono/open/images.ts`. **Risk:** High (public contract change). Validate by deploying to a preview env and watching access logs for 404s on the old path.
+
+#### PR-03 ｜ `chore(seo): add Cache-Control to RSS & sitemap`
+
+Add `Cache-Control: public, max-age=3600` to `/rss.xml` and `/sitemap.xml`. Trivial.
+
+**Files:** `app/rss.xml/route.ts`; `app/sitemap.ts` if present. **Risk:** Low.
+
+#### PR-04 ｜ `refactor(api): consolidate camera-lens-list under Hono`
+
+- Delete `app/api/public/camera-lens-list/route.ts` and `app/api/v1/images/camera-lens-list/route.ts`.
+- New `hono/open/camera-lens.ts` with two endpoints: public version returns filtered set (only albums where `show=true`); protected version returns full set.
+- Mount under `route.route('/open/camera-lens', cameraLens)` and `route.route('/images/camera-lens', cameraLens)` as appropriate.
+
+**Files:** delete 2 route handlers; new `hono/open/camera-lens.ts`; update `hono/index.ts`; update consumers in `components/album/camera-lens-filter.tsx` and `components/admin/list/list-props.tsx`. **Risk:** Medium.
+
+#### PR-05 ｜ `fix(tasks): reduce advisory lock scope around batch processing`
+
+Refactor `server/tasks/service.ts:661-738` so `withTaskLock()` only wraps state transitions (lease acquisition, status update), not the image-fetch loop. Batch fetches happen outside the lock; results are committed under a fresh short-lived lock acquisition.
+
+Add a logger.warn when `withTaskLock` returns null so silent failures become visible.
+
+**Files:** `server/tasks/service.ts`. **Risk:** High (concurrency). Validation: integration test that runs two concurrent kicks and verifies neither stalls > 30s.
+
+#### PR-06 ｜ `feat(upload): server-side validation — size, MIME, path traversal`
+
+- Max upload size from `max_upload_size` config (new) or hardcoded 50MB initially.
+- MIME allowlist: `image/*` plus configured Live Photo formats.
+- Filename sanitization: reject `..`, leading `/`, NUL bytes; run `path.basename`.
+- Update `hono/file.ts` `/presigned-url` and `/upload` to validate before any S3/R2 call.
+- Use new `BadRequestError` from PR-00.
+
+**Files:** `hono/file.ts`; `server/lib/file-upload.ts`. **Risk:** Medium.
+
+---
+
+### Wave 2A — snake_case independent (2 PRs, parallel)
+
+Both touch `types/index.ts` but **different type names**; Git merge will likely auto-resolve, and PR-09 in Wave 2B rebases last.
+
+#### PR-07 ｜ `refactor(api): configs key/value camelCase + settings PUT camelCase body`
+
+**Two coupled changes, bundled because both touch `hono/settings.ts`:**
+
+1. Response shape: `/settings/{custom,r2,s3,open-list,admin-config}-info` and `/daily/config` return `data: { customTitle, customAuthor, ... }` (flat camelCase object) instead of `Config[]` array. Server-side `fetchConfigsByKeys` keeps its current return shape; transform in route handler.
+2. Request shape: settings PUT endpoints accept `{ r2AccesskeyId, r2Bucket, ... }` flat camelCase object instead of `[{ config_key, config_value }, ...]`.
+
+Migrate ~8 frontend consumers:
+- `app/layout.tsx`, `app/(theme)/[...album]/layout.tsx`, `app/(theme)/map/layout.tsx`
+- `app/admin/settings/preferences/page.tsx`, `app/admin/settings/daily/page.tsx`
+- `components/admin/settings/storages/{r2,s3,open-list}-edit-sheet.tsx`
+- `components/layout/theme/polaroid/polaroid-gallery.tsx`, `simple-gallery.tsx`
+- `hooks/use-upload-config.ts`
+
+**Files:** `hono/settings.ts`, `hono/daily.ts` (read paths); `types/index.ts` (Config type rename + new shape interfaces); ~8 frontend files. **Risk:** Medium.
+
+#### PR-08 ｜ `refactor(types): exif.data_time → exif.dateTime`
+
+Smallest snake_case PR; serves as warm-up.
+
+- Rename `ExifType.data_time` → `dateTime` in `types/index.ts`.
+- Update raw SQL aliases in `server/db/query/images.ts` to emit `dateTime` key.
+- Update `hono/images.ts` POST validation field.
+- Update `components/album/preview-image-exif.tsx`.
+- Update 3 upload components where `exif.data_time` is set from EXIF parsing.
+
+**Files:** `types/index.ts`; `hono/images.ts`; `server/db/query/images.ts`; `components/album/preview-image-exif.tsx`; `components/admin/upload/{simple,livephoto,multiple}-file-upload.tsx`. **Risk:** Low.
+
+---
+
+### Wave 2B — snake_case bulk rename (1 PR, after PR-08)
+
+PR-09 depends on PR-08 because `Image` type embeds `ExifType`.
+
+#### PR-09 ｜ `refactor(types): album_value/image_name/image_sorting/show_on_mainpage → camelCase`
+
+Largest PR in the plan. Rename four fields across the entire stack:
+
+- `album_value` → `albumValue`
+- `image_name` → `imageName`
+- `image_sorting` → `imageSorting`
+- `show_on_mainpage` → `showOnMainpage`
+
+**Strategy:** rename in `types/index.ts` first, then chase TypeScript compile errors. Server-side raw SQL queries get camelCase aliases (`SELECT album_value AS "albumValue"`) so DB schema is untouched. Prisma client field names remain snake_case internally; only the API/UI boundary changes.
+
+**Files:**
+- `types/index.ts` (`Album`, `Image`, `ImagesAlbumsRelation`)
+- `server/db/query/*.ts` (~7 files with raw SQL)
+- `server/db/operate/{albums,images}.ts`
+- `hono/{albums,images,open/download}.ts`
+- ~25 frontend files: admin upload components, album list/edit sheets, image edit/batch sheets, tasks page, RSS feed, theme galleries, preview components.
+
+**Risk:** High (largest blast radius). Mitigation: agent should run `pnpm tsc --noEmit` after each batch of file edits to catch missed renames.
+
+**Validation:** Full smoke test of admin (upload, list, edit, delete, batch delete, daily config), gallery (album view, image view, RSS feed, sitemap).
+
+---
+
+### Wave 3 — Auth + upload dedup (2 PRs, parallel)
+
+#### PR-10 ｜ `feat(auth): admin layout server check + per-handler requireAuth`
+
+**Must be the last touch to `hono/*.ts` to avoid rebase pain.**
+
+1. `app/admin/layout.tsx`: convert to async server component; call better-auth `auth.api.getSession({ headers })`; redirect to `/login` if no session. Removes the client-side leak window.
+2. Mount `requireAuth()` (from PR-00's `hono/_lib/context.ts`) on every `/api/v1/*` Hono sub-router: `app.use('*', requireAuth())` at top of each module file in `hono/{settings,images,albums,daily,file,tasks,backup,storage/open-list}.ts`.
+3. **Do not** mount on `hono/open/*` — those are intentionally public.
+
+**Files:** `app/admin/layout.tsx`; all `hono/*.ts` except `open/*`. **Risk:** High (regression on every admin endpoint). Validation: each protected endpoint returns 401 when called without session cookie; admin pages still load when logged in.
+
+#### PR-11 ｜ `refactor(upload): extract useImageUpload shared hook`
+
+Pull common logic out of the three upload components:
+
+- EXIF extraction, HEIC conversion, presigned URL flow, error handling, progress reporting → new `hooks/use-image-upload.ts`.
+- The three components become thin wrappers focused on their unique UI (single file picker / Live Photo pairing / multi-file dropzone).
+
+**Files:** `hooks/use-image-upload.ts` (new); `components/admin/upload/{simple,livephoto,multiple}-file-upload.tsx`. **Risk:** Medium. Validation: each of the three upload modes still works end-to-end.
+
+---
+
+## Dependency & Scheduling Matrix
+
+```
+T0  │ PR-00 (foundation)
+    │   └─ blocks everything below
+    │
+T1  │ ┌── PR-01 ── PR-02 ── PR-03 ── PR-04 ── PR-05 ── PR-06   (6 in parallel)
+    │ │
+T2  │ ├── PR-07 ── PR-08                                       (2 in parallel)
+    │ │
+T3  │ ├── PR-09                                                (depends on PR-08)
+    │ │
+T4  │ └── PR-10 ── PR-11                                       (2 in parallel)
+```
+
+**Soft-conflict files** (multiple PRs touch the same file but different lines):
+- `types/index.ts` — PR-07 (Config), PR-08 (ExifType), PR-09 (Album/Image). Order PR-08 → PR-07 → PR-09 to minimize rebase.
+- `hono/images.ts` — PR-08 (validation field) and PR-09 (response transform) and PR-10 (auth middleware). PR-10 last.
+- Three upload components — PR-08 (EXIF field rename) and PR-11 (extract hook). PR-11 should rebase onto PR-08.
+
+---
+
+## Verification Strategy
+
+Each PR includes:
+- `pnpm run lint` clean.
+- `pnpm tsc --noEmit` clean.
+- `pnpm run build` succeeds.
+- Manual smoke checklist tailored to the PR's surface.
+
+Before merging Wave 0, the agent **must** open the dev server (`pnpm run dev:server`), log into admin, view gallery, and upload one image end-to-end. Type-checking does not verify feature correctness.
+
+---
+
+## Out of Scope (deferred or rejected)
+
+| Item | Reason |
+|------|--------|
+| Backup format V2 versioning | Not needed until V2 actually arrives. |
+| CSRF tokens on state-changing requests | Requires threat-model spike; better-auth handles same-site cookie. |
+| Per-user rate limiting | Current per-server limit (100/10s) is fine for self-deploy. |
+| Migrating `/api/auth/[...all]` under Hono | Works as-is; better-auth owns this surface. |
+| Renaming Prisma snake_case columns in DB | Migration cost > benefit; remap at server boundary instead. |
+
+---
+
+## Open Questions
+
+- **PR-02 (SSRF):** Confirm `/api/public/images/image-blob` truly has no consumer. If admin tooling uses it for thumbnail rendering, the allowlist path is mandatory.
+- **PR-04 (camera-lens-list):** Should the public variant filter to currently-`show` albums only, or all albums? Audit recommends `show`-only.
+- **PR-09 (snake_case bulk rename):** Should the API support a transition period (return both `album_value` and `albumValue` for one release), or hard-cut? Recommendation: hard-cut, since this is a self-deployed app with no external API consumers.

--- a/hono/_lib/context.ts
+++ b/hono/_lib/context.ts
@@ -1,0 +1,24 @@
+import type { MiddlewareHandler } from 'hono'
+import { auth } from '~/server/auth'
+import { unauthorized } from '~/hono/_lib/errors'
+
+type Session = Awaited<ReturnType<typeof auth.api.getSession>>
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    session: Session
+  }
+}
+
+export const sessionMiddleware: MiddlewareHandler = async (c, next) => {
+  const session = await auth.api.getSession({ headers: c.req.raw.headers })
+  c.set('session', session)
+  await next()
+}
+
+export const requireAuth: MiddlewareHandler = async (c, next) => {
+  if (!c.get('session')) {
+    throw unauthorized()
+  }
+  await next()
+}

--- a/hono/_lib/errors.ts
+++ b/hono/_lib/errors.ts
@@ -1,0 +1,16 @@
+import { HTTPException } from 'hono/http-exception'
+
+export const badRequest = (message: string, cause?: unknown) =>
+  new HTTPException(400, { message, cause })
+
+export const unauthorized = (message = 'Authentication required') =>
+  new HTTPException(401, { message })
+
+export const notFound = (message = 'Not Found') =>
+  new HTTPException(404, { message })
+
+export const conflict = (message: string, cause?: unknown) =>
+  new HTTPException(409, { message, cause })
+
+export const serverError = (message = 'Internal Server Error', cause?: unknown) =>
+  new HTTPException(500, { message, cause })

--- a/hono/_lib/response.ts
+++ b/hono/_lib/response.ts
@@ -1,0 +1,7 @@
+import type { Context } from 'hono'
+
+export const ok = <T>(c: Context, data?: T) =>
+  c.json({ code: 200, message: 'Success', data })
+
+export const okEmpty = (c: Context) =>
+  c.json({ code: 200, message: 'Success' })

--- a/hono/albums.ts
+++ b/hono/albums.ts
@@ -2,42 +2,43 @@ import 'server-only'
 import { fetchAlbumsList } from '~/server/db/query/albums'
 import { deleteAlbum, insertAlbums, updateAlbum, updateAlbumShow } from '~/server/db/operate/albums'
 import { Hono } from 'hono'
-import { HTTPException } from 'hono/http-exception'
+import { ok, okEmpty } from '~/hono/_lib/response'
+import { badRequest, serverError } from '~/hono/_lib/errors'
 
 const app = new Hono()
 
 app.get('/', async (c) => {
   try {
     const data = await fetchAlbumsList()
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed to fetch albums', cause: e })
+    throw serverError('Failed to fetch albums', e)
   }
 })
 
 app.post('/', async (c) => {
   const album = await c.req.json()
   if (album.album_value && album.album_value.charAt(0) !== '/') {
-    throw new HTTPException(500, { message: 'The route must start with /' })
+    throw badRequest('The route must start with /')
   }
   try {
     await insertAlbums(album)
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
 app.put('/', async (c) => {
   const album = await c.req.json()
   if (album.album_value && album.album_value.charAt(0) !== '/') {
-    throw new HTTPException(500, { message: 'The route must start with /' })
+    throw badRequest('The route must start with /')
   }
   try {
     await updateAlbum(album)
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
@@ -45,9 +46,9 @@ app.delete('/:id', async (c) => {
   try {
     const { id } = c.req.param()
     await deleteAlbum(id)
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
@@ -55,9 +56,9 @@ app.put('/update-show', async (c) => {
   try {
     const album = await c.req.json()
     await updateAlbumShow(album.id, album.show)
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 

--- a/hono/backup.ts
+++ b/hono/backup.ts
@@ -6,6 +6,8 @@ import { HTTPException } from 'hono/http-exception'
 import type { BackupPreviewData } from '~/types/backup'
 import { previewBackupImport, exportBackupEnvelope, importBackupEnvelope } from '~/server/backup/service'
 import { BackupValidationError } from '~/server/backup/format-adapter'
+import { ok } from '~/hono/_lib/response'
+import { badRequest, serverError } from '~/hono/_lib/errors'
 
 const app = new Hono()
 
@@ -40,20 +42,14 @@ function getUtcFileName() {
 
 function rethrowBackupError(error: unknown): never {
   if (error instanceof BackupValidationError) {
-    throw new HTTPException(400, {
-      message: error.message,
-      cause: error,
-    })
+    throw badRequest(error.message, error)
   }
 
   if (error instanceof HTTPException) {
     throw error
   }
 
-  throw new HTTPException(500, {
-    message: 'Backup request failed',
-    cause: error,
-  })
+  throw serverError('Backup request failed', error)
 }
 
 app.get('/export', async (c) => {
@@ -82,7 +78,7 @@ app.post('/import/preview', async (c) => {
 
   try {
     const data = await previewBackupImport(body)
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
     if (error instanceof BackupValidationError) {
       return c.json({
@@ -109,7 +105,7 @@ app.post('/import', async (c) => {
 
   try {
     const data = await importBackupEnvelope(body)
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
     if (error instanceof BackupValidationError) {
       return c.json({

--- a/hono/daily.ts
+++ b/hono/daily.ts
@@ -3,8 +3,9 @@ import 'server-only'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
 import { fetchAlbumsWithDailyWeight } from '~/server/db/query/daily'
 import { Hono } from 'hono'
-import { HTTPException } from 'hono/http-exception'
 import { updateDailyConfig, updateAlbumsDailyWeight, refreshDailyImages } from '~/server/db/operate/daily'
+import { ok, okEmpty } from '~/hono/_lib/response'
+import { badRequest, serverError } from '~/hono/_lib/errors'
 
 const app = new Hono()
 
@@ -16,10 +17,10 @@ app.get('/config', async (c) => {
       'daily_total_count',
       'daily_last_refresh'
     ])
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
     console.error('Error fetching daily config:', error)
-    throw new HTTPException(500, { message: 'Failed to fetch daily config', cause: error })
+    throw serverError('Failed to fetch daily config', error)
   }
 })
 
@@ -31,32 +32,29 @@ app.put('/config', async (c) => {
   }
   const validIntervals = ['6', '12', '24', '168']
   if (!validIntervals.includes(body.dailyRefreshInterval)) {
-    throw new HTTPException(400, { message: 'Invalid dailyRefreshInterval, must be one of: 6, 12, 24, 168' })
+    throw badRequest('Invalid dailyRefreshInterval, must be one of: 6, 12, 24, 168')
   }
   if (typeof body.dailyTotalCount !== 'number' || body.dailyTotalCount < 1 || body.dailyTotalCount > 1000) {
-    throw new HTTPException(400, { message: 'Invalid dailyTotalCount, must be between 1 and 1000' })
+    throw badRequest('Invalid dailyTotalCount, must be between 1 and 1000')
   }
   if (typeof body.dailyEnabled !== 'boolean') {
-    throw new HTTPException(400, { message: 'Invalid dailyEnabled, must be a boolean' })
+    throw badRequest('Invalid dailyEnabled, must be a boolean')
   }
   try {
     await updateDailyConfig(body)
-    return c.json({
-      code: 200,
-      message: 'Success'
-    })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
 app.get('/albums', async (c) => {
   try {
     const data = await fetchAlbumsWithDailyWeight()
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
     console.error('Error fetching albums with daily weight:', error)
-    throw new HTTPException(500, { message: 'Failed to fetch albums with daily weight', cause: error })
+    throw serverError('Failed to fetch albums with daily weight', error)
   }
 })
 
@@ -66,36 +64,30 @@ app.put('/albums', async (c) => {
     dailyWeight: number
   }>
   if (!Array.isArray(body)) {
-    throw new HTTPException(400, { message: 'Request body must be an array' })
+    throw badRequest('Request body must be an array')
   }
   for (const item of body) {
     if (typeof item.id !== 'string' || !item.id) {
-      throw new HTTPException(400, { message: 'Each item must have a non-empty string id' })
+      throw badRequest('Each item must have a non-empty string id')
     }
     if (typeof item.dailyWeight !== 'number' || item.dailyWeight < 0 || item.dailyWeight > 10) {
-      throw new HTTPException(400, { message: 'Each item must have a dailyWeight between 0 and 10' })
+      throw badRequest('Each item must have a dailyWeight between 0 and 10')
     }
   }
   try {
     await updateAlbumsDailyWeight(body)
-    return c.json({
-      code: 200,
-      message: 'Success'
-    })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
 app.post('/refresh', async (c) => {
   try {
     await refreshDailyImages()
-    return c.json({
-      code: 200,
-      message: 'Success'
-    })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 

--- a/hono/file.ts
+++ b/hono/file.ts
@@ -1,13 +1,15 @@
 import 'server-only'
 
 import { Hono } from 'hono'
-import { HTTPException } from 'hono/http-exception'
 import { openListUpload } from '~/server/lib/file-upload'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
 import type { Config } from '~/types'
 import { getClient } from '~/server/lib/s3'
 import { getR2Client } from '~/server/lib/r2'
 import { generatePresignedUrl } from '~/server/lib/s3api'
+import { ok } from '~/hono/_lib/response'
+import { badRequest, serverError } from '~/hono/_lib/errors'
+import { HTTPException } from 'hono/http-exception'
 
 interface S3StorageConfig {
   configs: Config[]
@@ -76,10 +78,10 @@ app.post('/presigned-url', async (c) => {
   try {
     const { filename, contentType, type = '/', storage } = await c.req.json()
     if (!filename) {
-      throw new HTTPException(400, { message: 'Filename is required' })
+      throw badRequest('Filename is required')
     }
     if (!storage) {
-      throw new HTTPException(400, { message: 'Storage type is required' })
+      throw badRequest('Storage type is required')
     }
 
     switch (storage) {
@@ -88,13 +90,7 @@ app.post('/presigned-url', async (c) => {
         const filePath = buildStoragePath(storageFolder, type, filename)
         const presignedUrl = await generatePresignedUrl(client, bucket, filePath, contentType, 'put')
 
-        return c.json({
-          code: 200,
-          data: {
-            presignedUrl,
-            key: filePath
-          }
-        })
+        return ok(c, { presignedUrl, key: filePath })
       }
 
       case 'r2': {
@@ -102,21 +98,15 @@ app.post('/presigned-url', async (c) => {
         const filePath = buildStoragePath(storageFolder, type, filename)
         const presignedUrl = await generatePresignedUrl(client, bucket, filePath, contentType, 'put')
 
-        return c.json({
-          code: 200,
-          data: {
-            presignedUrl,
-            key: filePath
-          }
-        })
+        return ok(c, { presignedUrl, key: filePath })
       }
 
       default:
-        throw new HTTPException(400, { message: 'Unsupported storage type' })
+        throw badRequest('Unsupported storage type')
     }
   } catch (e) {
     if (e instanceof HTTPException) throw e
-    throw new HTTPException(500, { message: 'Failed to generate presigned URL', cause: e })
+    throw serverError('Failed to generate presigned URL', e)
   }
 })
 
@@ -133,21 +123,19 @@ app.post('/upload', async (c) => {
       switch (storage.toString()) {
         case 'openList': {
           if (!file || !(file instanceof File)) {
-            throw new HTTPException(400, { message: 'File is required' })
+            throw badRequest('File is required')
           }
           const result = await openListUpload(file, type, mountPath)
-          return c.json({
-            code: 200, data: result
-          })
+          return ok(c, result)
         }
         default:
-          throw new HTTPException(500, { message: 'storage not support' })
+          throw badRequest('Unsupported storage type')
       }
     }
-    throw new HTTPException(400, { message: 'Storage type is required' })
+    throw badRequest('Storage type is required')
   } catch (e) {
     if (e instanceof HTTPException) throw e
-    throw new HTTPException(500, { message: 'Failed to upload file', cause: e })
+    throw serverError('Failed to upload file', e)
   }
 })
 
@@ -168,35 +156,27 @@ app.post('/object-url', async (c) => {
         const cleanS3CdnUrl = s3CdnUrl.replace(/^https?:\/\//, '')
 
         if (s3Cdn && s3Cdn === 'true') {
-          return c.json({
-            code: 200, data: `https://${cleanS3CdnUrl}/${key}`
-          })
+          return ok(c, `https://${cleanS3CdnUrl}/${key}`)
         } else {
           if (forcePathStyle && forcePathStyle === 'true') {
-            return c.json({
-              code: 200, data: `https://${cleanEndpoint}/${bucket}/${key}`
-            })
+            return ok(c, `https://${cleanEndpoint}/${bucket}/${key}`)
           }
         }
-        return c.json({
-          code: 200, data: `https://${bucket}.${cleanEndpoint}/${key}`
-        })
+        return ok(c, `https://${bucket}.${cleanEndpoint}/${key}`)
       }
 
       case 'r2': {
         const { r2PublicDomain } = await getR2Config()
 
-        return c.json({
-          code: 200, data: `${r2PublicDomain}/${key}`
-        })
+        return ok(c, `${r2PublicDomain}/${key}`)
       }
 
       default:
-        throw new HTTPException(400, { message: 'Unsupported storage type' })
+        throw badRequest('Unsupported storage type')
     }
   } catch (e) {
     if (e instanceof HTTPException) throw e
-    throw new HTTPException(500, { message: 'Failed to get object URL', cause: e })
+    throw serverError('Failed to get object URL', e)
   }
 })
 

--- a/hono/images.ts
+++ b/hono/images.ts
@@ -8,9 +8,10 @@ import {
   updateImageAlbum
 } from '~/server/db/operate/images'
 import { Hono } from 'hono'
-import { HTTPException } from 'hono/http-exception'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
+import { okEmpty } from '~/hono/_lib/response'
+import { badRequest, serverError } from '~/hono/_lib/errors'
 
 dayjs.extend(customParseFormat)
 
@@ -19,33 +20,27 @@ const app = new Hono()
 app.post('/', async (c) => {
   const body = await c.req.json()
   if (!body) {
-    throw new HTTPException(400, { message: 'Missing body' })
+    throw badRequest('Missing body')
   }
 
-  // 验证基本图片信息
   if (!body.url) {
-    throw new HTTPException(500, { message: 'Image link cannot be empty' })
+    throw badRequest('Image link cannot be empty')
   }
   if (!body.height || body.height <= 0) {
-    throw new HTTPException(500, { message: 'Image height cannot be empty and must be greater than 0' })
+    throw badRequest('Image height cannot be empty and must be greater than 0')
   }
   if (!body.width || body.width <= 0) {
-    throw new HTTPException(500, { message: 'Image width cannot be empty and must be greater than 0' })
+    throw badRequest('Image width cannot be empty and must be greater than 0')
   }
 
   try {
-    // 验证可能存在的时间信息
     if (body?.exif?.data_time && !dayjs(body?.exif?.data_time, 'YYYY:MM:DD HH:mm:ss', true).isValid()) {
       body.exif.data_time = ''
     }
-    // 保存图片信息
     await insertImage(body)
-    return c.json({
-      code: 200,
-      message: 'Success'
-    })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
@@ -53,9 +48,9 @@ app.delete('/batch-delete', async (c) => {
   try {
     const data = await c.req.json()
     await deleteBatchImage(data)
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
@@ -63,28 +58,28 @@ app.delete('/:id', async (c) => {
   try {
     const { id } = c.req.param()
     await deleteImage(id)
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
 app.put('/', async (c) => {
   const image = await c.req.json()
   if (!image.url) {
-    throw new HTTPException(500, { message: 'Image link cannot be empty' })
+    throw badRequest('Image link cannot be empty')
   }
   if (!image.height || image.height <= 0) {
-    throw new HTTPException(500, { message: 'Image height cannot be empty and must be greater than 0' })
+    throw badRequest('Image height cannot be empty and must be greater than 0')
   }
   if (!image.width || image.width <= 0) {
-    throw new HTTPException(500, { message: 'Image width cannot be empty and must be greater than 0' })
+    throw badRequest('Image width cannot be empty and must be greater than 0')
   }
   try {
     await updateImage(image)
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
@@ -92,9 +87,9 @@ app.put('/update-show', async (c) => {
   try {
     const image = await c.req.json()
     await updateImageShow(image.id, image.show)
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
@@ -102,12 +97,9 @@ app.put('/update-album', async (c) => {
   const image = await c.req.json()
   try {
     await updateImageAlbum(image.imageId, image.albumId)
-    return c.json({
-      code: 200,
-      message: 'Success'
-    })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 

--- a/hono/index.ts
+++ b/hono/index.ts
@@ -9,13 +9,16 @@ import daily from '~/hono/daily'
 import tasks from '~/hono/tasks'
 import backup from '~/hono/backup'
 import { HTTPException } from 'hono/http-exception'
+import { sessionMiddleware } from '~/hono/_lib/context'
 
 const route = new Hono()
+
+route.use('*', sessionMiddleware)
 
 route.onError((err, c) => {
   if (err instanceof HTTPException) {
     console.error(err)
-    return err.getResponse()
+    return c.json({ code: err.status, message: err.message }, err.status)
   }
   console.error('Unexpected error:', err)
   return c.json({ code: 500, message: 'Internal Server Error' }, 500)

--- a/hono/open/download.ts
+++ b/hono/open/download.ts
@@ -8,31 +8,35 @@ import { getR2Client } from '~/server/lib/r2'
 import { fetchImageByIdAndAuth } from '~/server/db/query/images'
 import type { Config } from '~/types'
 import { generatePresignedUrl } from '~/server/lib/s3api'
+import { badRequest, notFound, serverError } from '~/hono/_lib/errors'
 
 const app = new Hono()
 
+// NOTE: This endpoint intentionally returns a non-envelope response — either
+// a binary blob (with Content-Disposition) or a `{ url, filename }` JSON
+// payload. PR-01 in the API refactor plan splits this into two endpoints
+// with single contracts. Until then, the frontend
+// (components/album/preview-image.tsx) discriminates by Content-Type.
 app.get('/:id', async (c) => {
   const id = c.req.param('id')
   const storage = c.req.query('storage')
 
   if (!storage) {
-    throw new HTTPException(400, { message: 'Missing storage parameter' })
+    throw badRequest('Missing storage parameter')
   }
 
   try {
-    // 从数据库获取图片信息
     const imageData = await fetchImageByIdAndAuth(id)
     if (!imageData) {
-      throw new HTTPException(404, { message: 'Image not found' })
+      throw notFound('Image not found')
     }
 
     const imageUrl = imageData.url
     const imageName = imageData.image_name
     if (!imageUrl) {
-      throw new HTTPException(404, { message: 'Image URL not found' })
+      throw notFound('Image URL not found')
     }
 
-    // 如果没有开启直接下载，直接返回图片 URL
     const downloadConfigs = await fetchConfigsByKeys([
       's3_direct_download',
       'r2_direct_download',
@@ -43,11 +47,9 @@ app.get('/:id', async (c) => {
     const r2DirectDownload = downloadConfigs.find((item: Config) => item.config_key === 'r2_direct_download')?.config_value === 'true'
 
     if ((storage === 's3' && !s3DirectDownload) || (storage === 'r2' && !r2DirectDownload)) {
-      // 对于非直接下载，返回带有 Content-Disposition 的响应
       const response = await fetch(imageUrl)
       const blob = await response.blob()
 
-      // 提取并解码文件名
       const filename = imageName
         ? imageName
         : decodeURIComponent(imageUrl.split('/').pop() || 'download.jpg')
@@ -60,17 +62,14 @@ app.get('/:id', async (c) => {
       })
     }
 
-    // 处理 URL 格式，提取 key
     let key: string
     if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
-      // 从完整 URL 中提取路径部分，避免自动解码
       const urlMatch = imageUrl.match(/^https?:\/\/[^\/]+(\/.*)$/)
       if (urlMatch) {
-        key = urlMatch[1].slice(1) // 移除开头的斜杠
+        key = urlMatch[1].slice(1)
       } else {
         key = imageUrl
       }
-      // 如果路径以 storage_folder 开头，移除它
       if (storage === 's3') {
         const s3StorageFolder = downloadConfigs.find((item: Config) => item.config_key === 'storage_folder')?.config_value || ''
         if (s3StorageFolder && key.startsWith(s3StorageFolder)) {
@@ -86,7 +85,6 @@ app.get('/:id', async (c) => {
       key = imageUrl
     }
 
-    // 提取文件名
     const filename = imageName
       ? imageName
       : decodeURIComponent(imageUrl.split('/').pop() || 'download.jpg')
@@ -108,7 +106,6 @@ app.get('/:id', async (c) => {
         const bucket = configs.find((item: Config) => item.config_key === 'bucket')?.config_value || ''
         const storageFolder = configs.find((item: Config) => item.config_key === 'storage_folder')?.config_value || ''
 
-        // 如果 key 已经包含了 storage_folder，就不再添加
         const filePath = key.startsWith(storageFolder) ? key : `${storageFolder}${key}`
         const client = getClient(configs)
         const presignedUrl = await generatePresignedUrl(client, bucket, filePath, '')
@@ -131,7 +128,6 @@ app.get('/:id', async (c) => {
         const bucket = configs.find((item: Config) => item.config_key === 'r2_bucket')?.config_value || ''
         const storageFolder = configs.find((item: Config) => item.config_key === 'r2_storage_folder')?.config_value || ''
 
-        // 如果 key 已经包含了 storage_folder，就不再添加
         const filePath = key.startsWith(storageFolder) ? key : `${storageFolder}${key}`
         const client = getR2Client(configs)
         const presignedUrl = await generatePresignedUrl(client, bucket, filePath, '')
@@ -142,11 +138,11 @@ app.get('/:id', async (c) => {
         })
       }
       default:
-        throw new HTTPException(400, { message: 'Unsupported storage type' })
+        throw badRequest('Unsupported storage type')
     }
   } catch (e) {
     if (e instanceof HTTPException) throw e
-    throw new HTTPException(500, { message: 'Failed to process download', cause: e })
+    throw serverError('Failed to process download', e)
   }
 })
 

--- a/hono/open/images.ts
+++ b/hono/open/images.ts
@@ -2,6 +2,8 @@ import 'server-only'
 import { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import { fetchImageByIdAndAuth } from '~/server/db/query/images'
+import { ok } from '~/hono/_lib/response'
+import { badRequest, notFound, serverError } from '~/hono/_lib/errors'
 
 const app = new Hono()
 
@@ -13,10 +15,10 @@ app.get('/image-blob', async (c) => {
       const blob = await fetch(imageUrl).then(res => res.blob())
       return new Response(blob)
     }
-    throw new HTTPException(400, { message: 'Missing imageUrl parameter' })
+    throw badRequest('Missing imageUrl parameter')
   } catch (e) {
     if (e instanceof HTTPException) throw e
-    throw new HTTPException(500, { message: 'Failed to get image blob', cause: e })
+    throw serverError('Failed to get image blob', e)
   }
 })
 
@@ -26,13 +28,13 @@ app.get('/image-by-id', async (c) => {
     const id = searchParams.get('id')
     const data = await fetchImageByIdAndAuth(String(id))
     if (data) {
-      return c.json({ code: 200, data })
+      return ok(c, data)
     } else {
-      throw new HTTPException(404, { message: 'The image does not exist or is not publicly displayed' })
+      throw notFound('The image does not exist or is not publicly displayed')
     }
   } catch (e) {
     if (e instanceof HTTPException) throw e
-    throw new HTTPException(500, { message: 'Failed to get image', cause: e })
+    throw serverError('Failed to get image', e)
   }
 })
 

--- a/hono/settings.ts
+++ b/hono/settings.ts
@@ -3,9 +3,10 @@ import 'server-only'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
 import type { Config } from '~/types'
 import { Hono } from 'hono'
-import { HTTPException } from 'hono/http-exception'
 import { updateOpenListConfig, updateCustomInfo, updateR2Config, updateS3Config } from '~/server/db/operate/configs'
 import { normalizeDefaultTheme } from '~/lib/utils/theme'
+import { ok, okEmpty } from '~/hono/_lib/response'
+import { serverError } from '~/hono/_lib/errors'
 
 const app = new Hono()
 
@@ -29,9 +30,9 @@ app.get('/custom-info', async (c) => {
       'admin_images_per_page',
       'default_theme'
     ])
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
-    throw new HTTPException(500, { message: 'Failed to fetch custom info', cause: error })
+    throw serverError('Failed to fetch custom info', error)
   }
 })
 
@@ -46,9 +47,9 @@ app.get('/r2-info', async (c) => {
       'r2_public_domain',
       'r2_direct_download'
     ])
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
-    throw new HTTPException(500, { message: 'Failed to fetch R2 info', cause: error })
+    throw serverError('Failed to fetch R2 info', error)
   }
 })
 
@@ -66,9 +67,9 @@ app.get('/s3-info', async (c) => {
       's3_cdn_url',
       's3_direct_download'
     ])
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
-    throw new HTTPException(500, { message: 'Failed to fetch S3 info', cause: error })
+    throw serverError('Failed to fetch S3 info', error)
   }
 })
 
@@ -77,9 +78,9 @@ app.get('/admin-config', async (c) => {
     const data = await fetchConfigsByKeys([
       'admin_images_per_page'
     ])
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
-    throw new HTTPException(500, { message: 'Failed to fetch admin config', cause: error })
+    throw serverError('Failed to fetch admin config', error)
   }
 })
 
@@ -91,9 +92,9 @@ app.put('/open-list-info', async (c) => {
     const openListToken = query?.find((item: Config) => item.config_key === 'open_list_token').config_value
 
     await updateOpenListConfig({ openListUrl, openListToken })
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
@@ -110,9 +111,9 @@ app.put('/r2-info', async (c) => {
     const r2DirectDownload = query?.find((item: Config) => item.config_key === 'r2_direct_download').config_value
 
     await updateR2Config({ r2AccesskeyId, r2AccesskeySecret, r2AccountId, r2Bucket, r2StorageFolder, r2PublicDomain, r2DirectDownload })
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
@@ -132,9 +133,9 @@ app.put('/s3-info', async (c) => {
     const s3DirectDownload = query?.find((item: Config) => item.config_key === 's3_direct_download').config_value
 
     await updateS3Config({ accesskeyId, accesskeySecret, region, endpoint, bucket, storageFolder, forcePathStyle, s3Cdn, s3CdnUrl, s3DirectDownload })
-    return c.json({ code: 200, message: 'Success' })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 
@@ -162,12 +163,9 @@ app.put('/custom-info', async (c) => {
       ...query,
       defaultTheme: normalizeDefaultTheme(query.defaultTheme),
     })
-    return c.json({
-      code: 200,
-      message: 'Success'
-    })
+    return okEmpty(c)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed', cause: e })
+    throw serverError('Failed', e)
   }
 })
 

--- a/hono/storage/open-list.ts
+++ b/hono/storage/open-list.ts
@@ -4,6 +4,8 @@ import { fetchConfigsByKeys } from '~/server/db/query/configs'
 import { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import type { Config } from '~/types'
+import { ok } from '~/hono/_lib/response'
+import { badRequest, serverError } from '~/hono/_lib/errors'
 
 const app = new Hono()
 
@@ -13,9 +15,9 @@ app.get('/info', async (c) => {
       'open_list_url',
       'open_list_token'
     ])
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (e) {
-    throw new HTTPException(500, { message: 'Failed to fetch open list info', cause: e })
+    throw serverError('Failed to fetch open list info', e)
   }
 })
 
@@ -29,7 +31,7 @@ app.get('/storages', async (c) => {
     const openListUrl = findConfig.find((item: Config) => item.config_key === 'open_list_url')?.config_value || ''
 
     if (!openListUrl || !openListToken) {
-      throw new HTTPException(400, { message: 'Open List URL and token must be configured' })
+      throw badRequest('Open List URL and token must be configured')
     }
 
     const data = await fetch(`${openListUrl}/api/admin/storage/list`, {
@@ -38,10 +40,10 @@ app.get('/storages', async (c) => {
         'Authorization': openListToken.toString(),
       },
     }).then(res => res.json())
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (e) {
     if (e instanceof HTTPException) throw e
-    throw new HTTPException(500, { message: 'Failed to fetch storages', cause: e })
+    throw serverError('Failed to fetch storages', e)
   }
 })
 

--- a/hono/tasks.ts
+++ b/hono/tasks.ts
@@ -1,4 +1,4 @@
-﻿import 'server-only'
+import 'server-only'
 
 import { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
@@ -13,12 +13,14 @@ import {
   tickMetadataTaskRuns,
 } from '~/server/tasks/service'
 import { ADMIN_TASK_KEY_REFRESH_IMAGE_METADATA, normalizeMetadataTaskScope } from '~/types/admin-tasks'
+import { ok } from '~/hono/_lib/response'
+import { badRequest, conflict, notFound, serverError } from '~/hono/_lib/errors'
 
 const app = new Hono()
 
 function ensureTaskKey(taskKey: unknown) {
   if (taskKey !== ADMIN_TASK_KEY_REFRESH_IMAGE_METADATA) {
-    throw new HTTPException(400, { message: 'Unsupported task key' })
+    throw badRequest('Unsupported task key')
   }
 
   return taskKey
@@ -35,7 +37,7 @@ function getScopeFromBody(body: Record<string, unknown> | null) {
   return normalizeMetadataTaskScope(body?.scope)
 }
 
-function rethrowTaskError(error: unknown) {
+function rethrowTaskError(error: unknown): never {
   if (error instanceof HTTPException) {
     throw error
   }
@@ -43,21 +45,21 @@ function rethrowTaskError(error: unknown) {
   const message = error instanceof Error ? error.message : 'Task request failed'
 
   if (message === 'Another metadata task is already active') {
-    throw new HTTPException(409, { message })
+    throw conflict(message)
   }
 
   if (message === 'No images matched the selected filters') {
-    throw new HTTPException(400, { message })
+    throw badRequest(message)
   }
 
-  throw new HTTPException(500, { message, cause: error })
+  throw serverError(message, error)
 }
 
 app.get('/preview-count', async (c) => {
   try {
     const scope = getScopeFromQuery(c.req.query())
     const data = await getMetadataTaskPreviewCount(scope)
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
     rethrowTaskError(error)
   }
@@ -66,7 +68,7 @@ app.get('/preview-count', async (c) => {
 app.get('/runs', async (c) => {
   try {
     const data = await listMetadataTaskRuns()
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
     rethrowTaskError(error)
   }
@@ -77,10 +79,10 @@ app.get('/runs/:id', async (c) => {
     const data = await getMetadataTaskRunDetail(c.req.param('id'))
 
     if (!data) {
-      throw new HTTPException(404, { message: 'Task run not found' })
+      throw notFound('Task run not found')
     }
 
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
     rethrowTaskError(error)
   }
@@ -90,7 +92,7 @@ app.post('/runs', async (c) => {
   const body = await c.req.json<Record<string, unknown>>().catch(() => null)
 
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
-    throw new HTTPException(400, { message: 'Invalid task request body' })
+    throw badRequest('Invalid task request body')
   }
 
   try {
@@ -99,10 +101,10 @@ app.post('/runs', async (c) => {
     const data = await createMetadataTaskRun(scope)
 
     if (!data) {
-      throw new HTTPException(409, { message: 'Task system is busy, please retry shortly' })
+      throw conflict('Task system is busy, please retry shortly')
     }
 
-    return c.json({ code: 200, message: 'Success', data }, 201)
+    return ok(c, data)
   } catch (error) {
     rethrowTaskError(error)
   }
@@ -113,10 +115,10 @@ app.post('/runs/:id/kick', async (c) => {
     const data = await kickMetadataTaskRun(c.req.param('id'))
 
     if (!data) {
-      throw new HTTPException(404, { message: 'Task run not found' })
+      throw notFound('Task run not found')
     }
 
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
     rethrowTaskError(error)
   }
@@ -127,10 +129,10 @@ app.post('/runs/:id/cancel', async (c) => {
     const data = await cancelMetadataTaskRun(c.req.param('id'))
 
     if (!data) {
-      throw new HTTPException(404, { message: 'Task run not found' })
+      throw notFound('Task run not found')
     }
 
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
     rethrowTaskError(error)
   }
@@ -139,7 +141,7 @@ app.post('/runs/:id/cancel', async (c) => {
 app.post('/tick', async (c) => {
   try {
     const data = await tickMetadataTaskRuns()
-    return c.json({ code: 200, message: 'Success', data })
+    return ok(c, data)
   } catch (error) {
     console.error('Task tick failed:', error)
     rethrowTaskError(error)


### PR DESCRIPTION
## Summary

PR-00 of the API refactor plan tracked in `docs/plans/2026-05-19-api-refactor-design.md`.

This is the **foundation PR** — it introduces shared helpers, wires session middleware into the Hono `/v1` chain, normalizes every existing handler's success/error envelope, and syncs `CLAUDE.md` against reality so the next 12 PRs can land independently without re-touching every file.

### Helpers added under `hono/_lib/`

| File | Exports | Purpose |
|------|---------|---------|
| `response.ts` | `ok(c, data)`, `okEmpty(c)` | Standardized success envelope |
| `errors.ts` | `badRequest` / `notFound` / `conflict` / `serverError` / `unauthorized` | Semantic `HTTPException` wrappers |
| `context.ts` | `sessionMiddleware`, `requireAuth` | Better-auth session in Hono context |

`sessionMiddleware` mounts on the `/v1` chain once and resolves the better-auth session per request (better-auth's 30 min cookieCache absorbs DB pressure). `requireAuth` is exported but **not mounted** — PR-10 will opt-in per module.

### Behavioural changes

1. **Error responses are now JSON `{ code, message }` instead of plaintext.** Previously thrown `HTTPException` returned its default plaintext body. The global `onError` in `hono/index.ts` now shapes errors into the envelope. Status codes unchanged.
2. **Missing `message: 'Success'` filled in** for `/file/presigned-url`, `/file/upload`, `/file/object-url`, `/open/images/image-by-id`.
3. **Status codes corrected** — 6 client-input validation sites in `hono/images.ts` and 1 in `hono/file.ts` changed from 500 → 400. `tasks POST /runs` now returns HTTP 200 (was: 201 with body `code: 200`).
4. **`CLAUDE.md` synced** — dropped 5 already-fixed deviations from the old "Known Deviations" list, replaced with the current 7-item refactor snapshot keyed to PR-01..PR-10. Added `## API Helpers` section documenting helper usage.

### Frontend impact: none required

Audited with grep:
- 0 places read error response bodies as text (`response.text()`)
- 9 `if (!response.ok)` sites all use generic fallback toasts; none parse the body for error display except 3 (`tasks-page.tsx`, `backup/page.tsx`) that already expected envelope errors — those now display real backend messages instead of fallbacks.
- SWR consumers go through `lib/utils/fetcher.ts` which already auto-unwraps `data`.

## Verification

- `pnpm run lint` — 0 errors in changed files (193 pre-existing warnings unchanged)
- `pnpm exec tsc --noEmit` — 64 errors total, **identical to `main` before changes** (verified via stash). Zero new TypeScript errors introduced.
- `pnpm run build` — compiles successfully.

## Test plan

- [ ] Log into admin panel; confirm session-aware middleware doesn't add visible latency
- [ ] Verify a 4xx error response (e.g. POST `/api/v1/albums` with `album_value` missing leading `/`) returns `{ code: 400, message: "..." }` JSON instead of plaintext
- [ ] Verify gallery and RSS pages still render (no SWR consumer regression)
- [ ] Verify upload via one of the three modes (simple / livephoto / multi) end-to-end
- [ ] Verify backup export downloads as `.json` file and import preview shows envelope error correctly on bad input

## Next steps

Per the plan, PR-00 blocks Wave 1 (PR-01..PR-06, six independent parallel PRs). See `docs/plans/2026-05-19-api-refactor-design.md` § "Dependency & Scheduling Matrix".

🤖 Generated with [Claude Code](https://claude.com/claude-code)