### PR TITLE
chore(seo): add Cache-Control to RSS & sitemap

### DIFF
--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -75,6 +75,7 @@ export async function GET(request: Request) {
   return new Response(feed.xml(), {
     headers: {
       'Content-Type': 'application/xml',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
     }
   })
 }


### PR DESCRIPTION
## Summary

Implements **PR-03** from the API refactor plan (`docs/plans/2026-05-19-api-refactor-design.md` § PR-03).

Adds an HTTP `Cache-Control` header to the public RSS feed so that reverse proxies (CDN / Vercel edge) and feed readers can cache the response instead of hitting the database and re-rendering XML on every poll.

## Files changed

- `app/rss.xml/route.ts` — added `'Cache-Control': 'public, max-age=3600, s-maxage=3600'` to the existing `Response` headers. No other handler logic touched.

## Sitemap

No sitemap route currently exists in the repo (neither `app/sitemap.ts` nor `app/sitemap.xml/route.ts`), so this PR only covers `/rss.xml`. When a sitemap is added later, the same header (or `export const revalidate = 3600` if using the Next.js `sitemap.ts` convention) should be applied.

## Cache value rationale

`public, max-age=3600, s-maxage=3600` — 1 hour.

- The RSS feed enumerates public images that change at most a few times per day; an hour of staleness is acceptable for feed readers.
- `s-maxage=3600` lets shared caches (CDNs, reverse proxies) reuse the response without serializing every request to the origin.
- Matches the value specified in the plan document.

## Test plan

- [x] `pnpm run lint` — 0 errors in changed files.
- [x] `pnpm exec tsc --noEmit` — same error count as baseline `5127911` (no new TS errors introduced by this PR).
- [ ] Manual: after deploy, `curl -I https://<host>/rss.xml` should show `Cache-Control: public, max-age=3600, s-maxage=3600`.
- [ ] Manual: feed reader (e.g. Inoreader, Feedly) still parses the feed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)