### PR TITLE
refactor(api): configs/daily/settings switch to camelCase objects

### DIFF
--- a/app/(default)/layout.tsx
+++ b/app/(default)/layout.tsx
@@ -1,5 +1,6 @@
 import { fetchAlbumsShow } from '~/server/db/query/albums'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import { toCustomInfo } from '~/server/lib/config-transform'
 import type { AlbumType } from '~/types'
 import type { AlbumDataProps } from '~/types/props'
 import TopNav from '~/components/layout/top-nav'
@@ -17,8 +18,8 @@ export default async function DefaultLayout({
 
   const getTitle = async () => {
     'use server'
-    const configs = await fetchConfigsByKeys(['custom_title'])
-    return configs?.find((item) => item.config_key === 'custom_title')?.config_value || 'PicImpact'
+    const rows = await fetchConfigsByKeys(['custom_title'])
+    return toCustomInfo(rows).customTitle || 'PicImpact'
   }
 
   const data: AlbumType[] = await getData()

--- a/app/(default)/page.tsx
+++ b/app/(default)/page.tsx
@@ -2,8 +2,8 @@ import type { ImageHandleProps } from '~/types/props'
 import { getImagesData, getImagesPageTotal, getDisplayConfig, initDailyIfNeeded } from '~/server/actions/images'
 import SimpleGallery from '~/components/layout/theme/simple/simple-gallery.tsx'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import { toCustomInfo } from '~/server/lib/config-transform'
 import DefaultGallery from '~/components/layout/theme/default/default-gallery.tsx'
-import type { Config } from '~/types'
 import PolaroidGallery from '~/components/layout/theme/polaroid/polaroid-gallery.tsx'
 
 export default async function Home() {
@@ -11,13 +11,11 @@ export default async function Home() {
 
   const getStyleConfig = async () => {
     'use server'
-    return await fetchConfigsByKeys([
-      'custom_index_style',
-    ])
+    const rows = await fetchConfigsByKeys(['custom_index_style'])
+    return toCustomInfo(rows).customIndexStyle
   }
 
-  const style: Config[] = await getStyleConfig()
-  const currentStyle = style.find(a => a.config_key === 'custom_index_style')?.config_value
+  const currentStyle = await getStyleConfig()
 
   const props: ImageHandleProps = {
     handle: getImagesData,

--- a/app/(default)/preview/[...id]/page.tsx
+++ b/app/(default)/preview/[...id]/page.tsx
@@ -2,6 +2,7 @@ import { fetchImageByIdAndAuth } from '~/server/db/query/images'
 import type { PreviewImageHandleProps } from '~/types/props'
 import PreviewImage from '~/components/album/preview-image'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import type { GalleryDisplayConfig } from '~/types'
 import type { Metadata } from 'next/types'
 
 export async function generateMetadata({ params }: { params: any }): Promise<Metadata> {
@@ -49,11 +50,14 @@ export default async function PreView({params}: { params: any }) {
     return await fetchImageByIdAndAuth(String(id))
   }
 
-  const getConfig = async () => {
+  const getConfig = async (): Promise<GalleryDisplayConfig> => {
     'use server'
-    return await fetchConfigsByKeys([
-      'custom_index_download_enable'
-    ])
+    const rows = await fetchConfigsByKeys(['custom_index_download_enable'])
+    const value = rows.find((item) => item.config_key === 'custom_index_download_enable')?.config_value
+    return {
+      customIndexDownloadEnable: value === 'true',
+      customIndexOriginEnable: false,
+    }
   }
 
   const imageData = await getData(id)

--- a/app/(theme)/[...album]/layout.tsx
+++ b/app/(theme)/[...album]/layout.tsx
@@ -1,5 +1,6 @@
 import { fetchAlbumsShow } from '~/server/db/query/albums'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import { toCustomInfo } from '~/server/lib/config-transform'
 import type { AlbumType } from '~/types'
 import type { AlbumDataProps } from '~/types/props'
 import TopNav from '~/components/layout/top-nav'
@@ -18,8 +19,8 @@ export default async function ThemeAlbumLayout({
 
   const getTitle = async () => {
     'use server'
-    const configs = await fetchConfigsByKeys(['custom_title'])
-    return configs?.find((item) => item.config_key === 'custom_title')?.config_value || 'PicImpact'
+    const rows = await fetchConfigsByKeys(['custom_title'])
+    return toCustomInfo(rows).customTitle || 'PicImpact'
   }
 
   const dataList: AlbumType[] = await getData()

--- a/app/(theme)/map/layout.tsx
+++ b/app/(theme)/map/layout.tsx
@@ -1,5 +1,6 @@
 import { fetchAlbumsShow } from '~/server/db/query/albums'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import { toCustomInfo } from '~/server/lib/config-transform'
 import type { AlbumType } from '~/types'
 import type { AlbumDataProps } from '~/types/props'
 import TopNav from '~/components/layout/top-nav'
@@ -16,8 +17,8 @@ export default async function MapLayout({
 
   const getTitle = async () => {
     'use server'
-    const configs = await fetchConfigsByKeys(['custom_title'])
-    return configs?.find((item) => item.config_key === 'custom_title')?.config_value || 'PicImpact'
+    const rows = await fetchConfigsByKeys(['custom_title'])
+    return toCustomInfo(rows).customTitle || 'PicImpact'
   }
 
   const data: AlbumType[] = await getData()

--- a/app/(theme)/map/page.tsx
+++ b/app/(theme)/map/page.tsx
@@ -1,12 +1,13 @@
 import { fetchMapImages } from '~/server/db/query/images'
 import { MapView } from '~/components/layout/theme/map/map-view'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import { toCustomInfo } from '~/server/lib/config-transform'
 
 export const dynamic = 'force-dynamic'
 
 export async function generateMetadata() {
-  const data = await fetchConfigsByKeys(['custom_title'])
-  const siteTitle = data?.find(item => item.config_key === 'custom_title')?.config_value || 'PicImpact'
+  const rows = await fetchConfigsByKeys(['custom_title'])
+  const siteTitle = toCustomInfo(rows).customTitle || 'PicImpact'
   return {
     title: `Map | ${siteTitle}`,
   }

--- a/app/admin/settings/daily/page.tsx
+++ b/app/admin/settings/daily/page.tsx
@@ -20,6 +20,7 @@ import {
   TableHeader,
   TableRow,
 } from '~/components/ui/table'
+import type { DailyConfig } from '~/types'
 
 export default function DailySettings() {
   const [dailyEnabled, setDailyEnabled] = useState(false)
@@ -30,14 +31,14 @@ export default function DailySettings() {
   const [albumWeights, setAlbumWeights] = useState<Array<{ id: string, name: string, album_value: string, daily_weight: number, photo_count: number }>>([])
   const t = useTranslations()
 
-  const { data: configData, isValidating: configValidating, isLoading: configLoading, mutate: mutateConfig } = useSWR('/api/v1/daily/config', fetcher)
+  const { data: configData, isValidating: configValidating, isLoading: configLoading, mutate: mutateConfig } = useSWR<DailyConfig>('/api/v1/daily/config', fetcher)
   const { data: albumsData, isValidating: albumsValidating, isLoading: albumsLoading } = useSWR('/api/v1/daily/albums', fetcher)
 
   useEffect(() => {
     if (configData) {
-      setDailyEnabled(configData.find((item: { config_key: string, config_value: string }) => item.config_key === 'daily_enabled')?.config_value === 'true')
-      setRefreshInterval(configData.find((item: { config_key: string, config_value: string }) => item.config_key === 'daily_refresh_interval')?.config_value || '24')
-      setTotalCount(configData.find((item: { config_key: string, config_value: string }) => item.config_key === 'daily_total_count')?.config_value || '30')
+      setDailyEnabled(configData.dailyEnabled === true)
+      setRefreshInterval(configData.dailyRefreshInterval ?? '24')
+      setTotalCount((configData.dailyTotalCount ?? 30).toString())
     }
   }, [configData])
 
@@ -47,7 +48,7 @@ export default function DailySettings() {
     }
   }, [albumsData])
 
-  const lastRefresh = configData?.find((item: { config_key: string, config_value: string }) => item.config_key === 'daily_last_refresh')?.config_value
+  const lastRefresh = configData?.dailyLastRefresh
   const lastRefreshDate = lastRefresh ? new Date(lastRefresh) : null
   const intervalHours = parseInt(refreshInterval, 10)
   const nextRefreshDate = lastRefreshDate ? new Date(lastRefreshDate.getTime() + intervalHours * 60 * 60 * 1000) : null

--- a/app/admin/settings/preferences/page.tsx
+++ b/app/admin/settings/preferences/page.tsx
@@ -13,6 +13,7 @@ import { Input } from '~/components/ui/input'
 import { Label } from '~/components/ui/label'
 import { CopyIcon } from '~/components/icons/copy'
 import { normalizeDefaultTheme } from '~/lib/utils/theme'
+import type { CustomInfo } from '~/types'
 
 export default function Preferences() {
   const [title, setTitle] = useState('')
@@ -34,7 +35,7 @@ export default function Preferences() {
   const [defaultTheme, setDefaultTheme] = useState<'light' | 'dark' | 'system'>('light')
   const t = useTranslations()
 
-  const { data, isValidating, isLoading } = useSWR<{ config_key: string, config_value: string }[]>('/api/v1/settings/custom-info', fetcher)
+  const { data, isValidating, isLoading } = useSWR<CustomInfo>('/api/v1/settings/custom-info', fetcher)
 
   async function updateInfo() {
     const maxWidth = parseInt(previewImageMaxWidth)
@@ -57,6 +58,24 @@ export default function Preferences() {
       toast.error(t('Preferences.inputAdminImagesPerPage'))
       return
     }
+    const payload: CustomInfo = {
+      customTitle: title,
+      customFaviconUrl,
+      customAuthor,
+      rssFeedId: feedId,
+      rssUserId: userId,
+      customIndexStyle,
+      customIndexDownloadEnable,
+      previewMaxWidthLimitSwitch: enablePreviewImageMaxWidthLimit,
+      previewMaxWidthLimit: maxWidth,
+      previewQuality,
+      umamiHost,
+      umamiAnalytics,
+      maxUploadFiles: maxFiles,
+      customIndexOriginEnable,
+      adminImagesPerPage: imagesPerPage,
+      defaultTheme,
+    }
     try {
       setLoading(true)
       await fetch('/api/v1/settings/custom-info', {
@@ -64,24 +83,7 @@ export default function Preferences() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          title: title,
-          customFaviconUrl: customFaviconUrl,
-          customAuthor: customAuthor,
-          feedId: feedId,
-          userId: userId,
-          customIndexStyle: customIndexStyle,
-          customIndexDownloadEnable: customIndexDownloadEnable,
-          enablePreviewImageMaxWidthLimit,
-          previewImageMaxWidth: maxWidth,
-          previewQuality,
-          umamiHost,
-          umamiAnalytics,
-          maxUploadFiles: maxFiles,
-          customIndexOriginEnable,
-          adminImagesPerPage: imagesPerPage,
-          defaultTheme,
-        }),
+        body: JSON.stringify(payload),
       }).then(res => res.json())
       toast.success('修改成功！')
     } catch (e) {
@@ -92,22 +94,23 @@ export default function Preferences() {
   }
 
   useEffect(() => {
-    setTitle(data?.find((item) => item.config_key === 'custom_title')?.config_value || '')
-    setCustomFaviconUrl(data?.find((item) => item.config_key === 'custom_favicon_url')?.config_value || '')
-    setCustomAuthor(data?.find((item) => item.config_key === 'custom_author')?.config_value || '')
-    setFeedId(data?.find((item) => item.config_key === 'rss_feed_id')?.config_value || '')
-    setUserId(data?.find((item) => item.config_key === 'rss_user_id')?.config_value || '')
-    setCustomIndexStyle(data?.find((item) => item.config_key === 'custom_index_style')?.config_value || '0')
-    setCustomIndexDownloadEnable(data?.find((item) => item.config_key === 'custom_index_download_enable')?.config_value.toString() === 'true' || false)
-    setPreviewImageMaxWidth(data?.find((item) => item.config_key === 'preview_max_width_limit')?.config_value?.toString() || '0')
-    setPreviewImageMaxWidthLimitEnabled(data?.find((item) => item.config_key === 'preview_max_width_limit_switch')?.config_value === '1')
-    setPreviewQualityInput(data?.find((item) => item.config_key === 'preview_quality')?.config_value || '0.2')
-    setUmamiHost(data?.find((item) => item.config_key === 'umami_host')?.config_value || '')
-    setUmamiAnalytics(data?.find((item) => item.config_key === 'umami_analytics')?.config_value || '')
-    setMaxUploadFiles(data?.find((item) => item.config_key === 'max_upload_files')?.config_value || '5')
-    setCustomIndexOriginEnable(data?.find((item) => item.config_key === 'custom_index_origin_enable')?.config_value.toString() === 'true' || false)
-    setAdminImagesPerPage(data?.find((item) => item.config_key === 'admin_images_per_page')?.config_value || '8')
-    setDefaultTheme(normalizeDefaultTheme(data?.find((item) => item.config_key === 'default_theme')?.config_value))
+    if (!data) return
+    setTitle(data.customTitle ?? '')
+    setCustomFaviconUrl(data.customFaviconUrl ?? '')
+    setCustomAuthor(data.customAuthor ?? '')
+    setFeedId(data.rssFeedId ?? '')
+    setUserId(data.rssUserId ?? '')
+    setCustomIndexStyle(data.customIndexStyle ?? '0')
+    setCustomIndexDownloadEnable(data.customIndexDownloadEnable === true)
+    setPreviewImageMaxWidth((data.previewMaxWidthLimit ?? 0).toString())
+    setPreviewImageMaxWidthLimitEnabled(data.previewMaxWidthLimitSwitch === true)
+    setPreviewQualityInput((data.previewQuality ?? 0.2).toString())
+    setUmamiHost(data.umamiHost ?? '')
+    setUmamiAnalytics(data.umamiAnalytics ?? '')
+    setMaxUploadFiles((data.maxUploadFiles ?? 5).toString())
+    setCustomIndexOriginEnable(data.customIndexOriginEnable === true)
+    setAdminImagesPerPage((data.adminImagesPerPage ?? 8).toString())
+    setDefaultTheme(normalizeDefaultTheme(data.defaultTheme))
   }, [data])
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,12 +8,12 @@ import { ButtonStoreProvider } from '~/app/providers/button-store-providers'
 
 import '~/style/globals.css'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import { toCustomInfo } from '~/server/lib/config-transform'
 
 import { NextIntlClientProvider } from 'next-intl'
 import { getLocale, getMessages } from 'next-intl/server'
 import { ConfigStoreProvider } from '~/app/providers/config-store-providers'
 import Script from 'next/script'
-import { normalizeDefaultTheme } from '~/lib/utils/theme'
 
 const sourceSerif4 = Source_Serif_4({
   subsets: ['latin'],
@@ -29,22 +29,16 @@ const sourceSans3 = Source_Sans_3({
   weight: ['400', '500', '600'],
 })
 
-type ConfigItem = {
-  id: string;
-  config_key: string;
-  config_value: string | null;
-  detail: string | null;
-}
-
 export async function generateMetadata(): Promise<Metadata> {
-  const data = await fetchConfigsByKeys([
+  const rows = await fetchConfigsByKeys([
     'custom_title',
     'custom_favicon_url',
     'custom_author',
   ])
+  const info = toCustomInfo(rows)
 
-  const title = data?.find((item: ConfigItem) => item.config_key === 'custom_title')?.config_value || 'PicImpact'
-  const author = data?.find((item: ConfigItem) => item.config_key === 'custom_author')?.config_value || ''
+  const title = info.customTitle || 'PicImpact'
+  const author = info.customAuthor
   const description = author
     ? `${author}'s photography portfolio — powered by PicImpact`
     : 'A photography portfolio powered by PicImpact'
@@ -53,7 +47,7 @@ export async function generateMetadata(): Promise<Metadata> {
     metadataBase: process.env.BETTER_AUTH_URL ? new URL(process.env.BETTER_AUTH_URL) : null,
     title,
     description,
-    icons: { icon: data?.find((item: ConfigItem) => item.config_key === 'custom_favicon_url')?.config_value || './favicon.ico' },
+    icons: { icon: info.customFaviconUrl || './favicon.ico' },
     manifest: '/manifest.json',
     openGraph: {
       title,
@@ -93,15 +87,19 @@ export default async function RootLayout({
 
   const messages = await getMessages()
 
-  const data = await fetchConfigsByKeys([
+  const rows = await fetchConfigsByKeys([
     'default_theme',
     'umami_analytics',
     'umami_host'
   ])
+  const info = toCustomInfo(rows)
 
-  const defaultTheme = normalizeDefaultTheme(data?.find((item: ConfigItem) => item.config_key === 'default_theme')?.config_value)
-  const umamiHost = data?.find((item: ConfigItem) => item.config_key === 'umami_host')?.config_value || 'https://cloud.umami.is/script.js'
-  const umamiAnalytics = data?.find((item: ConfigItem) => item.config_key === 'umami_analytics')?.config_value
+  // `toCustomInfo` runs `default_theme` through `normalizeDefaultTheme`, so the
+  // value is already guaranteed to be one of 'light' | 'dark' | 'system'. Cast
+  // here because the public-facing `CustomInfo` type keeps the field as `string`.
+  const defaultTheme = info.defaultTheme as 'light' | 'dark' | 'system'
+  const umamiHost = info.umamiHost || 'https://cloud.umami.is/script.js'
+  const umamiAnalytics = info.umamiAnalytics
 
   return (
     <html className={`overflow-y-auto scrollbar-hide ${sourceSerif4.variable} ${sourceSans3.variable}`} lang={locale} suppressHydrationWarning>

--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -1,20 +1,22 @@
 import 'server-only'
 import RSS from 'rss'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import { toCustomInfo } from '~/server/lib/config-transform'
 import { getRSSImages } from '~/server/db/query/images'
 
 export async function GET(request: Request) {
-  const data = await fetchConfigsByKeys([
+  const rows = await fetchConfigsByKeys([
     'custom_title',
     'custom_author',
     'rss_feed_id',
     'rss_user_id'
   ])
+  const info = toCustomInfo(rows)
 
   const url = new URL(request.url)
 
-  const feedId = data?.find((item: any) => item.config_key === 'rss_feed_id')?.config_value?.toString()
-  const userId = data?.find((item: any) => item.config_key === 'rss_user_id')?.config_value?.toString()
+  const feedId = info.rssFeedId
+  const userId = info.rssUserId
 
   const customElements = feedId && userId
     ? [
@@ -28,13 +30,11 @@ export async function GET(request: Request) {
     : []
 
   const feed = new RSS({
-    title: data?.find((item: any) => item.config_key === 'custom_title')?.config_value?.toString() || '相册',
+    title: info.customTitle || '相册',
     generator: 'RSS for Next.js',
     feed_url: `${url.origin}/rss.xml`,
     site_url: url.origin,
-    copyright: `© 2024${new Date().getFullYear().toString() === '2024' ? '' : `-${new Date().getFullYear().toString()}`} ${
-      data?.find((item: any) => item.config_key === 'custom_author')?.config_value?.toString() || ''
-    }.`,
+    copyright: `© 2024${new Date().getFullYear().toString() === '2024' ? '' : `-${new Date().getFullYear().toString()}`} ${info.customAuthor}.`,
     pubDate: new Date().toUTCString(),
     ttl: 60,
     custom_elements: customElements,

--- a/components/admin/list/list-props.tsx
+++ b/components/admin/list/list-props.tsx
@@ -73,7 +73,7 @@ export default function ListProps(props : Readonly<ImageServerHandleProps>) {
     (state) => state,
   )
   const { data: albums, isLoading: albumsLoading } = useSWR('/api/v1/albums', fetcher)
-  const { data: adminConfig } = useSWR('/api/v1/settings/admin-config', fetcher)
+  const { data: adminConfig } = useSWR<import('~/types').AdminConfig>('/api/v1/settings/admin-config', fetcher)
   const t = useTranslations()
 
   const dataProps: ImageListDataProps = {
@@ -100,12 +100,8 @@ export default function ListProps(props : Readonly<ImageServerHandleProps>) {
   }, [])
 
   useEffect(() => {
-    if (adminConfig && adminConfig.length > 0) {
-      const pageSizeConfig = adminConfig.find((config: any) => config.config_key === 'admin_images_per_page')
-      if (pageSizeConfig) {
-        const newPageSize = parseInt(pageSizeConfig.config_value, 10) || 8
-        setPageSize(newPageSize)
-      }
+    if (adminConfig && typeof adminConfig.adminImagesPerPage === 'number' && adminConfig.adminImagesPerPage > 0) {
+      setPageSize(adminConfig.adminImagesPerPage)
     }
   }, [adminConfig])
 

--- a/components/admin/settings/storages/open-list-edit-sheet.tsx
+++ b/components/admin/settings/storages/open-list-edit-sheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Config } from '~/types'
+import type { OpenListInfo } from '~/types'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '~/components/ui/sheet'
 import { useButtonStore } from '~/app/providers/button-store-providers'
 import React, { useState } from 'react'
@@ -9,6 +9,11 @@ import { useSWRConfig } from 'swr'
 import { ReloadIcon } from '@radix-ui/react-icons'
 import { Button } from '~/components/ui/button'
 import { useTranslations } from 'next-intl'
+
+const FIELDS: Array<{ key: keyof OpenListInfo; dbKey: string }> = [
+  { key: 'openListUrl', dbKey: 'open_list_url' },
+  { key: 'openListToken', dbKey: 'open_list_token' },
+]
 
 export default function OpenListEditSheet() {
   const [loading, setLoading] = useState(false)
@@ -19,6 +24,7 @@ export default function OpenListEditSheet() {
   const t = useTranslations()
 
   async function submit() {
+    if (!openListData) return
     setLoading(true)
     try {
       await fetch('/api/v1/settings/open-list-info', {
@@ -31,12 +37,17 @@ export default function OpenListEditSheet() {
       toast.success(t('Config.updateSuccess'))
       mutate('/api/v1/storage/open-list/info')
       setOpenListEdit(false)
-      setOpenListEditData([] as Config[])
+      setOpenListEditData(null)
     } catch (e) {
       toast.error(t('Config.updateFailed'))
     } finally {
       setLoading(false)
     }
+  }
+
+  function updateField<K extends keyof OpenListInfo>(key: K, value: OpenListInfo[K]) {
+    if (!openListData) return
+    setOpenListEditData({ ...openListData, [key]: value })
   }
 
   return (
@@ -46,7 +57,7 @@ export default function OpenListEditSheet() {
       onOpenChange={(open: boolean) => {
         if (!open) {
           setOpenListEdit(false)
-          setOpenListEditData([] as Config[])
+          setOpenListEditData(null)
         }
       }}
       modal={false}
@@ -56,33 +67,24 @@ export default function OpenListEditSheet() {
           <SheetTitle>{t('Config.editOpenList')}</SheetTitle>
         </SheetHeader>
         <div className="flex flex-col space-y-2">
-          {
-            openListData?.map((config: Config) => (
-              <label
-                htmlFor="text"
-                key={config.id}
-                className="block overflow-hidden rounded-md border border-input px-3 py-2 shadow-sm focus-within:border-primary focus-within:ring-1 focus-within:ring-primary"
-              >
-                <span className="text-xs font-medium text-gray-700"> {config.config_key} </span>
+          {openListData && FIELDS.map((field) => (
+            <label
+              htmlFor={field.key as string}
+              key={field.key as string}
+              className="block overflow-hidden rounded-md border border-input px-3 py-2 shadow-sm focus-within:border-primary focus-within:ring-1 focus-within:ring-primary"
+            >
+              <span className="text-xs font-medium text-gray-700"> {field.dbKey} </span>
 
-                <input
-                  type="text"
-                  id="name"
-                  value={config.config_value || ''}
-                  placeholder={t('Config.' + config.config_key)}
-                  onChange={(e) => setOpenListEditData(
-                    openListData?.map((c: Config) => {
-                      if (c.config_key === config.config_key) {
-                        c.config_value = e.target.value
-                      }
-                      return c
-                    })
-                  )}
-                  className="mt-1 w-full border-none p-0 focus:border-transparent focus:outline-none focus:ring-0 sm:text-sm"
-                />
-              </label>
-            ))
-          }
+              <input
+                type="text"
+                id={field.key as string}
+                value={(openListData[field.key] as string) || ''}
+                placeholder={t('Config.' + field.dbKey)}
+                onChange={(e) => updateField(field.key, e.target.value as OpenListInfo[typeof field.key])}
+                className="mt-1 w-full border-none p-0 focus:border-transparent focus:outline-none focus:ring-0 sm:text-sm"
+              />
+            </label>
+          ))}
         </div>
         <Button className="cursor-pointer my-2" onClick={() => submit()} disabled={loading}>
           {loading && <ReloadIcon className="mr-2 h-4 w-4 animate-spin"/>}

--- a/components/admin/settings/storages/open-list-tabs.tsx
+++ b/components/admin/settings/storages/open-list-tabs.tsx
@@ -17,9 +17,10 @@ import { ReloadIcon } from '@radix-ui/react-icons'
 import OpenListEditSheet from '~/components/admin/settings/storages/open-list-edit-sheet.tsx'
 import { useTranslations } from 'next-intl'
 import TabsTableCell from '~/components/admin/settings/storages/tabs-table-cell'
+import type { OpenListInfo } from '~/types'
 
 export default function OpenListTabs() {
-  const { data, error, isValidating, mutate } = useSWR('/api/v1/storage/open-list/info', fetcher
+  const { data, error, isValidating, mutate } = useSWR<OpenListInfo>('/api/v1/storage/open-list/info', fetcher
     , { revalidateOnFocus: false })
   const { setOpenListEdit, setOpenListEditData } = useButtonStore(
     (state) => state,
@@ -79,7 +80,7 @@ export default function OpenListTabs() {
           </Table>
         </Card>
       }
-      {Array.isArray(data) && data.length > 0 && <OpenListEditSheet />}
+      {data && <OpenListEditSheet />}
     </div>
   )
 }

--- a/components/admin/settings/storages/r2-edit-sheet.tsx
+++ b/components/admin/settings/storages/r2-edit-sheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Config } from '~/types'
+import type { R2Info } from '~/types'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '~/components/ui/sheet'
 import { useButtonStore } from '~/app/providers/button-store-providers'
 import React, { useState } from 'react'
@@ -11,6 +11,20 @@ import { Button } from '~/components/ui/button'
 import { useTranslations } from 'next-intl'
 import { Switch } from '~/components/ui/switch'
 
+type R2Field =
+  | { key: keyof R2Info; type: 'string' }
+  | { key: keyof R2Info; type: 'boolean' }
+
+const FIELDS: Array<R2Field & { dbKey: string }> = [
+  { key: 'r2AccesskeyId', type: 'string', dbKey: 'r2_accesskey_id' },
+  { key: 'r2AccesskeySecret', type: 'string', dbKey: 'r2_accesskey_secret' },
+  { key: 'r2AccountId', type: 'string', dbKey: 'r2_account_id' },
+  { key: 'r2Bucket', type: 'string', dbKey: 'r2_bucket' },
+  { key: 'r2StorageFolder', type: 'string', dbKey: 'r2_storage_folder' },
+  { key: 'r2PublicDomain', type: 'string', dbKey: 'r2_public_domain' },
+  { key: 'r2DirectDownload', type: 'boolean', dbKey: 'r2_direct_download' },
+]
+
 export default function R2EditSheet() {
   const [loading, setLoading] = useState(false)
   const { mutate } = useSWRConfig()
@@ -20,6 +34,7 @@ export default function R2EditSheet() {
   const t = useTranslations()
 
   async function submit() {
+    if (!r2Data) return
     setLoading(true)
     try {
       await fetch('/api/v1/settings/r2-info', {
@@ -32,12 +47,17 @@ export default function R2EditSheet() {
       toast.success(t('Config.updateSuccess'))
       mutate('/api/v1/settings/r2-info')
       setR2Edit(false)
-      setR2EditData([] as Config[])
+      setR2EditData(null)
     } catch (e) {
       toast.error(t('Config.updateFailed'))
     } finally {
       setLoading(false)
     }
+  }
+
+  function updateField<K extends keyof R2Info>(key: K, value: R2Info[K]) {
+    if (!r2Data) return
+    setR2EditData({ ...r2Data, [key]: value })
   }
 
   return (
@@ -47,7 +67,7 @@ export default function R2EditSheet() {
       onOpenChange={(open: boolean) => {
         if (!open) {
           setR2Edit(false)
-          setR2EditData([] as Config[])
+          setR2EditData(null)
         }
       }}
       modal={false}
@@ -57,57 +77,42 @@ export default function R2EditSheet() {
           <SheetTitle>{t('Config.editR2')}</SheetTitle>
         </SheetHeader>
         <div className="flex flex-col space-y-2">
-          {
-            r2Data?.map((config: Config) => (
-              config.config_key === 'r2_direct_download' ?
-                <div
-                  key={config.id}
-                  className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm"
-                >
-                  <div className="flex flex-col gap-1">
-                    <div className="text-tiny text-default-400">
-                      {t('Config.' + config.config_key)}
-                    </div>
+          {r2Data && FIELDS.map((field) => (
+            field.type === 'boolean' ? (
+              <div
+                key={field.key as string}
+                className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm"
+              >
+                <div className="flex flex-col gap-1">
+                  <div className="text-tiny text-default-400">
+                    {t('Config.' + field.dbKey)}
                   </div>
-                  <Switch
-                    className="cursor-pointer"
-                    checked={config.config_value === 'true'}
-                    onCheckedChange={(value) => setR2EditData(
-                      r2Data?.map((c: Config) => {
-                        if (c.config_key === config.config_key) {
-                          c.config_value = value ? 'true' : 'false'
-                        }
-                        return c
-                      })
-                    )}
-                  />
                 </div>
-              :
+                <Switch
+                  className="cursor-pointer"
+                  checked={Boolean(r2Data[field.key])}
+                  onCheckedChange={(value) => updateField(field.key, value as R2Info[typeof field.key])}
+                />
+              </div>
+            ) : (
               <label
-                htmlFor="text"
-                key={config.id}
+                htmlFor={field.key as string}
+                key={field.key as string}
                 className="block overflow-hidden rounded-md border border-input px-3 py-2 shadow-sm focus-within:border-primary focus-within:ring-1 focus-within:ring-primary"
               >
-                <span className="text-xs font-medium text-gray-700"> {config.config_key} </span>
+                <span className="text-xs font-medium text-gray-700"> {field.dbKey} </span>
 
                 <input
                   type="text"
-                  id="name"
-                  value={config.config_value || ''}
-                  placeholder={t('Config.' + config.config_key)}
-                  onChange={(e) => setR2EditData(
-                    r2Data?.map((c: Config) => {
-                      if (c.config_key === config.config_key) {
-                        c.config_value = e.target.value
-                      }
-                      return c
-                    })
-                  )}
+                  id={field.key as string}
+                  value={(r2Data[field.key] as string) || ''}
+                  placeholder={t('Config.' + field.dbKey)}
+                  onChange={(e) => updateField(field.key, e.target.value as R2Info[typeof field.key])}
                   className="mt-1 w-full border-none p-0 focus:border-transparent focus:outline-none focus:ring-0 sm:text-sm"
                 />
               </label>
-            ))
-          }
+            )
+          ))}
         </div>
         <Button className="cursor-pointer my-2" onClick={() => submit()} disabled={loading}>
           {loading && <ReloadIcon className="mr-2 h-4 w-4 animate-spin"/>}

--- a/components/admin/settings/storages/r2-tabs.tsx
+++ b/components/admin/settings/storages/r2-tabs.tsx
@@ -17,9 +17,10 @@ import { useButtonStore } from '~/app/providers/button-store-providers'
 import R2EditSheet from '~/components/admin/settings/storages/r2-edit-sheet'
 import { useTranslations } from 'next-intl'
 import TabsTableCell from '~/components/admin/settings/storages/tabs-table-cell'
+import type { R2Info } from '~/types'
 
 export default function R2Tabs() {
-  const { data, error, isValidating, mutate } = useSWR('/api/v1/settings/r2-info', fetcher
+  const { data, error, isValidating, mutate } = useSWR<R2Info>('/api/v1/settings/r2-info', fetcher
     , { revalidateOnFocus: false })
   const { setR2Edit, setR2EditData } = useButtonStore(
     (state) => state,
@@ -80,7 +81,7 @@ export default function R2Tabs() {
           </Table>
         </Card>
       }
-      {Array.isArray(data) && data.length > 0 && <R2EditSheet />}
+      {data && <R2EditSheet />}
     </div>
   )
 }

--- a/components/admin/settings/storages/s3-edit-sheet.tsx
+++ b/components/admin/settings/storages/s3-edit-sheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Config } from '~/types'
+import type { S3Info } from '~/types'
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '~/components/ui/sheet'
 import { useButtonStore } from '~/app/providers/button-store-providers'
 import React, { useState } from 'react'
@@ -11,6 +11,25 @@ import { Button } from '~/components/ui/button'
 import { useTranslations } from 'next-intl'
 import { Switch } from '~/components/ui/switch'
 
+type S3Field =
+  | { key: keyof S3Info; type: 'string' }
+  | { key: keyof S3Info; type: 'boolean' }
+
+// 字段顺序与展示与原有 Config 数组保持一致；后端键名通过 Config.<dbKey>
+// 的国际化条目复用。
+const FIELDS: Array<S3Field & { dbKey: string }> = [
+  { key: 'accesskeyId', type: 'string', dbKey: 'accesskey_id' },
+  { key: 'accesskeySecret', type: 'string', dbKey: 'accesskey_secret' },
+  { key: 'region', type: 'string', dbKey: 'region' },
+  { key: 'endpoint', type: 'string', dbKey: 'endpoint' },
+  { key: 'bucket', type: 'string', dbKey: 'bucket' },
+  { key: 'storageFolder', type: 'string', dbKey: 'storage_folder' },
+  { key: 'forcePathStyle', type: 'boolean', dbKey: 'force_path_style' },
+  { key: 's3Cdn', type: 'boolean', dbKey: 's3_cdn' },
+  { key: 's3CdnUrl', type: 'string', dbKey: 's3_cdn_url' },
+  { key: 's3DirectDownload', type: 'boolean', dbKey: 's3_direct_download' },
+]
+
 export default function S3EditSheet() {
   const [loading, setLoading] = useState(false)
   const { mutate } = useSWRConfig()
@@ -20,6 +39,7 @@ export default function S3EditSheet() {
   const t = useTranslations()
 
   async function submit() {
+    if (!s3Data) return
     setLoading(true)
     try {
       await fetch('/api/v1/settings/s3-info', {
@@ -32,12 +52,17 @@ export default function S3EditSheet() {
       toast.success(t('Config.updateSuccess'))
       mutate('/api/v1/settings/s3-info')
       setS3Edit(false)
-      setS3EditData([] as Config[])
+      setS3EditData(null)
     } catch (e) {
       toast.error(t('Config.updateFailed'))
     } finally {
       setLoading(false)
     }
+  }
+
+  function updateField<K extends keyof S3Info>(key: K, value: S3Info[K]) {
+    if (!s3Data) return
+    setS3EditData({ ...s3Data, [key]: value })
   }
 
   return (
@@ -47,7 +72,7 @@ export default function S3EditSheet() {
       onOpenChange={(open: boolean) => {
         if (!open) {
           setS3Edit(false)
-          setS3EditData([] as Config[])
+          setS3EditData(null)
         }
       }}
       modal={false}
@@ -57,57 +82,42 @@ export default function S3EditSheet() {
           <SheetTitle>{t('Config.editS3')}</SheetTitle>
         </SheetHeader>
         <div className="flex flex-col space-y-2">
-          {
-            s3Data?.map((config: Config) => (
-              config.config_key === 'force_path_style' || config.config_key === 's3_cdn' || config.config_key === 's3_direct_download' ?
-                <div
-                  key={config.id}
-                  className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm"
-                >
-                  <div className="flex flex-col gap-1">
-                    <div className="text-tiny text-default-400">
-                      {t('Config.' + config.config_key)}
-                    </div>
+          {s3Data && FIELDS.map((field) => (
+            field.type === 'boolean' ? (
+              <div
+                key={field.key as string}
+                className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm"
+              >
+                <div className="flex flex-col gap-1">
+                  <div className="text-tiny text-default-400">
+                    {t('Config.' + field.dbKey)}
                   </div>
-                  <Switch
-                    className="cursor-pointer"
-                    checked={config.config_value === 'true'}
-                    onCheckedChange={(value) => setS3EditData(
-                      s3Data?.map((c: Config) => {
-                        if (c.config_key === config.config_key) {
-                          c.config_value = value ? 'true' : 'false'
-                        }
-                        return c
-                      })
-                    )}
-                  />
                 </div>
-              :
+                <Switch
+                  className="cursor-pointer"
+                  checked={Boolean(s3Data[field.key])}
+                  onCheckedChange={(value) => updateField(field.key, value as S3Info[typeof field.key])}
+                />
+              </div>
+            ) : (
               <label
-                htmlFor="text"
-                key={config.id}
+                htmlFor={field.key as string}
+                key={field.key as string}
                 className="block overflow-hidden rounded-md border border-input px-3 py-2 shadow-sm focus-within:border-primary focus-within:ring-1 focus-within:ring-primary"
               >
-                <span className="text-xs font-medium text-gray-700"> {config.config_key} </span>
+                <span className="text-xs font-medium text-gray-700"> {field.dbKey} </span>
 
                 <input
                   type="text"
-                  id="name"
-                  value={config.config_value || ''}
-                  placeholder={t('Config.' + config.config_key)}
-                  onChange={(e) => setS3EditData(
-                    s3Data?.map((c: Config) => {
-                      if (c.config_key === config.config_key) {
-                        c.config_value = e.target.value
-                      }
-                      return c
-                    })
-                  )}
+                  id={field.key as string}
+                  value={(s3Data[field.key] as string) || ''}
+                  placeholder={t('Config.' + field.dbKey)}
+                  onChange={(e) => updateField(field.key, e.target.value as S3Info[typeof field.key])}
                   className="mt-1 w-full border-none p-0 focus:border-transparent focus:outline-none focus:ring-0 sm:text-sm"
                 />
               </label>
-            ))
-          }
+            )
+          ))}
         </div>
         <Button className="cursor-pointer my-2" onClick={() => submit()} disabled={loading}>
           {loading && <ReloadIcon className="mr-2 h-4 w-4 animate-spin"/>}

--- a/components/admin/settings/storages/s3-tabs.tsx
+++ b/components/admin/settings/storages/s3-tabs.tsx
@@ -17,9 +17,10 @@ import { useButtonStore } from '~/app/providers/button-store-providers'
 import S3EditSheet from '~/components/admin/settings/storages/s3-edit-sheet'
 import { useTranslations } from 'next-intl'
 import TabsTableCell from '~/components/admin/settings/storages/tabs-table-cell'
+import type { S3Info } from '~/types'
 
 export default function S3Tabs() {
-  const { data, error, isValidating, mutate } = useSWR('/api/v1/settings/s3-info', fetcher
+  const { data, error, isValidating, mutate } = useSWR<S3Info>('/api/v1/settings/s3-info', fetcher
     , { revalidateOnFocus: false })
   const { setS3Edit, setS3EditData } = useButtonStore(
     (state) => state,
@@ -80,7 +81,7 @@ export default function S3Tabs() {
           </Table>
         </Card>
       }
-      {Array.isArray(data) && data.length > 0 && <S3EditSheet />}
+      {data && <S3EditSheet />}
     </div>
   )
 }

--- a/components/admin/settings/storages/tabs-table-cell.tsx
+++ b/components/admin/settings/storages/tabs-table-cell.tsx
@@ -2,33 +2,36 @@ import { TableCell, TableRow } from '~/components/ui/table.tsx'
 import { Badge } from '~/components/ui/badge.tsx'
 import { BadgeCheckIcon, BadgeXIcon } from 'lucide-react'
 
-export default function TabsTableCell(props : Readonly<any>) {
+type Row = { key: string; value: string | boolean | number | null | undefined }
+
+// Renders a typed config object (flat, camelCase) as a key/value table. The
+// `data` prop accepts the new camelCase shapes returned by
+// `/api/v1/settings/{s3,r2}-info` and `/api/v1/storage/open-list/info`.
+export default function TabsTableCell(props: Readonly<{ data: Record<string, string | boolean | number | null | undefined> }>) {
   const { data } = props
+  const rows: Row[] = Object.entries(data).map(([key, value]) => ({ key, value }))
   return (
     <>
-      {data.map((item: any) => (
-        <TableRow key={item.id}>
-          <TableCell className="font-medium">{item.config_key}</TableCell>
-          <TableCell className="truncate max-w-48">{item.config_value ?
-            item.config_value === 'true' ?
-              <Badge
-                variant="secondary"
-                className="bg-success text-success-foreground"
-              >
+      {rows.map((item) => (
+        <TableRow key={item.key}>
+          <TableCell className="font-medium">{item.key}</TableCell>
+          <TableCell className="truncate max-w-48">
+            {item.value === true ? (
+              <Badge variant="secondary" className="bg-success text-success-foreground">
                 <BadgeCheckIcon />
                 true
               </Badge>
-              : item.config_value === 'false' ?
-                <Badge
-                  variant="secondary"
-                  className="bg-warning text-warning-foreground"
-                >
-                  <BadgeXIcon />
-                  false
-                </Badge>
-                :
-                <Badge variant="secondary">{item.config_value}</Badge>
-            : <Badge variant="outline">N&A</Badge>}</TableCell>
+            ) : item.value === false ? (
+              <Badge variant="secondary" className="bg-warning text-warning-foreground">
+                <BadgeXIcon />
+                false
+              </Badge>
+            ) : item.value === null || item.value === undefined || item.value === '' ? (
+              <Badge variant="outline">N&A</Badge>
+            ) : (
+              <Badge variant="secondary">{String(item.value)}</Badge>
+            )}
+          </TableCell>
         </TableRow>
       ))}
     </>

--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Config } from '~/types'
+import type { GalleryDisplayConfig } from '~/types'
 import type { PreviewImageHandleProps } from '~/types/props'
 import LivePhoto from '~/components/album/live-photo'
 import { toast } from 'sonner'
@@ -72,8 +72,12 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   const exifIconClass = 'text-muted-foreground hover:text-primary transition-colors'
   const badgeIconClass = 'shrink-0 text-primary/60'
 
-  const { data: configData } = useSwrHydrated<Config[]>({
-    handle: props.configHandle ?? (async () => [] as Config[]),
+  const emptyConfig: GalleryDisplayConfig = {
+    customIndexDownloadEnable: false,
+    customIndexOriginEnable: false,
+  }
+  const { data: configData } = useSwrHydrated<GalleryDisplayConfig>({
+    handle: props.configHandle ?? (async () => emptyConfig),
     args: 'system-config',
   })
 
@@ -287,7 +291,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                   </button>
                 )}
               </AnimatedIconTrigger>
-              {configData?.find((item: Config) => item.config_key === 'custom_index_download_enable')?.config_value === 'true'
+              {configData?.customIndexDownloadEnable === true
                 && <>
                   {download ?
                     <RefreshCWIcon

--- a/components/layout/theme/polaroid/polaroid-gallery.tsx
+++ b/components/layout/theme/polaroid/polaroid-gallery.tsx
@@ -5,7 +5,7 @@ import type { ImageHandleProps } from '~/types/props.ts'
 import useSWRInfinite from 'swr/infinite'
 import { useSwrHydrated } from '~/hooks/use-swr-hydrated.ts'
 import { DraggableCardBody, DraggableCardContainer } from '~/components/ui/origin/draggable-card.tsx'
-import type { Config, ImageType } from '~/types'
+import type { GalleryDisplayConfig, ImageType } from '~/types'
 import Image from 'next/image'
 import { Skeleton } from '~/components/ui/skeleton'
 import { useBlurImageDataUrl } from '~/hooks/use-blurhash'
@@ -124,12 +124,16 @@ const PolaroidCard = memo(function PolaroidCard({
  * @param props - 包含配置处理和图片加载处理
  */
 export default function PolaroidGallery(props: Readonly<ImageHandleProps>) {
-  const { data: configData } = useSwrHydrated<Config[]>({
-    handle: props.configHandle ?? (async () => [] as Config[]),
+  const emptyConfig: GalleryDisplayConfig = {
+    customIndexDownloadEnable: false,
+    customIndexOriginEnable: false,
+  }
+  const { data: configData } = useSwrHydrated<GalleryDisplayConfig>({
+    handle: props.configHandle ?? (async () => emptyConfig),
     args: 'system-config',
   })
 
-  const customTitle = configData?.find((item: Config) => item.config_key === 'custom_title')?.config_value
+  const customTitle = configData?.customTitle
 
   const { data } = useSWRInfinite((index) => {
     return [`client-${props.args}-${index}-${props.album}`, index]

--- a/components/layout/theme/simple/simple-gallery.tsx
+++ b/components/layout/theme/simple/simple-gallery.tsx
@@ -4,7 +4,7 @@ import type { ImageHandleProps } from '~/types/props.ts'
 import useSWRInfinite from 'swr/infinite'
 import { useSwrHydrated } from '~/hooks/use-swr-hydrated.ts'
 import { useTranslations } from 'next-intl'
-import type { Config, ImageType } from '~/types'
+import type { GalleryDisplayConfig, ImageType } from '~/types'
 import GalleryImage from '~/components/gallery/simple/gallery-image.tsx'
 import InfiniteScroll from '~/components/ui/origin/infinite-scroll.tsx'
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
@@ -43,14 +43,18 @@ export default function SimpleGallery(props: Readonly<ImageHandleProps>) {
       keepPreviousData: true,
     }
   )
-  const { data: configData } = useSwrHydrated<Config[]>({
-    handle: props.configHandle ?? (async () => [] as Config[]),
+  const emptyConfig: GalleryDisplayConfig = {
+    customIndexDownloadEnable: false,
+    customIndexOriginEnable: false,
+  }
+  const { data: configData } = useSwrHydrated<GalleryDisplayConfig>({
+    handle: props.configHandle ?? (async () => emptyConfig),
     args: 'system-config',
   })
   // Memoize dataList to avoid unnecessary recalculations
   const dataList = useMemo(() => data?.flat() ?? [], [data])
   const customIndexOriginEnable = useMemo(
-    () => configData?.find((item: Config) => item.config_key === 'custom_index_origin_enable')?.config_value === 'true',
+    () => configData?.customIndexOriginEnable === true,
     [configData]
   )
   const t = useTranslations()

--- a/components/layout/theme/template/template-gallery.tsx
+++ b/components/layout/theme/template/template-gallery.tsx
@@ -5,7 +5,7 @@ import { useSwrPageTotalHook } from '~/hooks/use-swr-page-total-hook.ts'
 import useSWRInfinite from 'swr/infinite'
 import { useSwrHydrated } from '~/hooks/use-swr-hydrated.ts'
 import { useTranslations } from 'next-intl'
-import type { Config, ImageType } from '~/types'
+import type { GalleryDisplayConfig, ImageType } from '~/types'
 
 /**
  * 这个是相册页面模板，需要写新主题时直接复制一份，然后开写！
@@ -27,8 +27,12 @@ export default function TemplateGallery(props : Readonly<ImageHandleProps>) {
       revalidateOnReconnect: false,
     })
   // config 配置信息
-  const { data: configData } = useSwrHydrated<Config[]>({
-    handle: props.configHandle ?? (async () => [] as Config[]),
+  const emptyConfig: GalleryDisplayConfig = {
+    customIndexDownloadEnable: false,
+    customIndexOriginEnable: false,
+  }
+  const { data: configData } = useSwrHydrated<GalleryDisplayConfig>({
+    handle: props.configHandle ?? (async () => emptyConfig),
     args: 'system-config',
   })
   // 处理好的数据，直接用这个即可

--- a/hono/daily.ts
+++ b/hono/daily.ts
@@ -4,6 +4,7 @@ import { fetchConfigsByKeys } from '~/server/db/query/configs'
 import { fetchAlbumsWithDailyWeight } from '~/server/db/query/daily'
 import { Hono } from 'hono'
 import { updateDailyConfig, updateAlbumsDailyWeight, refreshDailyImages } from '~/server/db/operate/daily'
+import { toDailyConfig } from '~/server/lib/config-transform'
 import { ok, okEmpty } from '~/hono/_lib/response'
 import { badRequest, serverError } from '~/hono/_lib/errors'
 
@@ -11,13 +12,13 @@ const app = new Hono()
 
 app.get('/config', async (c) => {
   try {
-    const data = await fetchConfigsByKeys([
+    const rows = await fetchConfigsByKeys([
       'daily_enabled',
       'daily_refresh_interval',
       'daily_total_count',
       'daily_last_refresh'
     ])
-    return ok(c, data)
+    return ok(c, toDailyConfig(rows))
   } catch (error) {
     console.error('Error fetching daily config:', error)
     throw serverError('Failed to fetch daily config', error)

--- a/hono/settings.ts
+++ b/hono/settings.ts
@@ -1,36 +1,67 @@
 import 'server-only'
 
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
-import type { Config } from '~/types'
 import { Hono } from 'hono'
 import { updateOpenListConfig, updateCustomInfo, updateR2Config, updateS3Config } from '~/server/db/operate/configs'
 import { normalizeDefaultTheme } from '~/lib/utils/theme'
+import {
+  toAdminConfig,
+  toCustomInfo,
+  toR2Info,
+  toS3Info,
+} from '~/server/lib/config-transform'
+import type { CustomInfo, OpenListInfo, R2Info, S3Info } from '~/types'
 import { ok, okEmpty } from '~/hono/_lib/response'
 import { serverError } from '~/hono/_lib/errors'
 
 const app = new Hono()
 
+const CUSTOM_INFO_KEYS = [
+  'custom_title',
+  'custom_favicon_url',
+  'custom_author',
+  'rss_feed_id',
+  'rss_user_id',
+  'custom_index_style',
+  'custom_index_download_enable',
+  'preview_max_width_limit',
+  'preview_max_width_limit_switch',
+  'preview_quality',
+  'umami_host',
+  'umami_analytics',
+  'max_upload_files',
+  'custom_index_origin_enable',
+  'admin_images_per_page',
+  'default_theme',
+]
+
+const R2_INFO_KEYS = [
+  'r2_accesskey_id',
+  'r2_accesskey_secret',
+  'r2_account_id',
+  'r2_bucket',
+  'r2_storage_folder',
+  'r2_public_domain',
+  'r2_direct_download',
+]
+
+const S3_INFO_KEYS = [
+  'accesskey_id',
+  'accesskey_secret',
+  'region',
+  'endpoint',
+  'bucket',
+  'storage_folder',
+  'force_path_style',
+  's3_cdn',
+  's3_cdn_url',
+  's3_direct_download',
+]
+
 app.get('/custom-info', async (c) => {
   try {
-    const data = await fetchConfigsByKeys([
-      'custom_title',
-      'custom_favicon_url',
-      'custom_author',
-      'rss_feed_id',
-      'rss_user_id',
-      'custom_index_style',
-      'custom_index_download_enable',
-      'preview_max_width_limit',
-      'preview_max_width_limit_switch',
-      'preview_quality',
-      'umami_host',
-      'umami_analytics',
-      'max_upload_files',
-      'custom_index_origin_enable',
-      'admin_images_per_page',
-      'default_theme'
-    ])
-    return ok(c, data)
+    const rows = await fetchConfigsByKeys(CUSTOM_INFO_KEYS)
+    return ok(c, toCustomInfo(rows))
   } catch (error) {
     throw serverError('Failed to fetch custom info', error)
   }
@@ -38,16 +69,8 @@ app.get('/custom-info', async (c) => {
 
 app.get('/r2-info', async (c) => {
   try {
-    const data = await fetchConfigsByKeys([
-      'r2_accesskey_id',
-      'r2_accesskey_secret',
-      'r2_account_id',
-      'r2_bucket',
-      'r2_storage_folder',
-      'r2_public_domain',
-      'r2_direct_download'
-    ])
-    return ok(c, data)
+    const rows = await fetchConfigsByKeys(R2_INFO_KEYS)
+    return ok(c, toR2Info(rows))
   } catch (error) {
     throw serverError('Failed to fetch R2 info', error)
   }
@@ -55,19 +78,8 @@ app.get('/r2-info', async (c) => {
 
 app.get('/s3-info', async (c) => {
   try {
-    const data = await fetchConfigsByKeys([
-      'accesskey_id',
-      'accesskey_secret',
-      'region',
-      'endpoint',
-      'bucket',
-      'storage_folder',
-      'force_path_style',
-      's3_cdn',
-      's3_cdn_url',
-      's3_direct_download'
-    ])
-    return ok(c, data)
+    const rows = await fetchConfigsByKeys(S3_INFO_KEYS)
+    return ok(c, toS3Info(rows))
   } catch (error) {
     throw serverError('Failed to fetch S3 info', error)
   }
@@ -75,10 +87,8 @@ app.get('/s3-info', async (c) => {
 
 app.get('/admin-config', async (c) => {
   try {
-    const data = await fetchConfigsByKeys([
-      'admin_images_per_page'
-    ])
-    return ok(c, data)
+    const rows = await fetchConfigsByKeys(['admin_images_per_page'])
+    return ok(c, toAdminConfig(rows))
   } catch (error) {
     throw serverError('Failed to fetch admin config', error)
   }
@@ -86,12 +96,11 @@ app.get('/admin-config', async (c) => {
 
 app.put('/open-list-info', async (c) => {
   try {
-    const query = await c.req.json()
-
-    const openListUrl = query?.find((item: Config) => item.config_key === 'open_list_url').config_value
-    const openListToken = query?.find((item: Config) => item.config_key === 'open_list_token').config_value
-
-    await updateOpenListConfig({ openListUrl, openListToken })
+    const body = await c.req.json<OpenListInfo>()
+    await updateOpenListConfig({
+      openListUrl: body.openListUrl ?? '',
+      openListToken: body.openListToken ?? '',
+    })
     return okEmpty(c)
   } catch (e) {
     throw serverError('Failed', e)
@@ -100,17 +109,8 @@ app.put('/open-list-info', async (c) => {
 
 app.put('/r2-info', async (c) => {
   try {
-    const query = await c.req.json()
-
-    const r2AccesskeyId = query?.find((item: Config) => item.config_key === 'r2_accesskey_id').config_value
-    const r2AccesskeySecret = query?.find((item: Config) => item.config_key === 'r2_accesskey_secret').config_value
-    const r2AccountId = query?.find((item: Config) => item.config_key === 'r2_account_id').config_value
-    const r2Bucket = query?.find((item: Config) => item.config_key === 'r2_bucket').config_value
-    const r2StorageFolder = query?.find((item: Config) => item.config_key === 'r2_storage_folder').config_value
-    const r2PublicDomain = query?.find((item: Config) => item.config_key === 'r2_public_domain').config_value
-    const r2DirectDownload = query?.find((item: Config) => item.config_key === 'r2_direct_download').config_value
-
-    await updateR2Config({ r2AccesskeyId, r2AccesskeySecret, r2AccountId, r2Bucket, r2StorageFolder, r2PublicDomain, r2DirectDownload })
+    const body = await c.req.json<R2Info>()
+    await updateR2Config(body)
     return okEmpty(c)
   } catch (e) {
     throw serverError('Failed', e)
@@ -119,20 +119,8 @@ app.put('/r2-info', async (c) => {
 
 app.put('/s3-info', async (c) => {
   try {
-    const query = await c.req.json()
-
-    const accesskeyId = query?.find((item: Config) => item.config_key === 'accesskey_id').config_value
-    const accesskeySecret = query?.find((item: Config) => item.config_key === 'accesskey_secret').config_value
-    const region = query?.find((item: Config) => item.config_key === 'region').config_value
-    const endpoint = query?.find((item: Config) => item.config_key === 'endpoint').config_value
-    const bucket = query?.find((item: Config) => item.config_key === 'bucket').config_value
-    const storageFolder = query?.find((item: Config) => item.config_key === 'storage_folder').config_value
-    const forcePathStyle = query?.find((item: Config) => item.config_key === 'force_path_style').config_value
-    const s3Cdn = query?.find((item: Config) => item.config_key === 's3_cdn').config_value
-    const s3CdnUrl = query?.find((item: Config) => item.config_key === 's3_cdn_url').config_value
-    const s3DirectDownload = query?.find((item: Config) => item.config_key === 's3_direct_download').config_value
-
-    await updateS3Config({ accesskeyId, accesskeySecret, region, endpoint, bucket, storageFolder, forcePathStyle, s3Cdn, s3CdnUrl, s3DirectDownload })
+    const body = await c.req.json<S3Info>()
+    await updateS3Config(body)
     return okEmpty(c)
   } catch (e) {
     throw serverError('Failed', e)
@@ -140,28 +128,11 @@ app.put('/s3-info', async (c) => {
 })
 
 app.put('/custom-info', async (c) => {
-  const query = await c.req.json() satisfies {
-    title: string
-    customFaviconUrl: string
-    customAuthor: string
-    feedId: string
-    userId: string
-    customIndexStyle: number
-    customIndexDownloadEnable: boolean
-    enablePreviewImageMaxWidthLimit: boolean
-    previewImageMaxWidth: number
-    previewQuality: number
-    umamiHost: string
-    umamiAnalytics: string
-    maxUploadFiles: number
-    customIndexOriginEnable: boolean
-    adminImagesPerPage: number
-    defaultTheme: string
-  }
   try {
+    const body = await c.req.json<CustomInfo>()
     await updateCustomInfo({
-      ...query,
-      defaultTheme: normalizeDefaultTheme(query.defaultTheme),
+      ...body,
+      defaultTheme: normalizeDefaultTheme(body.defaultTheme),
     })
     return okEmpty(c)
   } catch (e) {

--- a/hono/storage/open-list.ts
+++ b/hono/storage/open-list.ts
@@ -3,7 +3,7 @@ import { fetchConfigsByKeys } from '~/server/db/query/configs'
 
 import { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
-import type { Config } from '~/types'
+import { toOpenListInfo } from '~/server/lib/config-transform'
 import { ok } from '~/hono/_lib/response'
 import { badRequest, serverError } from '~/hono/_lib/errors'
 
@@ -11,11 +11,11 @@ const app = new Hono()
 
 app.get('/info', async (c) => {
   try {
-    const data = await fetchConfigsByKeys([
+    const rows = await fetchConfigsByKeys([
       'open_list_url',
       'open_list_token'
     ])
-    return ok(c, data)
+    return ok(c, toOpenListInfo(rows))
   } catch (e) {
     throw serverError('Failed to fetch open list info', e)
   }
@@ -23,12 +23,11 @@ app.get('/info', async (c) => {
 
 app.get('/storages', async (c) => {
   try {
-    const findConfig = await fetchConfigsByKeys([
+    const rows = await fetchConfigsByKeys([
       'open_list_url',
       'open_list_token'
     ])
-    const openListToken = findConfig.find((item: Config) => item.config_key === 'open_list_token')?.config_value || ''
-    const openListUrl = findConfig.find((item: Config) => item.config_key === 'open_list_url')?.config_value || ''
+    const { openListUrl, openListToken } = toOpenListInfo(rows)
 
     if (!openListUrl || !openListToken) {
       throw badRequest('Open List URL and token must be configured')
@@ -37,7 +36,7 @@ app.get('/storages', async (c) => {
     const data = await fetch(`${openListUrl}/api/admin/storage/list`, {
       method: 'get',
       headers: {
-        'Authorization': openListToken.toString(),
+        'Authorization': openListToken,
       },
     }).then(res => res.json())
     return ok(c, data)

--- a/hooks/use-upload-config.ts
+++ b/hooks/use-upload-config.ts
@@ -8,7 +8,7 @@ import { useTranslations } from 'next-intl'
 import Compressor from 'compressorjs'
 import { heicTo, isHeic } from 'heic-to'
 import { uploadFile } from '~/lib/utils/file'
-import type { AlbumType } from '~/types'
+import type { AlbumType, CustomInfo } from '~/types'
 
 export const STORAGE_OPTIONS = [
   {
@@ -56,12 +56,12 @@ export function useUploadConfig(): UploadConfig {
   const t = useTranslations()
 
   const { data: albums, isLoading: isAlbumsLoading } = useSWR('/api/v1/albums', fetcher)
-  const { data: configs } = useSWR<{ config_key: string, config_value: string }[]>('/api/v1/settings/custom-info', fetcher)
+  const { data: configs } = useSWR<CustomInfo>('/api/v1/settings/custom-info', fetcher)
 
-  const previewImageMaxWidthLimitSwitchOn = configs?.find(config => config.config_key === 'preview_max_width_limit_switch')?.config_value === '1'
-  const previewImageMaxWidthLimit = parseInt(configs?.find(config => config.config_key === 'preview_max_width_limit')?.config_value || '0')
-  const previewCompressQuality = parseFloat(configs?.find(config => config.config_key === 'preview_quality')?.config_value || '0.2')
-  const maxUploadFiles = parseInt(configs?.find(config => config.config_key === 'max_upload_files')?.config_value || '5')
+  const previewImageMaxWidthLimitSwitchOn = configs?.previewMaxWidthLimitSwitch === true
+  const previewImageMaxWidthLimit = configs?.previewMaxWidthLimit ?? 0
+  const previewCompressQuality = configs?.previewQuality ?? 0.2
+  const maxUploadFiles = configs?.maxUploadFiles ?? 5
 
   const getOpenListStorage = useCallback(async () => {
     if (openListStorage.length > 0) {

--- a/server/actions/images.ts
+++ b/server/actions/images.ts
@@ -4,8 +4,7 @@ import { fetchClientImagesListByAlbum, fetchClientImagesPageTotalByAlbum } from 
 import { fetchConfigsByKeys, fetchConfigValue } from '~/server/db/query/configs'
 import { fetchDailyImagesList, fetchDailyImagesPageTotal } from '~/server/db/query/daily'
 import { checkAndRefreshDailyImages } from '~/server/db/operate/daily'
-import type { ImageType } from '~/types'
-import type { Config } from '~/types'
+import type { GalleryDisplayConfig, ImageType } from '~/types'
 
 export async function getImagesData(pageNum: number, album: string, camera?: string, lens?: string): Promise<ImageType[]> {
   if (album === '/') {
@@ -27,18 +26,27 @@ export async function getImagesPageTotal(album: string, camera?: string, lens?: 
   return fetchClientImagesPageTotalByAlbum(album, camera, lens)
 }
 
-export async function getDisplayConfig(): Promise<Config[]> {
-  return fetchConfigsByKeys([
+export async function getDisplayConfig(): Promise<GalleryDisplayConfig> {
+  const rows = await fetchConfigsByKeys([
     'custom_index_download_enable',
     'custom_index_origin_enable',
-    'custom_title'
+    'custom_title',
   ])
+  const get = (key: string) => rows.find((item) => item.config_key === key)?.config_value
+  return {
+    customTitle: get('custom_title') ?? undefined,
+    customIndexDownloadEnable: get('custom_index_download_enable') === 'true',
+    customIndexOriginEnable: get('custom_index_origin_enable') === 'true',
+  }
 }
 
-export async function getAlbumDisplayConfig(): Promise<Config[]> {
-  return fetchConfigsByKeys([
-    'custom_index_download_enable'
-  ])
+export async function getAlbumDisplayConfig(): Promise<GalleryDisplayConfig> {
+  const rows = await fetchConfigsByKeys(['custom_index_download_enable'])
+  const get = (key: string) => rows.find((item) => item.config_key === key)?.config_value
+  return {
+    customIndexDownloadEnable: get('custom_index_download_enable') === 'true',
+    customIndexOriginEnable: false,
+  }
 }
 
 export async function initDailyIfNeeded(): Promise<void> {

--- a/server/db/operate/configs.ts
+++ b/server/db/operate/configs.ts
@@ -4,12 +4,27 @@
 
 import { db } from '~/server/lib/db'
 import { normalizeDefaultTheme } from '~/lib/utils/theme'
+import type { CustomInfo, R2Info, S3Info, OpenListInfo } from '~/types'
+
+// The configs table stores everything as text, so boolean values coming from
+// the API layer (real `boolean`) need to be serialised back to 'true' / 'false'
+// before they hit the raw SQL UPDATE statements below. `toBoolString` accepts
+// both real booleans (the new API contract) and pre-serialised strings (any
+// remaining legacy call sites) to keep the layer permissive during migration.
+const toBoolString = (value: boolean | string | undefined | null): string => {
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (value === 'true' || value === 'false') return value
+  return 'false'
+}
 
 /**
  * 更新 S3 配置
- * @param configs 配置信息
+ * @param configs S3 配置（camelCase, see {@link S3Info}）
  */
-export async function updateS3Config(configs: any) {
+export async function updateS3Config(configs: S3Info) {
+  const forcePathStyle = toBoolString(configs.forcePathStyle)
+  const s3Cdn = toBoolString(configs.s3Cdn)
+  const s3DirectDownload = toBoolString(configs.s3DirectDownload)
   return await db.$executeRaw`
     UPDATE "public"."configs"
     SET config_value = CASE
@@ -19,10 +34,10 @@ export async function updateS3Config(configs: any) {
        WHEN config_key = 'endpoint' THEN ${configs.endpoint}
        WHEN config_key = 'bucket' THEN ${configs.bucket}
        WHEN config_key = 'storage_folder' THEN ${configs.storageFolder}
-       WHEN config_key = 'force_path_style' THEN ${configs.forcePathStyle}
-       WHEN config_key = 's3_cdn' THEN ${configs.s3Cdn}
+       WHEN config_key = 'force_path_style' THEN ${forcePathStyle}
+       WHEN config_key = 's3_cdn' THEN ${s3Cdn}
        WHEN config_key = 's3_cdn_url' THEN ${configs.s3CdnUrl}
-       WHEN config_key = 's3_direct_download' THEN ${configs.s3DirectDownload}
+       WHEN config_key = 's3_direct_download' THEN ${s3DirectDownload}
        ELSE 'N&A'
     END,
         updated_at = NOW()
@@ -32,9 +47,10 @@ export async function updateS3Config(configs: any) {
 
 /**
  * 更新 R2 配置
- * @param configs 配置信息
+ * @param configs R2 配置（camelCase, see {@link R2Info}）
  */
-export async function updateR2Config(configs: any) {
+export async function updateR2Config(configs: R2Info) {
+  const r2DirectDownload = toBoolString(configs.r2DirectDownload)
   return await db.$executeRaw`
     UPDATE "public"."configs"
     SET config_value = CASE
@@ -44,7 +60,7 @@ export async function updateR2Config(configs: any) {
        WHEN config_key = 'r2_bucket' THEN ${configs.r2Bucket}
        WHEN config_key = 'r2_storage_folder' THEN ${configs.r2StorageFolder}
        WHEN config_key = 'r2_public_domain' THEN ${configs.r2PublicDomain}
-       WHEN config_key = 'r2_direct_download' THEN ${configs.r2DirectDownload}
+       WHEN config_key = 'r2_direct_download' THEN ${r2DirectDownload}
        ELSE 'N&A'
     END,
         updated_at = NOW()
@@ -54,9 +70,9 @@ export async function updateR2Config(configs: any) {
 
 /**
  * 更新 Open List 配置
- * @param configs 配置信息
+ * @param configs Open List 配置（camelCase, see {@link OpenListInfo}）
  */
-export async function updateOpenListConfig(configs: any) {
+export async function updateOpenListConfig(configs: OpenListInfo) {
   return await db.$executeRaw`
     UPDATE "public"."configs"
     SET config_value = CASE
@@ -71,36 +87,19 @@ export async function updateOpenListConfig(configs: any) {
 
 /**
  * 更新自定义信息
- * @param payload 自定义信息
+ * @param payload 自定义信息（camelCase API shape, see {@link CustomInfo}）
  */
-export async function updateCustomInfo(payload: {
-  title: string
-  customFaviconUrl: string
-  customAuthor: string
-  feedId: string
-  userId: string
-  customIndexStyle: number
-  customIndexDownloadEnable: boolean
-  enablePreviewImageMaxWidthLimit: boolean
-  previewImageMaxWidth: number
-  previewQuality: number
-  umamiHost: string
-  umamiAnalytics: string
-  maxUploadFiles: number
-  customIndexOriginEnable: boolean
-  adminImagesPerPage: number
-  defaultTheme: string
-}) {
+export async function updateCustomInfo(payload: CustomInfo) {
   const {
-    title,
+    customTitle,
     customFaviconUrl,
     customAuthor,
-    feedId,
-    userId,
+    rssFeedId,
+    rssUserId,
     customIndexStyle,
     customIndexDownloadEnable,
-    enablePreviewImageMaxWidthLimit,
-    previewImageMaxWidth,
+    previewMaxWidthLimitSwitch,
+    previewMaxWidthLimit,
     previewQuality,
     umamiHost,
     umamiAnalytics,
@@ -112,16 +111,16 @@ export async function updateCustomInfo(payload: {
   const normalizedDefaultTheme = normalizeDefaultTheme(defaultTheme)
 
   const updates = [
-    db.configs.update({ where: { config_key: 'custom_title' }, data: { config_value: title, updatedAt: new Date() } }),
+    db.configs.update({ where: { config_key: 'custom_title' }, data: { config_value: customTitle, updatedAt: new Date() } }),
     db.configs.update({ where: { config_key: 'custom_favicon_url' }, data: { config_value: customFaviconUrl, updatedAt: new Date() } }),
     db.configs.update({ where: { config_key: 'custom_author' }, data: { config_value: customAuthor, updatedAt: new Date() } }),
-    db.configs.update({ where: { config_key: 'rss_feed_id' }, data: { config_value: feedId, updatedAt: new Date() } }),
-    db.configs.update({ where: { config_key: 'rss_user_id' }, data: { config_value: userId, updatedAt: new Date() } }),
+    db.configs.update({ where: { config_key: 'rss_feed_id' }, data: { config_value: rssFeedId, updatedAt: new Date() } }),
+    db.configs.update({ where: { config_key: 'rss_user_id' }, data: { config_value: rssUserId, updatedAt: new Date() } }),
     db.configs.update({ where: { config_key: 'umami_host' }, data: { config_value: umamiHost, updatedAt: new Date() } }),
     db.configs.update({ where: { config_key: 'umami_analytics' }, data: { config_value: umamiAnalytics, updatedAt: new Date() } }),
     db.configs.update({ where: { config_key: 'custom_index_style' }, data: { config_value: customIndexStyle.toString(), updatedAt: new Date() } }),
     db.configs.update({ where: { config_key: 'custom_index_download_enable' }, data: { config_value: customIndexDownloadEnable ? 'true' : 'false', updatedAt: new Date() } }),
-    db.configs.update({ where: { config_key: 'preview_max_width_limit_switch' }, data: { config_value: enablePreviewImageMaxWidthLimit ? '1' : '0', updatedAt: new Date() } }),
+    db.configs.update({ where: { config_key: 'preview_max_width_limit_switch' }, data: { config_value: previewMaxWidthLimitSwitch ? '1' : '0', updatedAt: new Date() } }),
     db.configs.update({ where: { config_key: 'max_upload_files' }, data: { config_value: maxUploadFiles.toString(), updatedAt: new Date() } }),
     db.configs.update({ where: { config_key: 'custom_index_origin_enable' }, data: { config_value: customIndexOriginEnable ? 'true' : 'false', updatedAt: new Date() } }),
     db.configs.update({ where: { config_key: 'admin_images_per_page' }, data: { config_value: adminImagesPerPage.toString(), updatedAt: new Date() } }),
@@ -136,8 +135,8 @@ export async function updateCustomInfo(payload: {
     }),
   ]
 
-  if (previewImageMaxWidth > 0) {
-    updates.push(db.configs.update({ where: { config_key: 'preview_max_width_limit' }, data: { config_value: previewImageMaxWidth.toString(), updatedAt: new Date() } }))
+  if (previewMaxWidthLimit > 0) {
+    updates.push(db.configs.update({ where: { config_key: 'preview_max_width_limit' }, data: { config_value: previewMaxWidthLimit.toString(), updatedAt: new Date() } }))
   }
 
   if (previewQuality > 0) {

--- a/server/db/operate/daily.ts
+++ b/server/db/operate/daily.ts
@@ -4,30 +4,26 @@
 
 import { db } from '~/server/lib/db'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import { toDailyConfig } from '~/server/lib/config-transform'
 
 /**
  * 检查并刷新每日精选图片
  * 根据配置的刷新间隔，判断是否需要刷新物化视图
  */
 export async function checkAndRefreshDailyImages() {
-  const configs = await fetchConfigsByKeys([
+  const rows = await fetchConfigsByKeys([
     'daily_enabled',
     'daily_refresh_interval',
     'daily_last_refresh',
   ])
+  const { dailyEnabled, dailyRefreshInterval, dailyLastRefresh } = toDailyConfig(rows)
 
-  const enabledConfig = configs.find(c => c.config_key === 'daily_enabled')
-  const intervalConfig = configs.find(c => c.config_key === 'daily_refresh_interval')
-  const lastRefreshConfig = configs.find(c => c.config_key === 'daily_last_refresh')
-
-  if (!enabledConfig || enabledConfig.config_value !== 'true') {
+  if (!dailyEnabled) {
     return
   }
 
-  const intervalHours = parseInt(intervalConfig?.config_value || '24', 10)
-  const lastRefresh = lastRefreshConfig?.config_value
-    ? new Date(lastRefreshConfig.config_value).getTime()
-    : 0
+  const intervalHours = parseInt(dailyRefreshInterval, 10)
+  const lastRefresh = dailyLastRefresh ? new Date(dailyLastRefresh).getTime() : 0
 
   const now = Date.now()
   const intervalMs = intervalHours * 60 * 60 * 1000

--- a/server/lib/config-transform.ts
+++ b/server/lib/config-transform.ts
@@ -1,0 +1,128 @@
+import 'server-only'
+
+import type {
+  AdminConfig,
+  Config,
+  CustomInfo,
+  DailyConfig,
+  OpenListInfo,
+  R2Info,
+  S3Info,
+} from '~/types'
+import { normalizeDefaultTheme } from '~/lib/utils/theme'
+
+// Per-shape mappers that convert the `Config[]` snake_case rows returned by
+// `fetchConfigsByKeys` into the flat camelCase objects exposed by the
+// `/api/v1/settings/*` and `/api/v1/daily/config` endpoints.
+//
+// Coercion rules:
+//   - boolean fields stored as the string 'true' / 'false' → real `boolean`
+//   - the legacy `preview_max_width_limit_switch` flag stored as '0' / '1' is
+//     normalised to a boolean (`'1'` → true)
+//   - numeric fields parsed via `parseInt` / `parseFloat`; non-numeric values
+//     fall back to the documented default for that field
+//   - missing rows yield the field default ('' for strings, false for bools,
+//     0 / sensible defaults for numbers, null for `dailyLastRefresh`)
+
+const valueOf = (configs: Config[], key: string): string | null | undefined =>
+  configs.find((item) => item.config_key === key)?.config_value
+
+const str = (configs: Config[], key: string, fallback = ''): string =>
+  valueOf(configs, key) ?? fallback
+
+const bool = (configs: Config[], key: string, fallback = false): boolean => {
+  const raw = valueOf(configs, key)
+  if (raw === undefined || raw === null) return fallback
+  return raw === 'true'
+}
+
+const switchBool = (configs: Config[], key: string, fallback = false): boolean => {
+  // Legacy '0' / '1' switch flag (e.g. preview_max_width_limit_switch).
+  const raw = valueOf(configs, key)
+  if (raw === undefined || raw === null) return fallback
+  return raw === '1'
+}
+
+const int = (configs: Config[], key: string, fallback: number): number => {
+  const raw = valueOf(configs, key)
+  if (raw === undefined || raw === null || raw === '') return fallback
+  const parsed = parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const float = (configs: Config[], key: string, fallback: number): number => {
+  const raw = valueOf(configs, key)
+  if (raw === undefined || raw === null || raw === '') return fallback
+  const parsed = parseFloat(raw)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+export function toCustomInfo(configs: Config[]): CustomInfo {
+  return {
+    customTitle: str(configs, 'custom_title'),
+    customFaviconUrl: str(configs, 'custom_favicon_url'),
+    customAuthor: str(configs, 'custom_author'),
+    rssFeedId: str(configs, 'rss_feed_id'),
+    rssUserId: str(configs, 'rss_user_id'),
+    customIndexStyle: str(configs, 'custom_index_style', '0'),
+    customIndexDownloadEnable: bool(configs, 'custom_index_download_enable'),
+    previewMaxWidthLimit: int(configs, 'preview_max_width_limit', 0),
+    previewMaxWidthLimitSwitch: switchBool(configs, 'preview_max_width_limit_switch'),
+    previewQuality: float(configs, 'preview_quality', 0.2),
+    umamiHost: str(configs, 'umami_host'),
+    umamiAnalytics: str(configs, 'umami_analytics'),
+    maxUploadFiles: int(configs, 'max_upload_files', 5),
+    customIndexOriginEnable: bool(configs, 'custom_index_origin_enable'),
+    adminImagesPerPage: int(configs, 'admin_images_per_page', 8),
+    defaultTheme: normalizeDefaultTheme(valueOf(configs, 'default_theme')),
+  }
+}
+
+export function toS3Info(configs: Config[]): S3Info {
+  return {
+    accesskeyId: str(configs, 'accesskey_id'),
+    accesskeySecret: str(configs, 'accesskey_secret'),
+    region: str(configs, 'region'),
+    endpoint: str(configs, 'endpoint'),
+    bucket: str(configs, 'bucket'),
+    storageFolder: str(configs, 'storage_folder'),
+    forcePathStyle: bool(configs, 'force_path_style'),
+    s3Cdn: bool(configs, 's3_cdn'),
+    s3CdnUrl: str(configs, 's3_cdn_url'),
+    s3DirectDownload: bool(configs, 's3_direct_download'),
+  }
+}
+
+export function toR2Info(configs: Config[]): R2Info {
+  return {
+    r2AccesskeyId: str(configs, 'r2_accesskey_id'),
+    r2AccesskeySecret: str(configs, 'r2_accesskey_secret'),
+    r2AccountId: str(configs, 'r2_account_id'),
+    r2Bucket: str(configs, 'r2_bucket'),
+    r2StorageFolder: str(configs, 'r2_storage_folder'),
+    r2PublicDomain: str(configs, 'r2_public_domain'),
+    r2DirectDownload: bool(configs, 'r2_direct_download'),
+  }
+}
+
+export function toOpenListInfo(configs: Config[]): OpenListInfo {
+  return {
+    openListUrl: str(configs, 'open_list_url'),
+    openListToken: str(configs, 'open_list_token'),
+  }
+}
+
+export function toAdminConfig(configs: Config[]): AdminConfig {
+  return {
+    adminImagesPerPage: int(configs, 'admin_images_per_page', 8),
+  }
+}
+
+export function toDailyConfig(configs: Config[]): DailyConfig {
+  return {
+    dailyEnabled: bool(configs, 'daily_enabled'),
+    dailyRefreshInterval: str(configs, 'daily_refresh_interval', '24'),
+    dailyTotalCount: int(configs, 'daily_total_count', 30),
+    dailyLastRefresh: valueOf(configs, 'daily_last_refresh') ?? null,
+  }
+}

--- a/stores/button-stores.ts
+++ b/stores/button-stores.ts
@@ -1,6 +1,6 @@
 import { createStore } from 'zustand/vanilla'
 import { persist, createJSONStorage } from 'zustand/middleware'
-import type { AlbumType, ImageType, Config } from '~/types'
+import type { AlbumType, ImageType, OpenListInfo, R2Info, S3Info } from '~/types'
 
 export type ButtonState = {
   albumAdd: boolean
@@ -11,11 +11,11 @@ export type ButtonState = {
   imageViewData: ImageType
   imageView: boolean
   s3Edit: boolean
-  s3Data: Config[]
+  s3Data: S3Info | null
   r2Edit: boolean
-  r2Data: Config[]
+  r2Data: R2Info | null
   openListEdit: boolean
-  openListData: Config[]
+  openListData: OpenListInfo | null
   MasonryView: boolean
   MasonryViewData: ImageType
   MasonryViewDataList: ImageType[]
@@ -34,11 +34,11 @@ export type ButtonActions = {
   setImageView: (imageView: boolean) => void
   setImageViewData: (imageViewData: ImageType) => void
   setS3Edit: (s3Edit: boolean) => void
-  setS3EditData: (s3Data: Config[]) => void
+  setS3EditData: (s3Data: S3Info | null) => void
   setR2Edit: (r2Edit: boolean) => void
-  setR2EditData: (r2Data: Config[]) => void
+  setR2EditData: (r2Data: R2Info | null) => void
   setOpenListEdit: (openListEdit: boolean) => void
-  setOpenListEditData: (openListData: Config[]) => void
+  setOpenListEditData: (openListData: OpenListInfo | null) => void
   setMasonryView: (masonryView: boolean) => void
   setMasonryViewData: (masonryViewData: ImageType) => void
   setMasonryViewDataList: (masonryViewDataList: ImageType[]) => void
@@ -60,11 +60,11 @@ export const initButtonStore = (): ButtonState => {
     imageView: false,
     imageViewData: {} as ImageType,
     s3Edit: false,
-    s3Data: [] as Config[],
+    s3Data: null,
     r2Edit: false,
-    r2Data: [] as Config[],
+    r2Data: null,
     openListEdit: false,
-    openListData: [] as Config[],
+    openListData: null,
     MasonryView: false,
     MasonryViewData: {} as ImageType,
     MasonryViewDataList: [] as ImageType[],
@@ -84,11 +84,11 @@ export const defaultInitState: ButtonState = {
   imageView: false,
   imageViewData: {} as ImageType,
   s3Edit: false,
-  s3Data: [] as Config[],
+  s3Data: null,
   r2Edit: false,
-  r2Data: [] as Config[],
+  r2Data: null,
   openListEdit: false,
-  openListData: [] as Config[],
+  openListData: null,
   MasonryView: false,
   MasonryViewData: {} as ImageType,
   MasonryViewDataList: [] as ImageType[],

--- a/types/index.ts
+++ b/types/index.ts
@@ -59,9 +59,91 @@ export type ImageType = {
   album_license: string;
 }
 
+/**
+ * @deprecated Use the dedicated config-shape types below (`CustomInfo`, `S3Info`,
+ * `R2Info`, `OpenListInfo`, `AdminConfig`, `DailyConfig`). This raw row shape is
+ * still consumed by the storage client builders (`getClient`, `getR2Client`) and
+ * by parts of the server-side download/upload pipeline that read the
+ * `Config[]` snapshot returned by `fetchConfigsByKeys`. The API contract for
+ * `/api/v1/settings/*` and `/api/v1/daily/config` no longer exposes this shape.
+ */
 export type Config = {
   id: string;
   config_key: string;
   config_value: string | null;
   detail: string | null;
+}
+
+// === API-facing configuration shapes (camelCase, flat) ===
+//
+// These types describe what `/api/v1/settings/*` and `/api/v1/daily/config`
+// return and accept on the wire. Snake_case DB column names are mapped at the
+// server boundary via `server/lib/config-transform.ts`.
+
+export type CustomInfo = {
+  customTitle: string
+  customFaviconUrl: string
+  customAuthor: string
+  rssFeedId: string
+  rssUserId: string
+  customIndexStyle: string
+  customIndexDownloadEnable: boolean
+  previewMaxWidthLimit: number
+  previewMaxWidthLimitSwitch: boolean
+  previewQuality: number
+  umamiHost: string
+  umamiAnalytics: string
+  maxUploadFiles: number
+  customIndexOriginEnable: boolean
+  adminImagesPerPage: number
+  defaultTheme: string
+}
+
+export type S3Info = {
+  accesskeyId: string
+  accesskeySecret: string
+  region: string
+  endpoint: string
+  bucket: string
+  storageFolder: string
+  forcePathStyle: boolean
+  s3Cdn: boolean
+  s3CdnUrl: string
+  s3DirectDownload: boolean
+}
+
+export type R2Info = {
+  r2AccesskeyId: string
+  r2AccesskeySecret: string
+  r2AccountId: string
+  r2Bucket: string
+  r2StorageFolder: string
+  r2PublicDomain: string
+  r2DirectDownload: boolean
+}
+
+export type OpenListInfo = {
+  openListUrl: string
+  openListToken: string
+}
+
+export type AdminConfig = {
+  adminImagesPerPage: number
+}
+
+export type DailyConfig = {
+  dailyEnabled: boolean
+  dailyRefreshInterval: string
+  dailyTotalCount: number
+  dailyLastRefresh: string | null
+}
+
+// Slim camelCase shape passed from server actions to gallery components via
+// `configHandle`. The fields are the subset of `CustomInfo` the public/album
+// pages actually need; populated by the server action that wraps
+// `fetchConfigsByKeys`.
+export type GalleryDisplayConfig = {
+  customTitle?: string
+  customIndexDownloadEnable: boolean
+  customIndexOriginEnable: boolean
 }

--- a/types/props.ts
+++ b/types/props.ts
@@ -1,6 +1,6 @@
 // 业务专用类型
 
-import { AlbumType, Config, ImageType } from '~/types/index'
+import { AlbumType, GalleryDisplayConfig, ImageType } from '~/types/index'
 
 export type AlbumDataProps = {
   data: AlbumType[]
@@ -23,14 +23,14 @@ export type ImageHandleProps = {
   args: string
   album: string
   totalHandle: (album: string, camera?: string, lens?: string) => Promise<number>
-  configHandle?: () => Promise<Config[]>
+  configHandle?: () => Promise<GalleryDisplayConfig>
 }
 
 export type PreviewImageHandleProps = {
   data: ImageType
   args: string
   id: string
-  configHandle?: () => Promise<Config[]>
+  configHandle?: () => Promise<GalleryDisplayConfig>
 }
 
 export type ProgressiveImageProps = {


### PR DESCRIPTION
Implements PR-07 of [`docs/plans/2026-05-19-api-refactor-design.md`](docs/plans/2026-05-19-api-refactor-design.md) — the configs/daily/settings switch from snake_case `Config[]` rows to flat camelCase objects on both response and request payloads.

## Summary

- New shape types added to `types/index.ts`: `CustomInfo`, `S3Info`, `R2Info`, `OpenListInfo`, `AdminConfig`, `DailyConfig`, plus a slim `GalleryDisplayConfig` for the server-action handoff into the gallery components. The legacy `Config` type stays around with a `@deprecated` JSDoc note — it's still consumed by `getClient` / `getR2Client` and a few download/upload helpers that read the raw `fetchConfigsByKeys` snapshot.
- New `server/lib/config-transform.ts` exposes per-shape mappers (`toCustomInfo`, `toS3Info`, `toR2Info`, `toOpenListInfo`, `toAdminConfig`, `toDailyConfig`). Picked per-type mappers over a generic reducer because the boolean / number coercion rules vary per field (the legacy `preview_max_width_limit_switch` flag is `'0'` / `'1'`, everything else is `'true'` / `'false'`) and inline coercions are easier to audit than a registry.
- `server/db/operate/configs.ts`: `updateCustomInfo` / `updateS3Config` / `updateR2Config` / `updateOpenListConfig` now take the new typed shapes; a small `toBoolString` helper serialises real booleans back to the `'true'` / `'false'` strings the DB column expects.

## Contract changes

### GET responses
Every `/api/v1/settings/*` and `/api/v1/daily/config` GET now returns the envelope `{ code: 200, message: 'Success', data: <flat camelCase object> }` instead of `data: Config[]`.

- `GET /api/v1/settings/custom-info` → `CustomInfo`
- `GET /api/v1/settings/s3-info` → `S3Info`
- `GET /api/v1/settings/r2-info` → `R2Info`
- `GET /api/v1/settings/admin-config` → `AdminConfig`
- `GET /api/v1/storage/open-list/info` → `OpenListInfo`
- `GET /api/v1/daily/config` → `DailyConfig`

### PUT bodies
The matching PUT endpoints now accept the same flat camelCase objects directly:

- `PUT /api/v1/settings/custom-info` accepts `CustomInfo`
- `PUT /api/v1/settings/s3-info` accepts `S3Info`
- `PUT /api/v1/settings/r2-info` accepts `R2Info`
- `PUT /api/v1/settings/open-list-info` accepts `OpenListInfo`

Booleans (`forcePathStyle`, `s3Cdn`, `s3DirectDownload`, `r2DirectDownload`, `customIndexDownloadEnable`, `customIndexOriginEnable`, `previewMaxWidthLimitSwitch`, `dailyEnabled`) are now real JSON booleans on the wire — the boundary in `config-transform.ts` reads the underlying `'true'` / `'false'` / `'0'` / `'1'` strings, and `server/db/operate/configs.ts:toBoolString` converts them back when writing.

## Frontend files migrated

15 frontend / server-rendered consumer files updated:

- `app/layout.tsx`
- `app/(default)/layout.tsx`
- `app/(default)/page.tsx`
- `app/(default)/preview/[...id]/page.tsx`
- `app/(theme)/[...album]/layout.tsx`
- `app/(theme)/map/layout.tsx`
- `app/(theme)/map/page.tsx`
- `app/rss.xml/route.ts`
- `app/admin/settings/preferences/page.tsx`
- `app/admin/settings/daily/page.tsx`
- `components/admin/list/list-props.tsx`
- `components/admin/settings/storages/{s3,r2,open-list}-tabs.tsx`
- `components/admin/settings/storages/{s3,r2,open-list}-edit-sheet.tsx`
- `components/admin/settings/storages/tabs-table-cell.tsx`
- `components/album/preview-image.tsx`
- `components/layout/theme/simple/simple-gallery.tsx`
- `components/layout/theme/polaroid/polaroid-gallery.tsx`
- `components/layout/theme/template/template-gallery.tsx`
- `hooks/use-upload-config.ts`
- `stores/button-stores.ts` (storage edit drafts are now `S3Info | R2Info | OpenListInfo | null` instead of `Config[]`)
- `server/actions/images.ts` (`getDisplayConfig` / `getAlbumDisplayConfig` now return `GalleryDisplayConfig`)
- `types/props.ts` (`configHandle` signature updated)

## Test plan

- [ ] Open `/admin/settings/storages`, edit S3 storage settings, save, refresh — values round-trip through `useSWR` / PUT correctly.
- [ ] Same for R2 and OpenList tabs (including the boolean switches for `force_path_style`, `s3_cdn`, `s3_direct_download`, `r2_direct_download`).
- [ ] Open `/admin/settings/preferences`, change `customTitle`, toggle `customIndexDownloadEnable` and `previewMaxWidthLimitSwitch`, change `defaultTheme`, save, refresh — all values persist; the home page picks up the new title and default theme.
- [ ] Open `/admin/settings/daily`, toggle `dailyEnabled`, change `dailyRefreshInterval` and `dailyTotalCount`, save — config persists and `dailyLastRefresh` survives.
- [ ] Public gallery (default / simple / polaroid theme) still renders with the correct title and download-enable behaviour.
- [ ] `pnpm run lint` — 0 errors.
- [ ] `pnpm exec tsc --noEmit` — 100 errors, matching the baseline at `b7c0722` (no new errors introduced).
- [ ] `pnpm run build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)