### PR TITLE
feat(upload): server-side validation — size, MIME, path traversal

### DIFF
--- a/hono/file.ts
+++ b/hono/file.ts
@@ -9,6 +9,11 @@ import { getR2Client } from '~/server/lib/r2'
 import { generatePresignedUrl } from '~/server/lib/s3api'
 import { ok } from '~/hono/_lib/response'
 import { badRequest, serverError } from '~/hono/_lib/errors'
+import {
+  validateFilename,
+  validateFileSize,
+  validateMimeType,
+} from '~/server/lib/upload-validation'
 import { HTTPException } from 'hono/http-exception'
 
 interface S3StorageConfig {
@@ -77,17 +82,16 @@ const app = new Hono()
 app.post('/presigned-url', async (c) => {
   try {
     const { filename, contentType, type = '/', storage } = await c.req.json()
-    if (!filename) {
-      throw badRequest('Filename is required')
-    }
     if (!storage) {
       throw badRequest('Storage type is required')
     }
+    const safeFilename = validateFilename(filename)
+    validateMimeType(contentType)
 
     switch (storage) {
       case 's3': {
         const { bucket, storageFolder, client } = await getS3Config()
-        const filePath = buildStoragePath(storageFolder, type, filename)
+        const filePath = buildStoragePath(storageFolder, type, safeFilename)
         const presignedUrl = await generatePresignedUrl(client, bucket, filePath, contentType, 'put')
 
         return ok(c, { presignedUrl, key: filePath })
@@ -95,7 +99,7 @@ app.post('/presigned-url', async (c) => {
 
       case 'r2': {
         const { bucket, storageFolder, client } = await getR2Config()
-        const filePath = buildStoragePath(storageFolder, type, filename)
+        const filePath = buildStoragePath(storageFolder, type, safeFilename)
         const presignedUrl = await generatePresignedUrl(client, bucket, filePath, contentType, 'put')
 
         return ok(c, { presignedUrl, key: filePath })
@@ -125,6 +129,9 @@ app.post('/upload', async (c) => {
           if (!file || !(file instanceof File)) {
             throw badRequest('File is required')
           }
+          validateFilename(file.name)
+          validateMimeType(file.type)
+          validateFileSize(file.size)
           const result = await openListUpload(file, type, mountPath)
           return ok(c, result)
         }

--- a/server/lib/file-upload.ts
+++ b/server/lib/file-upload.ts
@@ -1,8 +1,14 @@
 import 'server-only'
 
+import path from 'node:path'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
 import { HTTPException } from 'hono/http-exception'
 import { Config } from '~/types'
+import {
+  validateFilename,
+  validateFileSize,
+  validateMimeType,
+} from '~/server/lib/upload-validation'
 
 /**
  * Open List API 文件上传封装
@@ -12,14 +18,27 @@ import { Config } from '~/types'
  * @return {Promise<string>} 返回文件路径
  */
 export async function openListUpload(file: any, type: any, mountPath: any): Promise<string | undefined> {
+  // Defence in depth: validate even though the Hono handler already checked.
+  // `openListUpload` is exported and may be called from other code paths.
+  const safeName = validateFilename(file?.name)
+  validateMimeType(file?.type)
+  validateFileSize(file?.size)
+
+  // Sanitize the mount path so a malicious caller can't traverse out via
+  // `..` segments in the OpenList `File-Path` header. `path.basename` strips
+  // any directory portion that might have been embedded.
+  const mountString = mountPath == null ? '' : mountPath.toString()
+  const mountBase = mountString === '/' || mountString === '' ? '' : path.basename(mountString)
+
   const findConfig = await fetchConfigsByKeys([
     'open_list_url',
     'open_list_token'
   ])
   const openListToken = findConfig.find((item: Config) => item.config_key === 'open_list_token')?.config_value || ''
   const openListUrl = findConfig.find((item: Config) => item.config_key === 'open_list_url')?.config_value || ''
-  const filePath = encodeURIComponent(`${mountPath && mountPath.toString() === '/' ? '' : mountPath}${
-    type && type !== '/' ? `${type}/${file?.name}` : `/${file?.name}`}`)
+  const mountPrefix = mountBase ? `/${mountBase}` : ''
+  const filePath = encodeURIComponent(`${mountPrefix}${
+    type && type !== '/' ? `${type}/${safeName}` : `/${safeName}`}`)
   const data = await fetch(`${openListUrl}/api/fs/put`, {
     method: 'PUT',
     headers: {

--- a/server/lib/upload-validation.ts
+++ b/server/lib/upload-validation.ts
@@ -1,0 +1,84 @@
+import 'server-only'
+
+import path from 'node:path'
+import { badRequest } from '~/hono/_lib/errors'
+
+/**
+ * Maximum upload size enforced for direct (`/upload`) uploads.
+ *
+ * Hardcoded for now — a config-driven `max_upload_size` is a future enhancement.
+ */
+export const MAX_UPLOAD_SIZE = 50 * 1024 * 1024
+
+/**
+ * MIME types permitted by the upload pipeline.
+ *
+ * Covers the still-image formats the gallery renders plus the two container
+ * formats used by Live Photo videos (`.mov`/`.mp4`).
+ */
+export const ALLOWED_MIME_TYPES: readonly string[] = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/avif',
+  'image/heic',
+  'image/heif',
+  'image/gif',
+  'video/mp4',
+  'video/quicktime',
+]
+
+const FILENAME_REJECT_PATTERN = /[/\\\0]|\.\./
+
+/**
+ * Validate an uploaded filename.
+ *
+ * Rejects empty strings, NUL bytes, path separators (`/`, `\\`) and any `..`
+ * segments, then runs `path.basename` to strip residual directory components
+ * (defence in depth in case the caller crafted something the surface checks
+ * missed).
+ *
+ * Returns the sanitized basename so callers can substitute it for the raw
+ * user input.
+ *
+ * Throws `badRequest('Invalid filename')` on any failure.
+ */
+export function validateFilename(name: unknown): string {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw badRequest('Invalid filename')
+  }
+  if (FILENAME_REJECT_PATTERN.test(name)) {
+    throw badRequest('Invalid filename')
+  }
+  const base = path.basename(name)
+  if (base.length === 0 || base === '.' || base === '..') {
+    throw badRequest('Invalid filename')
+  }
+  return base
+}
+
+/**
+ * Validate that the supplied MIME type is on the upload allowlist.
+ *
+ * Throws `badRequest('Unsupported file type: <type>')` otherwise.
+ */
+export function validateMimeType(type: unknown): void {
+  const value = typeof type === 'string' ? type : ''
+  if (!ALLOWED_MIME_TYPES.includes(value)) {
+    throw badRequest(`Unsupported file type: ${value}`)
+  }
+}
+
+/**
+ * Validate that the supplied file size is within `MAX_UPLOAD_SIZE`.
+ *
+ * Throws `badRequest('File too large')` otherwise.
+ */
+export function validateFileSize(size: unknown): void {
+  if (typeof size !== 'number' || !Number.isFinite(size) || size < 0) {
+    throw badRequest('File too large')
+  }
+  if (size > MAX_UPLOAD_SIZE) {
+    throw badRequest('File too large')
+  }
+}


### PR DESCRIPTION
## Summary

Implements **PR-06** from `docs/plans/2026-05-19-api-refactor-design.md` — adds defence-in-depth validation to the upload pipeline. Every check runs **before** any S3/R2/Open List SDK call.

A new module `server/lib/upload-validation.ts` exposes three synchronous helpers (`validateFilename`, `validateMimeType`, `validateFileSize`). All throw `badRequest(...)` from `hono/_lib/errors.ts`. They are applied in `hono/file.ts` (`/presigned-url`, `/upload`) and re-applied defensively inside `server/lib/file-upload.ts#openListUpload`.

## Validation rules

| Rule | Where | Rejected example |
|------|-------|------------------|
| Filename non-empty | all upload entry points | `""` → 400 |
| Filename has no `..` | all upload entry points | `"../etc/passwd.jpg"` → 400 |
| Filename has no NUL byte | all upload entry points | `"foo\0.jpg"` → 400 |
| Filename has no `/` or `\` | all upload entry points | `"a/b.jpg"`, `"a\b.jpg"` → 400 |
| Filename basename not `.` / `..` / empty | all upload entry points | `"."` → 400 |
| MIME on allowlist | `/presigned-url` (`contentType`), `/upload` (`file.type`) | `"text/plain"` → `400 Unsupported file type: text/plain` |
| Size ≤ 50 MiB | `/upload` direct | `100 MB` file → `400 File too large` |
| Mount path sanitized | `openListUpload` | `mountPath="/legit/../etc"` collapses to `"/etc"` via `path.basename`, blocking arbitrary traversal |

**Allowed MIME types:** `image/jpeg`, `image/png`, `image/webp`, `image/avif`, `image/heic`, `image/heif`, `image/gif`, plus Live Photo containers `video/mp4` and `video/quicktime`.

## Limitations

- **No size enforcement on `/presigned-url`.** Once a signed PUT URL is issued, the client uploads directly to S3/R2 and the Hono process never sees the bytes. The existing `generatePresignedUrl` helper in `server/lib/s3api.ts` does not currently set a `Content-Length` condition on the signed URL; adding one is out of scope for this PR. Followup: thread a `maxSize` argument through `generatePresignedUrl` to set the signature condition.
- **`MAX_UPLOAD_SIZE` is hardcoded to 50 MiB.** A `max_upload_size` config key is mentioned in the PR-06 spec as a future enhancement; deferred to keep this PR scoped.
- **`mountPath` basename collapse.** The spec mandates `path.basename(mountPath)` to block traversal. This means OpenList mounts whose `mount_path` contains multiple segments (e.g. `/storage/uploads`) will have everything but the last segment dropped. If existing deployments rely on multi-segment mount paths the followup is to switch to a normalize-and-reject-`..` strategy instead.

## Test plan

- [ ] Upload a `.txt` file via `/upload` → 400 `Unsupported file type: text/plain`.
- [ ] Upload a 100 MB image via `/upload` (direct) → 400 `File too large`.
- [ ] POST `/presigned-url` with `filename: "../../../etc/passwd.jpg"` → 400 `Invalid filename`.
- [ ] POST `/presigned-url` with a filename containing a NUL byte → 400 `Invalid filename`.
- [ ] POST `/presigned-url` with `contentType: "application/zip"` → 400 `Unsupported file type: application/zip`.
- [ ] Happy path: upload a real `.jpg`, `.png`, `.heic`, and Live Photo `.mov` end-to-end via the admin upload UI.
- [ ] Confirm OpenList upload still works for a single-segment mount such as `/photos`.

## Verification

- `pnpm run lint` — 0 errors (193 pre-existing warnings unchanged).
- `pnpm exec tsc --noEmit` — 100 errors, identical to baseline on `main`; no new errors in the three changed files.
- `pnpm run build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
