### PR TITLE
fix(upload): preserve multi-segment OpenList mountPath

### DIFF
--- a/server/lib/file-upload.ts
+++ b/server/lib/file-upload.ts
@@ -1,6 +1,5 @@
 import 'server-only'
 
-import path from 'node:path'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
 import { HTTPException } from 'hono/http-exception'
 import { Config } from '~/types'
@@ -8,6 +7,7 @@ import {
   validateFilename,
   validateFileSize,
   validateMimeType,
+  validateMountPath,
 } from '~/server/lib/upload-validation'
 
 /**
@@ -24,11 +24,12 @@ export async function openListUpload(file: any, type: any, mountPath: any): Prom
   validateMimeType(file?.type)
   validateFileSize(file?.size)
 
-  // Sanitize the mount path so a malicious caller can't traverse out via
-  // `..` segments in the OpenList `File-Path` header. `path.basename` strips
-  // any directory portion that might have been embedded.
-  const mountString = mountPath == null ? '' : mountPath.toString()
-  const mountBase = mountString === '/' || mountString === '' ? '' : path.basename(mountString)
+  // Validate the mount path without flattening it: OpenList deployments
+  // routinely use multi-segment mounts like `/storage/uploads`, which an
+  // earlier `path.basename` sanitization incorrectly collapsed to `uploads`.
+  // `validateMountPath` rejects `..` traversal and NUL bytes while preserving
+  // the full path.
+  const normalizedMount = validateMountPath(mountPath)
 
   const findConfig = await fetchConfigsByKeys([
     'open_list_url',
@@ -36,7 +37,10 @@ export async function openListUpload(file: any, type: any, mountPath: any): Prom
   ])
   const openListToken = findConfig.find((item: Config) => item.config_key === 'open_list_token')?.config_value || ''
   const openListUrl = findConfig.find((item: Config) => item.config_key === 'open_list_url')?.config_value || ''
-  const mountPrefix = mountBase ? `/${mountBase}` : ''
+  // The downstream path always carries its own leading slash via either `type`
+  // or the `/${safeName}` fallback. Strip a root-only mount so we don't emit
+  // `//<file>`.
+  const mountPrefix = normalizedMount === '/' ? '' : normalizedMount
   const filePath = encodeURIComponent(`${mountPrefix}${
     type && type !== '/' ? `${type}/${safeName}` : `/${safeName}`}`)
   const data = await fetch(`${openListUrl}/api/fs/put`, {

--- a/server/lib/upload-validation.ts
+++ b/server/lib/upload-validation.ts
@@ -82,3 +82,48 @@ export function validateFileSize(size: unknown): void {
     throw badRequest('File too large')
   }
 }
+
+/**
+ * Validate and normalize an OpenList mount path.
+ *
+ * Unlike a filename, a mount path is a *directory prefix* that may legitimately
+ * contain multiple segments (e.g. `/storage/uploads`). We must preserve the
+ * full path while still rejecting genuinely dangerous input:
+ *
+ * - `..` as a path segment (would let a caller traverse out of the mount).
+ * - NUL bytes (terminator injection in downstream consumers).
+ *
+ * Normalization:
+ * - Repeated slashes are collapsed (`//foo//bar` -> `/foo/bar`).
+ * - A trailing slash is trimmed (`/foo/` -> `/foo`), except for the root.
+ * - A leading slash, if present in the input, is preserved.
+ * - `null`/`undefined`/empty input returns `''` (no mount prefix).
+ *
+ * Throws `badRequest('Invalid mount path')` if the input contains a `..`
+ * segment or a NUL byte.
+ */
+export function validateMountPath(mountPath: unknown): string {
+  if (mountPath == null) {
+    return ''
+  }
+  const raw = typeof mountPath === 'string' ? mountPath : String(mountPath)
+  if (raw.length === 0) {
+    return ''
+  }
+  if (raw.includes('\0')) {
+    throw badRequest('Invalid mount path')
+  }
+  const hasLeadingSlash = raw.startsWith('/')
+  const segments = raw.split('/').filter((segment) => segment.length > 0)
+  for (const segment of segments) {
+    if (segment === '..') {
+      throw badRequest('Invalid mount path')
+    }
+  }
+  if (segments.length === 0) {
+    // Input was something like '/' or '///' — treat as root, no prefix.
+    return hasLeadingSlash ? '/' : ''
+  }
+  const joined = segments.join('/')
+  return hasLeadingSlash ? `/${joined}` : joined
+}


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by #462. The upload-hardening PR sanitized the OpenList `mountPath` with `path.basename`, which collapses multi-segment paths like `/storage/uploads` down to `uploads`. Every OpenList deployment with a non-trivial mount path has been uploading to the wrong directory since #462 merged.

This PR replaces the flattening with a `validateMountPath` helper that rejects only genuinely dangerous content and preserves the full path otherwise.

## Changes

- `server/lib/upload-validation.ts` — new exported `validateMountPath(mountPath)` helper.
  - Rejects `..` as a path segment (split on `/`, check each segment).
  - Rejects NUL bytes.
  - Normalizes by collapsing repeated slashes and trimming a trailing slash.
  - Preserves a leading slash if the input had one.
  - Returns `''` for null/undefined/empty input and `'/'` for the bare root.
- `server/lib/file-upload.ts` — `openListUpload` now uses `validateMountPath` instead of `path.basename`; the unused `node:path` import is removed.

## Acceptance criteria

- `validateMountPath('/storage/uploads')` -> `/storage/uploads`
- `validateMountPath('/')` -> `/`
- `validateMountPath('')` -> `''`
- `validateMountPath('/foo/../bar')` -> throws `badRequest('Invalid mount path')`
- `validateMountPath('/foo\x00bar')` -> throws `badRequest('Invalid mount path')`
- `validateMountPath('//foo//bar/')` -> `/foo/bar`

## Test plan

- [x] `pnpm run lint` — no new errors in changed files.
- [x] `pnpm exec tsc --noEmit` — error count matches the HEAD baseline (100), no new errors in `server/lib/file-upload.ts` or `server/lib/upload-validation.ts`.
- [x] `pnpm run build` — compiles successfully.
- [x] Mentally traced the example cases above against the implementation.
- [ ] Manual smoke test: configure an OpenList storage with a multi-segment mount (e.g. `/storage/uploads`) and upload an image; verify the file appears under the full mount path on the OpenList backend.
- [ ] Manual smoke test: confirm `..` and NUL byte inputs still error out with `400 Invalid mount path`.

Refs: #462