### PR TITLE
fix(tasks): narrow advisory lock to state transitions

### DIFF
--- a/server/tasks/service.ts
+++ b/server/tasks/service.ts
@@ -385,6 +385,36 @@ async function withTaskLock<T>(callback: () => Promise<T>) {
   }
 }
 
+async function withTaskLockWarn<T>(context: string, callback: () => Promise<T>) {
+  const result = await withTaskLock(callback)
+  if (result === null) {
+    console.warn(`metadata task lock busy: ${context}`)
+  }
+  return result
+}
+
+const PROGRESS_LOCK_RETRY_COUNT = 5
+const PROGRESS_LOCK_RETRY_DELAY_MS = 50
+
+async function delay(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+// Re-acquires the advisory lock briefly to run a state-transition callback. The
+// per-image checkpoint and finalization paths use this so they don't have to
+// give up cleanly when another short-lived lock holder is mid-write.
+async function withTaskLockRetry<T>(context: string, callback: () => Promise<T>) {
+  for (let attempt = 0; attempt < PROGRESS_LOCK_RETRY_COUNT; attempt += 1) {
+    const result = await withTaskLock(callback)
+    if (result !== null) return result
+    if (attempt < PROGRESS_LOCK_RETRY_COUNT - 1) {
+      await delay(PROGRESS_LOCK_RETRY_DELAY_MS)
+    }
+  }
+  console.warn(`metadata task lock busy after retries: ${context}`)
+  return null
+}
+
 async function findTaskRunById(runId: string) {
   const rows = await db.$queryRaw<TaskRunRecord[]>`
     ${taskRunSelect}
@@ -466,22 +496,46 @@ async function finalizeTaskRunAsCancelled(runId: string, now = new Date()) {
   return rows[0] ?? null
 }
 
-async function ensureTaskRunCanContinue(runId: string, controller: AbortController) {
-  throwIfMetadataTaskCancelled(controller.signal)
-
-  const record = await findTaskRunById(runId)
-  if (!record) {
-    abortTaskController(controller, 'Task run no longer exists.')
-    throw createMetadataTaskCancelledError('Task run no longer exists.')
+async function commitTaskRunProgress(runId: string, progress: TaskBatchProgress) {
+  if (progress.processedCount === 0 && progress.issues.length === 0) {
+    return findTaskRunById(runId)
   }
 
-  if (record.status === 'cancelling' || record.status === 'cancelled') {
-    abortTaskController(controller, 'Task cancellation requested.')
-    throw createMetadataTaskCancelledError('Task cancellation requested.')
-  }
+  const currentRecord = await findTaskRunById(runId)
+  if (!currentRecord) return null
 
-  throwIfMetadataTaskCancelled(controller.signal)
-  return record
+  const now = new Date()
+  const leaseExpiresAt = new Date(now.getTime() + METADATA_TASK_LEASE_MS)
+  const nextCursor = progress.processedCount > 0 ? progress.nextCursor : currentRecord.nextCursor
+  const mergedIssues = mergeRecentIssues(currentRecord.recentIssues, progress.issues, fallbackIssueTime(currentRecord))
+
+  const rows = await db.$queryRaw<TaskRunRecord[]>`
+    UPDATE "public"."admin_task_runs"
+    SET
+      "processed_count" = "processed_count" + ${progress.processedCount},
+      "success_count" = "success_count" + ${progress.successCount},
+      "skipped_count" = "skipped_count" + ${progress.skippedCount},
+      "failed_count" = "failed_count" + ${progress.failedCount},
+      "next_cursor" = ${nextCursor},
+      "recent_issues" = ${jsonValue(mergedIssues)},
+      "lease_expires_at" = CASE
+        WHEN "status" IN ('cancelling', 'cancelled') THEN "lease_expires_at"
+        ELSE ${leaseExpiresAt}
+      END,
+      "updated_at" = ${now}
+    WHERE "id" = ${runId}
+    ${taskRunReturning}
+  `
+
+  return rows[0] ?? null
+}
+
+function resetProgress(progress: TaskBatchProgress) {
+  progress.processedCount = 0
+  progress.successCount = 0
+  progress.skippedCount = 0
+  progress.failedCount = 0
+  progress.issues = []
 }
 
 async function finalizeFailedTaskRun(runId: string, progress: TaskBatchProgress, error: unknown) {
@@ -584,7 +638,7 @@ export async function getMetadataTaskRunDetail(runId: string) {
 }
 
 export async function createMetadataTaskRun(scope: AdminTaskScope) {
-  return withTaskLock(async () => {
+  return withTaskLockWarn('createRun', async () => {
     const existingRun = await findActiveTaskRun('desc')
     if (existingRun) throw new Error('Another metadata task is already active')
 
@@ -658,84 +712,132 @@ export async function cancelMetadataTaskRun(runId: string) {
 }
 
 export async function kickMetadataTaskRun(runId: string) {
-  const result = await withTaskLock(async () => {
+  // Phase 1: state transition — lease the run under the advisory lock so
+  // concurrent kick attempts see a held lease and bail. The lock is released
+  // immediately after this; the per-image network I/O happens outside it.
+  const leaseResult = await withTaskLockWarn('kick:lease', async () => {
     const leasedRun = await leaseTaskRun(runId)
-    if (!leasedRun) return toAdminTaskRunSummary(await findTaskRunById(runId))
+    if (!leasedRun) return { leased: null as TaskRunRecord | null }
+    return { leased: leasedRun }
+  })
 
-    const controller = registerTaskAbortController(leasedRun.id)
-    const progress: TaskBatchProgress = {
-      processedCount: 0,
-      successCount: 0,
-      skippedCount: 0,
-      failedCount: 0,
-      nextCursor: leasedRun.nextCursor,
-      issues: [],
+  if (leaseResult === null) {
+    // Advisory lock unavailable; surface the current state without progressing.
+    return toAdminTaskRunSummary(await findTaskRunById(runId))
+  }
+
+  const leasedRun = leaseResult.leased
+  if (!leasedRun) {
+    // Lock was free but the run couldn't be leased (wrong status, lease held,
+    // or row missing). Mirror previous behavior: return the current row.
+    return toAdminTaskRunSummary(await findTaskRunById(runId))
+  }
+
+  const controller = registerTaskAbortController(leasedRun.id)
+  const progress: TaskBatchProgress = {
+    processedCount: 0,
+    successCount: 0,
+    skippedCount: 0,
+    failedCount: 0,
+    nextCursor: leasedRun.nextCursor,
+    issues: [],
+  }
+  let stoppedByCancellation = false
+  let batchLength = 0
+
+  try {
+    const scope = normalizeMetadataTaskScope(leasedRun.scope)
+    // Phase 2: batch read happens outside the advisory lock — it is a
+    // read-only DB query and does not need the lock.
+    const batch = await fetchImagesBatchForScope(scope, leasedRun.nextCursor)
+    batchLength = batch.length
+
+    if (batch.length === 0) {
+      const finalized = await withTaskLockRetry('kick:finalize-empty', () =>
+        finalizeTaskRunBatch(leasedRun.id, progress, 0, false),
+      )
+      return finalized ?? toAdminTaskRunSummary(await findTaskRunById(runId))
     }
 
     try {
-      const scope = normalizeMetadataTaskScope(leasedRun.scope)
-      const batch = await fetchImagesBatchForScope(scope, leasedRun.nextCursor)
+      for (const image of batch) {
+        throwIfMetadataTaskCancelled(controller.signal)
 
-      if (batch.length === 0) {
-        return await finalizeTaskRunBatch(leasedRun.id, progress, 0, false)
-      }
+        try {
+          // Network fetch + EXIF parse: happens entirely OUTSIDE the lock.
+          const result = await refreshImageMetadata(image, controller.signal)
+          throwIfMetadataTaskCancelled(controller.signal)
 
-      let stoppedByCancellation = false
+          progress.issues.push(...result.issues)
 
-      try {
-        for (const image of batch) {
-          await ensureTaskRunCanContinue(leasedRun.id, controller)
-
-          try {
-            const result = await refreshImageMetadata(image, controller.signal)
-            await ensureTaskRunCanContinue(leasedRun.id, controller)
-
-            progress.issues.push(...result.issues)
-
-            if (result.outcome === 'success') {
-              await updateImageMetadataFields(image.id, result.updates)
-              progress.successCount += 1
-            } else if (result.outcome === 'skipped') {
-              progress.skippedCount += 1
-            } else {
-              progress.failedCount += 1
-            }
-
-            progress.processedCount += 1
-            progress.nextCursor = image.id
-          } catch (error) {
-            if (isMetadataTaskCancelledError(error)) {
-              stoppedByCancellation = true
-              break
-            }
-
+          if (result.outcome === 'success') {
+            await updateImageMetadataFields(image.id, result.updates)
+            progress.successCount += 1
+          } else if (result.outcome === 'skipped') {
+            progress.skippedCount += 1
+          } else {
             progress.failedCount += 1
-            progress.processedCount += 1
-            progress.nextCursor = image.id
-            progress.issues.push(createImageIssue(image, {
-              level: 'error',
-              stage: 'process-batch',
-              code: 'unexpected_error',
-              summary: 'Unexpected error while processing image metadata.',
-              detail: unknownErrorDetail(error),
-            }))
+          }
+
+          progress.processedCount += 1
+          progress.nextCursor = image.id
+        } catch (error) {
+          if (isMetadataTaskCancelledError(error)) {
+            stoppedByCancellation = true
+            break
+          }
+
+          progress.failedCount += 1
+          progress.processedCount += 1
+          progress.nextCursor = image.id
+          progress.issues.push(createImageIssue(image, {
+            level: 'error',
+            stage: 'process-batch',
+            code: 'unexpected_error',
+            summary: 'Unexpected error while processing image metadata.',
+            detail: unknownErrorDetail(error),
+          }))
+        }
+
+        // Per-image checkpoint: briefly re-acquire the advisory lock to
+        // persist incremental progress, refresh the lease, and check whether
+        // a concurrent cancel has flipped the row into the cancelling state.
+        const checkpoint = await withTaskLockRetry('kick:checkpoint', () =>
+          commitTaskRunProgress(leasedRun.id, progress),
+        )
+
+        if (checkpoint) {
+          resetProgress(progress)
+
+          if (checkpoint.status === 'cancelling' || checkpoint.status === 'cancelled') {
+            abortTaskController(controller, 'Task cancellation requested.')
+            stoppedByCancellation = true
+            break
           }
         }
-      } catch (error) {
-        if (isMetadataTaskCancelledError(error)) {
-          stoppedByCancellation = true
-        } else {
-          return await finalizeFailedTaskRun(leasedRun.id, progress, error)
-        }
+        // If checkpoint is null (row missing or lock saturated after retries),
+        // we keep the local progress and let the finalize step flush it.
       }
-
-      return await finalizeTaskRunBatch(leasedRun.id, progress, batch.length, stoppedByCancellation)
-    } finally {
-      clearTaskAbortController(leasedRun.id, controller)
+    } catch (error) {
+      if (isMetadataTaskCancelledError(error)) {
+        stoppedByCancellation = true
+      } else {
+        const failed = await withTaskLockRetry('kick:finalize-failed', () =>
+          finalizeFailedTaskRun(leasedRun.id, progress, error),
+        )
+        return failed ?? toAdminTaskRunSummary(await findTaskRunById(leasedRun.id))
+      }
     }
-  })
 
-  return result ?? toAdminTaskRunSummary(await findTaskRunById(runId))
+    // Phase 3: state transition — flip status to succeeded/running/cancelled
+    // and flush any tail counters the checkpoint loop hasn't committed yet.
+    const finalized = await withTaskLockRetry('kick:finalize', () =>
+      finalizeTaskRunBatch(leasedRun.id, progress, batchLength, stoppedByCancellation),
+    )
+    return finalized ?? toAdminTaskRunSummary(await findTaskRunById(leasedRun.id))
+  } finally {
+    clearTaskAbortController(leasedRun.id, controller)
+  }
 }
 
 export async function tickMetadataTaskRuns() {


### PR DESCRIPTION
## Summary

Implements **PR-05** from `docs/plans/2026-05-19-api-refactor-design.md` (§ PR-05, lines 146–152).

`kickMetadataTaskRun` previously held the Postgres advisory lock (`pg_try_advisory_lock(42011)`) around the entire 10-image processing loop. Each `refreshImageMetadata` call can spend up to ~20s on network I/O (`FETCH_TIMEOUT_MS = 20_000` in `server/tasks/metadata-refresh.ts`), so worst-case the lock was held for ~200s per kick — blocking every other `createMetadataTaskRun` / `kickMetadataTaskRun` attempt during that window.

This PR narrows the lock to only state-transition SQL, leaving the per-image network I/O lock-free.

## What changed (server/tasks/service.ts)

- **New `withTaskLockWarn(context, callback)`** — wraps `withTaskLock` and emits `console.warn('metadata task lock busy: <context>')` when contention causes a `null` return. Addresses the audit note about silent failures.
- **New `withTaskLockRetry(context, callback)`** — same as above but retries up to 5 times with 50ms backoff before warning. Used at the per-image checkpoint and at finalization, where giving up immediately would lose accumulated progress.
- **New `commitTaskRunProgress(runId, progress)`** — incremental SQL update that increments counters by the delta, advances `next_cursor`, appends issues, and refreshes the lease (`lease_expires_at`). Returns the current row so the caller can detect a `cancelling`/`cancelled` flip.
- **`createMetadataTaskRun`** — now uses `withTaskLockWarn('createRun', …)` instead of the bare `withTaskLock`.
- **`kickMetadataTaskRun`** restructured into three phases (see annotated comments in the file):
  1. `withTaskLockWarn('kick:lease', …)` — lease the run, release the lock.
  2. *No lock held:* `fetchImagesBatchForScope`, then loop over images calling `refreshImageMetadata` + `updateImageMetadataFields`.
  3. After each image, `withTaskLockRetry('kick:checkpoint', commitTaskRunProgress)` — briefly re-acquire the lock to persist progress and refresh the lease. If the returned status is `cancelling`/`cancelled`, abort the controller and break.
  4. `withTaskLockRetry('kick:finalize', finalizeTaskRunBatch)` — flip the final status.
- Removed unused helper `ensureTaskRunCanContinue` (per-image cancel check is now inline + via the checkpoint round-trip).

## Advisory lock vs. run lease — important distinction

These are two complementary mechanisms; the refactor relies on both:

- **Advisory lock** (`pg_try_advisory_lock(42011)`) — process-level mutex around state-mutation SQL. Held for milliseconds at a time after this change.
- **Run lease** (`admin_task_runs.lease_expires_at`) — per-row claim that says "process X is currently working this run". `leaseTaskRun` only succeeds when the lease is null or expired (2 min TTL, refreshed by `commitTaskRunProgress` on every checkpoint).

A concurrent kick attempt for the same run mid-flight does **not** contend on the advisory lock (lock is free between checkpoints). It acquires the lock, attempts `leaseTaskRun`, sees an active lease, fails the lease, releases the lock, and returns the current row summary — no work done, no stall.

## Public API preserved

Signatures of `kickMetadataTaskRun`, `createMetadataTaskRun`, `cancelMetadataTaskRun`, `tickMetadataTaskRuns` are unchanged. Return-value semantics are unchanged — including the "task not found" / "lock busy" → return the current row pattern.

## Test plan

- [ ] `pnpm exec eslint server/tasks/service.ts` clean (verified locally — 0 errors/warnings).
- [ ] `pnpm exec tsc --noEmit` error count unchanged vs. main (100, all pre-existing in unrelated files).
- [ ] `pnpm run build` succeeds (verified locally).
- [ ] **Manual: happy path** — start a refresh-metadata task in the admin UI on a non-trivial album, tail the server log, confirm no `metadata task lock busy` warnings appear under normal single-kick operation. Confirm `processed_count` / `next_cursor` advance incrementally (not in a single jump at the end) by polling `/api/v1/tasks/runs/:id`.
- [ ] **Manual: concurrent kick** — while a kick is mid-batch, fire a second `POST /api/v1/tasks/runs/:id/kick` for the same run. Expect HTTP 200 with the active run summary; expect the second call to NOT spend ~20s waiting; expect no double-progress.
- [ ] **Manual: cancel mid-flight** — start a task, then `POST /api/v1/tasks/runs/:id/cancel` while images are being fetched. Expect the task to terminate at the next per-image checkpoint (not at batch end), with status `cancelled` and `finished_at` populated.
- [ ] **Manual: log contention** — temporarily wedge the advisory lock from a `psql` session (`SELECT pg_advisory_lock(42011);`) and trigger `createMetadataTaskRun`. Expect a `metadata task lock busy: createRun` warning in the server log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)