### PR TITLE
refactor(types): rename exif.data_time → exif.dateTime

### DIFF
--- a/components/admin/album/exif-view.tsx
+++ b/components/admin/album/exif-view.tsx
@@ -48,10 +48,10 @@ export default function ExifView(props: Readonly<ImageDataProps>) {
             </TableRow>
           }
           {
-            dayjs(props.data?.exif?.data_time, 'YYYY:MM:DD HH:mm:ss').isValid() &&
-            <TableRow key="data_time">
+            dayjs(props.data?.exif?.dateTime, 'YYYY:MM:DD HH:mm:ss').isValid() &&
+            <TableRow key="dateTime">
               <TableCell className="font-medium">拍摄时间</TableCell>
-              <TableCell className="truncate max-w-48">{dayjs(props.data?.exif?.data_time, 'YYYY:MM:DD HH:mm:ss').format('YYYY-MM-DD HH:mm:ss')}</TableCell>
+              <TableCell className="truncate max-w-48">{dayjs(props.data?.exif?.dateTime, 'YYYY:MM:DD HH:mm:ss').format('YYYY-MM-DD HH:mm:ss')}</TableCell>
             </TableRow>
           }
           {

--- a/components/album/preview-image-exif.tsx
+++ b/components/album/preview-image-exif.tsx
@@ -67,10 +67,10 @@ export default function PreviewImageExif(props: Readonly<ImageDataProps>) {
 
   // Format date time
   const formattedDateTime = React.useMemo(() => {
-    if (!props.data?.exif?.data_time) return null
-    const parsed = dayjs(props.data.exif.data_time, 'YYYY:MM:DD HH:mm:ss')
-    return parsed.isValid() ? parsed.format('YYYY-MM-DD HH:mm:ss') : props.data.exif.data_time
-  }, [props.data?.exif?.data_time])
+    if (!props.data?.exif?.dateTime) return null
+    const parsed = dayjs(props.data.exif.dateTime, 'YYYY:MM:DD HH:mm:ss')
+    return parsed.isValid() ? parsed.format('YYYY-MM-DD HH:mm:ss') : props.data.exif.dateTime
+  }, [props.data?.exif?.dateTime])
 
   // Calculate file info
   const dimensions = React.useMemo(() => {

--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -79,10 +79,10 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
 
   // Format date time
   const formattedDateTime = useMemo(() => {
-    if (!props.data?.exif?.data_time) return null
-    const parsed = dayjs(props.data.exif.data_time, 'YYYY:MM:DD HH:mm:ss')
-    return parsed.isValid() ? parsed.format('YYYY-MM-DD HH:mm:ss') : props.data.exif.data_time
-  }, [props.data?.exif?.data_time])
+    if (!props.data?.exif?.dateTime) return null
+    const parsed = dayjs(props.data.exif.dateTime, 'YYYY:MM:DD HH:mm:ss')
+    return parsed.isValid() ? parsed.format('YYYY-MM-DD HH:mm:ss') : props.data.exif.dateTime
+  }, [props.data?.exif?.dateTime])
 
   // Calculate file info
   const dimensions = useMemo(() => {

--- a/components/viewer/photo-viewer.tsx
+++ b/components/viewer/photo-viewer.tsx
@@ -190,8 +190,8 @@ export default function PhotoViewer({ photo, photos }: PhotoViewerProps) {
             )}
 
             {/* Date */}
-            {currentPhoto.exif?.data_time && (
-              <p className="text-sm text-muted-foreground">{currentPhoto.exif.data_time}</p>
+            {currentPhoto.exif?.dateTime && (
+              <p className="text-sm text-muted-foreground">{currentPhoto.exif.dateTime}</p>
             )}
 
             {/* Description */}

--- a/hono/images.ts
+++ b/hono/images.ts
@@ -36,8 +36,8 @@ app.post('/', async (c) => {
   }
 
   try {
-    if (body?.exif?.data_time && !dayjs(body?.exif?.data_time, 'YYYY:MM:DD HH:mm:ss', true).isValid()) {
-      body.exif.data_time = ''
+    if (body?.exif?.dateTime && !dayjs(body?.exif?.dateTime, 'YYYY:MM:DD HH:mm:ss', true).isValid()) {
+      body.exif.dateTime = ''
     }
     await insertImage(body)
     return okEmpty(c)

--- a/lib/utils/file.ts
+++ b/lib/utils/file.ts
@@ -14,7 +14,7 @@ export async function exifReader(file: ArrayBuffer | SharedArrayBuffer | Buffer)
     make: '',
     model: '',
     bits: '',
-    data_time: '',
+    dateTime: '',
     exposure_time: '',
     f_number: '',
     exposure_program: '',
@@ -30,7 +30,7 @@ export async function exifReader(file: ArrayBuffer | SharedArrayBuffer | Buffer)
   exifObj.make = tags?.Make?.description
   exifObj.model = tags?.Model?.description
   exifObj.bits = tags?.['Bits Per Sample']?.description
-  exifObj.data_time = tags?.DateTimeOriginal?.description !== '' ? tags?.DateTimeOriginal?.description : tags?.DateTime?.description
+  exifObj.dateTime = tags?.DateTimeOriginal?.description !== '' ? tags?.DateTimeOriginal?.description : tags?.DateTime?.description
   exifObj.exposure_time = tags?.ExposureTime?.description
   exifObj.f_number = tags?.FNumber?.description
   exifObj.exposure_program = tags?.ExposureProgram?.description

--- a/prisma/migrations/20260519102435_rename_exif_data_time_to_date_time/migration.sql
+++ b/prisma/migrations/20260519102435_rename_exif_data_time_to_date_time/migration.sql
@@ -1,0 +1,9 @@
+-- Rename the JSONB key `data_time` to `dateTime` inside the `images.exif`
+-- column to match the camelCase `ExifType.dateTime` field used by the API
+-- and frontend. The column type stays JSONB; we only rename a key inside it.
+--
+-- Idempotent: only rows that still have the old key are touched, so running
+-- this migration multiple times is safe.
+UPDATE "images"
+SET "exif" = ("exif" - 'data_time') || jsonb_build_object('dateTime', "exif"->>'data_time')
+WHERE "exif" ? 'data_time';

--- a/server/db/query/images.ts
+++ b/server/db/query/images.ts
@@ -11,9 +11,9 @@ import { buildExifFilters, buildPagination, buildShowFilter, calcPageTotal } fro
 const ALBUM_IMAGE_SORTING_ORDER = [
   null,
   'image.created_at DESC, image.updated_at DESC',
-  'COALESCE(TO_TIMESTAMP(image.exif->>\'data_time\', \'YYYY:MM:DD HH24:MI:SS\'), \'1970-01-01 00:00:00\') DESC, image.created_at DESC, image.updated_at DESC',
+  'COALESCE(TO_TIMESTAMP(image.exif->>\'dateTime\', \'YYYY:MM:DD HH24:MI:SS\'), \'1970-01-01 00:00:00\') DESC, image.created_at DESC, image.updated_at DESC',
   'image.created_at ASC, image.updated_at ASC',
-  'COALESCE(TO_TIMESTAMP(image.exif->>\'data_time\', \'YYYY:MM:DD HH24:MI:SS\'), \'1970-01-01 00:00:00\') ASC, image.created_at ASC, image.updated_at ASC',
+  'COALESCE(TO_TIMESTAMP(image.exif->>\'dateTime\', \'YYYY:MM:DD HH24:MI:SS\'), \'1970-01-01 00:00:00\') ASC, image.created_at ASC, image.updated_at ASC',
 ]
 
 const DEFAULT_SIZE = 24

--- a/server/tasks/metadata-refresh.ts
+++ b/server/tasks/metadata-refresh.ts
@@ -26,7 +26,7 @@ const EMPTY_EXIF: ExifType = {
   make: '',
   model: '',
   bits: '',
-  data_time: '',
+  dateTime: '',
   exposure_time: '',
   f_number: '',
   exposure_program: '',
@@ -151,7 +151,7 @@ function normalizeExif(input: Partial<ExifType> | null | undefined): ExifType | 
     make: cleanString(input?.make),
     model: cleanString(input?.model),
     bits: cleanString(input?.bits),
-    data_time: cleanString(input?.data_time),
+    dateTime: cleanString(input?.dateTime),
     exposure_time: cleanString(input?.exposure_time),
     f_number: cleanString(input?.f_number),
     exposure_program: cleanString(input?.exposure_program),
@@ -165,8 +165,8 @@ function normalizeExif(input: Partial<ExifType> | null | undefined): ExifType | 
     white_balance: cleanString(input?.white_balance),
   }
 
-  if (exif.data_time && !dayjs(exif.data_time, 'YYYY:MM:DD HH:mm:ss', true).isValid()) {
-    exif.data_time = ''
+  if (exif.dateTime && !dayjs(exif.dateTime, 'YYYY:MM:DD HH:mm:ss', true).isValid()) {
+    exif.dateTime = ''
   }
 
   return Object.values(exif).some(Boolean) ? exif : null
@@ -329,7 +329,7 @@ function buildNormalizedExifFromTags(tags: ExifTags | null) {
     make: tags.Make?.description,
     model: tags.Model?.description,
     bits: tags['Bits Per Sample']?.description,
-    data_time: tags.DateTimeOriginal?.description || tags.DateTime?.description,
+    dateTime: tags.DateTimeOriginal?.description || tags.DateTime?.description,
     exposure_time: tags.ExposureTime?.description,
     f_number: tags.FNumber?.description,
     exposure_program: tags.ExposureProgram?.description,

--- a/types/index.ts
+++ b/types/index.ts
@@ -20,7 +20,7 @@ export type ExifType = {
   make: string | undefined;
   model: string | undefined;
   bits: string | undefined;
-  data_time: string | undefined;
+  dateTime: string | undefined;
   exposure_time: string | undefined;
   f_number: string | undefined;
   exposure_program: string | undefined;


### PR DESCRIPTION
## Summary

Implements **PR-08** from `docs/plans/2026-05-19-api-refactor-design.md` — the smallest snake_case rename in the API refactor plan.

`ExifType.data_time` is renamed to `ExifType.dateTime` end-to-end so the type matches the camelCase API convention documented in `CLAUDE.md`. The Prisma column stays JSONB; we only change the key name inside the JSON payload, both in code and on existing rows via a one-shot migration.

Scope is deliberately limited to this single field. Other snake_case fields on `Album` / `Image` (`album_value`, `image_name`, `image_sorting`, `show_on_mainpage`) plus the other `ExifType` snake_case fields are left for PR-09 / future work.

## Files changed

- `types/index.ts` — `ExifType.data_time` → `dateTime`.
- `lib/utils/file.ts` — `exifReader()` writes `exifObj.dateTime`.
- `hono/images.ts` — POST `/images` validation reads/writes `body.exif.dateTime`.
- `server/db/query/images.ts` — raw SQL `image.exif->>'data_time'` → `image.exif->>'dateTime'` in `ALBUM_IMAGE_SORTING_ORDER`.
- `server/tasks/metadata-refresh.ts` — `EMPTY_EXIF`, `normalizeExif`, and `buildNormalizedExifFromTags` all use `dateTime`.
- `components/album/preview-image-exif.tsx` — reads `exif?.dateTime`.
- `components/album/preview-image.tsx` — reads `exif?.dateTime`.
- `components/admin/album/exif-view.tsx` — reads `exif?.dateTime`.
- `components/viewer/photo-viewer.tsx` — reads `exif?.dateTime`.
- `prisma/migrations/20260519102435_rename_exif_data_time_to_date_time/migration.sql` — see below.

The 3 upload components (`simple-file-upload.tsx`, `livephoto-file-upload.tsx`, `multiple-file-upload.tsx`) consume the `exifObj` returned from `exifReader()` as an opaque object, so they pick up the rename automatically — verified by grep.

## Prisma migration (included)

`prisma/migrations/20260519102435_rename_exif_data_time_to_date_time/migration.sql`:

```sql
UPDATE "images"
SET "exif" = ("exif" - 'data_time') || jsonb_build_object('dateTime', "exif"->>'data_time')
WHERE "exif" ? 'data_time';
```

- **Safe to re-run:** the `WHERE "exif" ? 'data_time'` predicate makes it idempotent.
- **No schema change:** the `exif` column stays JSONB; only the inner key is renamed in place on existing rows.
- **Manual verification recommended** on a staging DB before deploying: confirm a sampled row's `exif->>'dateTime'` value matches what was previously at `exif->>'data_time'` and the old key is gone.

## Verification

- `pnpm run lint` — 0 errors (warnings are all pre-existing, none in the files touched).
- `pnpm exec tsc --noEmit` — 64 errors, matches baseline at HEAD (pre-existing).
- `pnpm run build` — succeeds.
- `grep -rn "data_time" --include="*.ts" --include="*.tsx" .` — 0 matches outside the migration SQL.

## Test plan

- [ ] Apply the migration on a staging DB that has existing rows with `data_time` keys, confirm `exif->>'dateTime'` now holds the same value and `exif ? 'data_time'` returns false.
- [ ] Re-upload an image with EXIF capture time; confirm it is persisted under the new key in `images.exif` and displays correctly in the album preview (`PreviewImageExif`) and the admin EXIF view.
- [ ] Sort an album by capture-time (descending and ascending); confirm ordering matches the EXIF dates of the test images (validates the SQL change in `server/db/query/images.ts`).
- [ ] Refresh metadata for an existing image via the admin task; confirm the refreshed payload still carries the date under `dateTime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)