### PR TITLE
feat(api): split public/download into binary vs presigned endpoints

### DIFF
--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -129,44 +129,51 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
       // 获取存储类型
       const storageType = props.data?.url?.includes('s3') ? 's3' : 'r2'
 
-      // 使用新的下载 API
-      let response = await fetch(`/api/public/download/${props.id}?storage=${storageType}`)
-      const contentType = response.headers.get('content-type')
+      // 读取直接下载配置，决定走二进制 blob 端点还是 presigned URL 端点
+      const flagsResponse = await fetch('/api/public/download/config')
+      const flagsJson = flagsResponse.ok ? await flagsResponse.json() : null
+      const directDownload = storageType === 's3'
+        ? Boolean(flagsJson?.data?.s3DirectDownload)
+        : Boolean(flagsJson?.data?.r2DirectDownload)
 
-      if (contentType?.includes('application/json')) {
-        // 如果是 JSON 响应，说明是直接下载模式
-        const data = await response.json()
-        // 使用后端返回的文件名，并进行 URL 解码
-        const filename = decodeURIComponent(data.filename || 'download.jpg')
-        // 直接使用 window.location.href 触发下载
-        response = await fetch(data.url)
-        const blob = await response.blob()
-        const url = window.URL.createObjectURL(new Blob([blob]))
-        const link = document.createElement('a')
-        link.href = url
-        link.download = filename
-        document.body.appendChild(link)
-        link.click()
-        document.body.removeChild(link)
+      let blob: Blob
+      let filename: string
+
+      if (directDownload) {
+        // 直接下载模式：从 presigned 端点拿到 URL 后由浏览器拉对象存储
+        const presignedResponse = await fetch(`/api/public/download/${props.id}/presigned?storage=${storageType}`)
+        if (!presignedResponse.ok) throw new Error('presigned request failed')
+        const presignedJson = await presignedResponse.json()
+        const data = presignedJson?.data
+        if (!data?.url) throw new Error('presigned response missing url')
+        filename = decodeURIComponent(data.filename || 'download.jpg')
+        const objectResponse = await fetch(data.url)
+        if (!objectResponse.ok) throw new Error('object fetch failed')
+        blob = await objectResponse.blob()
       } else {
-        // 对于非直接下载模式，从 Content-Disposition 头中获取文件名
-        const contentDisposition = response.headers.get('content-disposition')
-        let filename = 'download'
+        // 代理下载模式：服务端返回二进制 blob，文件名从 Content-Disposition 取
+        const binaryResponse = await fetch(`/api/public/download/${props.id}?storage=${storageType}`)
+        if (!binaryResponse.ok) throw new Error('download request failed')
+        const contentDisposition = binaryResponse.headers.get('content-disposition')
+        let parsedFilename = 'download'
         if (contentDisposition) {
           const filenameMatch = contentDisposition.match(/filename="([^"]+)"/)
           if (filenameMatch) {
-            filename = decodeURIComponent(filenameMatch[1])
+            parsedFilename = decodeURIComponent(filenameMatch[1])
           }
         }
-        const blob = await response.blob()
-        const url = window.URL.createObjectURL(new Blob([blob]))
-        const link = document.createElement('a')
-        link.href = url
-        link.download = filename
-        document.body.appendChild(link)
-        link.click()
-        document.body.removeChild(link)
+        blob = await binaryResponse.blob()
+        filename = parsedFilename
       }
+
+      const objectUrl = window.URL.createObjectURL(new Blob([blob]))
+      const link = document.createElement('a')
+      link.href = objectUrl
+      link.download = filename
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      window.URL.revokeObjectURL(objectUrl)
     } catch {
       toast.error(t('Tips.downloadFailed'), { duration: 500 })
     } finally {

--- a/hono/open/download.ts
+++ b/hono/open/download.ts
@@ -8,15 +8,170 @@ import { getR2Client } from '~/server/lib/r2'
 import { fetchImageByIdAndAuth } from '~/server/db/query/images'
 import type { Config } from '~/types'
 import { generatePresignedUrl } from '~/server/lib/s3api'
+import { ok } from '~/hono/_lib/response'
 import { badRequest, notFound, serverError } from '~/hono/_lib/errors'
 
 const app = new Hono()
 
-// NOTE: This endpoint intentionally returns a non-envelope response — either
-// a binary blob (with Content-Disposition) or a `{ url, filename }` JSON
-// payload. PR-01 in the API refactor plan splits this into two endpoints
-// with single contracts. Until then, the frontend
-// (components/album/preview-image.tsx) discriminates by Content-Type.
+type DownloadFlags = {
+  s3DirectDownload: boolean
+  r2DirectDownload: boolean
+}
+
+async function readDirectDownloadFlags(): Promise<DownloadFlags> {
+  const configs = await fetchConfigsByKeys(['s3_direct_download', 'r2_direct_download'])
+  return {
+    s3DirectDownload: configs.find((item: Config) => item.config_key === 's3_direct_download')?.config_value === 'true',
+    r2DirectDownload: configs.find((item: Config) => item.config_key === 'r2_direct_download')?.config_value === 'true',
+  }
+}
+
+function deriveFilename(imageName: string | null | undefined, imageUrl: string): string {
+  if (imageName) return imageName
+  const tail = imageUrl.split('/').pop() || 'download.jpg'
+  try {
+    return decodeURIComponent(tail)
+  } catch {
+    return tail
+  }
+}
+
+function buildContentDisposition(filename: string): string {
+  const encoded = encodeURIComponent(filename)
+  return `attachment; filename="${encoded}"; filename*=UTF-8''${encoded}`
+}
+
+async function loadImageOrThrow(id: string) {
+  const imageData = await fetchImageByIdAndAuth(id)
+  if (!imageData) {
+    throw notFound('Image not found')
+  }
+  const imageUrl = imageData.url
+  if (!imageUrl) {
+    throw notFound('Image URL not found')
+  }
+  return { imageData, imageUrl }
+}
+
+async function buildPresignedUrlForStorage(storage: string, imageUrl: string): Promise<string> {
+  let key: string
+  if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
+    const urlMatch = imageUrl.match(/^https?:\/\/[^\/]+(\/.*)$/)
+    key = urlMatch ? urlMatch[1].slice(1) : imageUrl
+  } else {
+    key = imageUrl
+  }
+
+  switch (storage) {
+    case 's3': {
+      const folderConfigs = await fetchConfigsByKeys(['storage_folder'])
+      const s3StorageFolder = folderConfigs.find((item: Config) => item.config_key === 'storage_folder')?.config_value || ''
+      if (s3StorageFolder && key.startsWith(s3StorageFolder)) {
+        key = key.slice(s3StorageFolder.length)
+      }
+
+      const configs = await fetchConfigsByKeys([
+        'accesskey_id',
+        'accesskey_secret',
+        'region',
+        'endpoint',
+        'bucket',
+        'storage_folder',
+        'force_path_style',
+        's3_cdn',
+        's3_cdn_url',
+        's3_direct_download'
+      ])
+      const bucket = configs.find((item: Config) => item.config_key === 'bucket')?.config_value || ''
+      const storageFolder = configs.find((item: Config) => item.config_key === 'storage_folder')?.config_value || ''
+
+      const filePath = key.startsWith(storageFolder) ? key : `${storageFolder}${key}`
+      const client = getClient(configs)
+      return await generatePresignedUrl(client, bucket, filePath, '')
+    }
+    case 'r2': {
+      const folderConfigs = await fetchConfigsByKeys(['r2_storage_folder'])
+      const r2StorageFolder = folderConfigs.find((item: Config) => item.config_key === 'r2_storage_folder')?.config_value || ''
+      if (r2StorageFolder && key.startsWith(r2StorageFolder)) {
+        key = key.slice(r2StorageFolder.length)
+      }
+
+      const configs = await fetchConfigsByKeys([
+        'r2_accesskey_id',
+        'r2_accesskey_secret',
+        'r2_account_id',
+        'r2_bucket',
+        'r2_storage_folder',
+        'r2_public_domain',
+        'r2_direct_download'
+      ])
+      const bucket = configs.find((item: Config) => item.config_key === 'r2_bucket')?.config_value || ''
+      const storageFolder = configs.find((item: Config) => item.config_key === 'r2_storage_folder')?.config_value || ''
+
+      const filePath = key.startsWith(storageFolder) ? key : `${storageFolder}${key}`
+      const client = getR2Client(configs)
+      return await generatePresignedUrl(client, bucket, filePath, '')
+    }
+    default:
+      throw badRequest('Unsupported storage type')
+  }
+}
+
+/**
+ * GET /api/public/download/config
+ *
+ * Exposes the per-storage direct-download flags so the frontend can pick
+ * the correct download endpoint deterministically (binary vs presigned)
+ * without inferring from response shape.
+ */
+app.get('/config', async (c) => {
+  try {
+    const flags = await readDirectDownloadFlags()
+    c.header('Cache-Control', 'private, max-age=60')
+    return ok(c, flags)
+  } catch (e) {
+    if (e instanceof HTTPException) throw e
+    throw serverError('Failed to read download config', e)
+  }
+})
+
+/**
+ * GET /api/public/download/:id/presigned?storage=s3|r2
+ *
+ * Always returns the standard envelope:
+ *   { code: 200, message: 'Success', data: { url, filename } }
+ *
+ * Intended for the "direct download" code path where the browser fetches
+ * the presigned URL itself. Use `/api/public/download/:id` when direct
+ * download is disabled and the server must proxy the bytes.
+ */
+app.get('/:id/presigned', async (c) => {
+  const id = c.req.param('id')
+  const storage = c.req.query('storage')
+
+  if (!storage) {
+    throw badRequest('Missing storage parameter')
+  }
+
+  try {
+    const { imageData, imageUrl } = await loadImageOrThrow(id)
+    const filename = deriveFilename(imageData.image_name, imageUrl)
+    const url = await buildPresignedUrlForStorage(storage, imageUrl)
+    c.header('Cache-Control', 'private, max-age=60')
+    return ok(c, { url, filename: encodeURIComponent(filename) })
+  } catch (e) {
+    if (e instanceof HTTPException) throw e
+    throw serverError('Failed to build presigned download URL', e)
+  }
+})
+
+/**
+ * GET /api/public/download/:id?storage=s3|r2
+ *
+ * Always returns the image bytes with an `attachment` Content-Disposition.
+ * Use `/api/public/download/:id/presigned` when direct download is enabled
+ * for the storage and the client should fetch from object storage itself.
+ */
 app.get('/:id', async (c) => {
   const id = c.req.param('id')
   const storage = c.req.query('storage')
@@ -26,120 +181,22 @@ app.get('/:id', async (c) => {
   }
 
   try {
-    const imageData = await fetchImageByIdAndAuth(id)
-    if (!imageData) {
-      throw notFound('Image not found')
+    const { imageData, imageUrl } = await loadImageOrThrow(id)
+    const filename = deriveFilename(imageData.image_name, imageUrl)
+
+    const response = await fetch(imageUrl)
+    if (!response.ok) {
+      throw serverError('Failed to fetch image from storage')
     }
+    const blob = await response.blob()
 
-    const imageUrl = imageData.url
-    const imageName = imageData.image_name
-    if (!imageUrl) {
-      throw notFound('Image URL not found')
-    }
-
-    const downloadConfigs = await fetchConfigsByKeys([
-      's3_direct_download',
-      'r2_direct_download',
-      'storage_folder',
-      'r2_storage_folder'
-    ])
-    const s3DirectDownload = downloadConfigs.find((item: Config) => item.config_key === 's3_direct_download')?.config_value === 'true'
-    const r2DirectDownload = downloadConfigs.find((item: Config) => item.config_key === 'r2_direct_download')?.config_value === 'true'
-
-    if ((storage === 's3' && !s3DirectDownload) || (storage === 'r2' && !r2DirectDownload)) {
-      const response = await fetch(imageUrl)
-      const blob = await response.blob()
-
-      const filename = imageName
-        ? imageName
-        : decodeURIComponent(imageUrl.split('/').pop() || 'download.jpg')
-
-      return new Response(blob, {
-        headers: {
-          'Content-Type': response.headers.get('Content-Type') || 'application/octet-stream',
-          'Content-Disposition': `attachment; filename="${encodeURIComponent(filename)}"; filename*=UTF-8''${encodeURIComponent(filename)}`
-        }
-      })
-    }
-
-    let key: string
-    if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
-      const urlMatch = imageUrl.match(/^https?:\/\/[^\/]+(\/.*)$/)
-      if (urlMatch) {
-        key = urlMatch[1].slice(1)
-      } else {
-        key = imageUrl
-      }
-      if (storage === 's3') {
-        const s3StorageFolder = downloadConfigs.find((item: Config) => item.config_key === 'storage_folder')?.config_value || ''
-        if (s3StorageFolder && key.startsWith(s3StorageFolder)) {
-          key = key.slice(s3StorageFolder.length)
-        }
-      } else if (storage === 'r2') {
-        const r2StorageFolder = downloadConfigs.find((item: Config) => item.config_key === 'r2_storage_folder')?.config_value || ''
-        if (r2StorageFolder && key.startsWith(r2StorageFolder)) {
-          key = key.slice(r2StorageFolder.length)
-        }
-      }
-    } else {
-      key = imageUrl
-    }
-
-    const filename = imageName
-      ? imageName
-      : decodeURIComponent(imageUrl.split('/').pop() || 'download.jpg')
-
-    switch (storage) {
-      case 's3': {
-        const configs = await fetchConfigsByKeys([
-          'accesskey_id',
-          'accesskey_secret',
-          'region',
-          'endpoint',
-          'bucket',
-          'storage_folder',
-          'force_path_style',
-          's3_cdn',
-          's3_cdn_url',
-          's3_direct_download'
-        ])
-        const bucket = configs.find((item: Config) => item.config_key === 'bucket')?.config_value || ''
-        const storageFolder = configs.find((item: Config) => item.config_key === 'storage_folder')?.config_value || ''
-
-        const filePath = key.startsWith(storageFolder) ? key : `${storageFolder}${key}`
-        const client = getClient(configs)
-        const presignedUrl = await generatePresignedUrl(client, bucket, filePath, '')
-
-        return c.json({
-          url: presignedUrl,
-          filename: encodeURIComponent(filename)
-        })
-      }
-      case 'r2': {
-        const configs = await fetchConfigsByKeys([
-          'r2_accesskey_id',
-          'r2_accesskey_secret',
-          'r2_account_id',
-          'r2_bucket',
-          'r2_storage_folder',
-          'r2_public_domain',
-          'r2_direct_download'
-        ])
-        const bucket = configs.find((item: Config) => item.config_key === 'r2_bucket')?.config_value || ''
-        const storageFolder = configs.find((item: Config) => item.config_key === 'r2_storage_folder')?.config_value || ''
-
-        const filePath = key.startsWith(storageFolder) ? key : `${storageFolder}${key}`
-        const client = getR2Client(configs)
-        const presignedUrl = await generatePresignedUrl(client, bucket, filePath, '')
-
-        return c.json({
-          url: presignedUrl,
-          filename: encodeURIComponent(filename)
-        })
-      }
-      default:
-        throw badRequest('Unsupported storage type')
-    }
+    return new Response(blob, {
+      headers: {
+        'Content-Type': response.headers.get('Content-Type') || 'application/octet-stream',
+        'Content-Disposition': buildContentDisposition(filename),
+        'Cache-Control': 'private, no-store',
+      },
+    })
   } catch (e) {
     if (e instanceof HTTPException) throw e
     throw serverError('Failed to process download', e)


### PR DESCRIPTION
## Summary

Implements **PR-01** from `docs/plans/2026-05-19-api-refactor-design.md`.

The old `GET /api/public/download/:id` had two response contracts on one URL (binary blob when proxying, JSON `{ url, filename }` when direct-download is enabled for the storage). The frontend disambiguated by sniffing `Content-Type`, which mixes routing with response inspection and blocks the API from converging on the standard envelope.

This PR splits the endpoint into two single-contract routes and adds a tiny config endpoint so the frontend can pick the right path deterministically.

## Endpoints

- `GET /api/public/download/:id?storage=s3|r2` -> **always** binary bytes with `Content-Disposition: attachment; filename="..."; filename*=UTF-8''<encoded>` and `Cache-Control: private, no-store`.
- `GET /api/public/download/:id/presigned?storage=s3|r2` -> **always** `{ code: 200, message: 'Success', data: { url, filename } }` (via the `ok()` helper) with `Cache-Control: private, max-age=60`.
- `GET /api/public/download/config` -> **new**, returns `{ code: 200, message: 'Success', data: { s3DirectDownload, r2DirectDownload } }`. The frontend reads these flags before triggering a download.

All handlers use `ok` / `badRequest` / `notFound` / `serverError` from `hono/_lib/` -- no hand-written envelopes remain in this module.

## Config-exposure decision

Considered two options:

1. **Fold the flags into `GET /api/public/images/image-by-id`** -- rejected because preview-metadata fetching and the download action are independent (the user can click download without the metadata sheet having loaded a fresh copy), and it would couple two endpoints' contracts.
2. **Add `GET /api/public/download/config`** (chosen) -- minimal surface, cacheable on its own for ~60s, lives under the same `/download` namespace as its consumers, and doesn't need to grow further when more storages are added.

## Frontend

`components/album/preview-image.tsx` -- replaces the content-type sniffing branch with: (1) fetch `/api/public/download/config`, (2) pick endpoint by storage flag, (3) unified blob -> object URL -> anchor trigger path for both modes, with `URL.revokeObjectURL` cleanup.

## Scope discipline

- Field names like `image_name`, `album_value` are deliberately untouched (PR-08 / PR-09).
- No changes to `/api/public/images/*`, helpers, or auth (other PRs).

## Test plan

- [x] `pnpm run lint` -- clean on `hono/open/download.ts` and `components/album/preview-image.tsx`.
- [x] `pnpm exec tsc --noEmit` -- error count unchanged at baseline (69 on main; no new errors introduced).
- [x] `pnpm run build` -- succeeds.
- [ ] Manual: with `s3_direct_download` / `r2_direct_download` **disabled** in admin settings, click download on a preview image -> proxied binary download succeeds, filename preserved (incl. non-ASCII via `filename*=UTF-8''`).
- [ ] Manual: with the flag **enabled**, same click -> browser fetches the presigned URL directly and saves with the same filename.
- [ ] Manual: `curl /api/public/download/config` returns the envelope.
- [ ] Manual: `curl /api/public/download/:id/presigned?storage=s3` returns the envelope with a working presigned URL.