### PR TITLE
fix(prisma): cast exif json to jsonb in rename migration

### DIFF
--- a/prisma/migrations/20260519102435_rename_exif_data_time_to_date_time/migration.sql
+++ b/prisma/migrations/20260519102435_rename_exif_data_time_to_date_time/migration.sql
@@ -1,9 +1,16 @@
--- Rename the JSONB key `data_time` to `dateTime` inside the `images.exif`
+-- Rename the JSON key `data_time` to `dateTime` inside the `images.exif`
 -- column to match the camelCase `ExifType.dateTime` field used by the API
--- and frontend. The column type stays JSONB; we only rename a key inside it.
+-- and frontend. The column type stays `json`; we only rename a key inside it.
+--
+-- `images.exif` is `json` (not `jsonb`), and operators `?`, `-`, `||` are only
+-- defined on `jsonb`, so we cast to `jsonb` for the manipulation and back to
+-- `json` on write.
 --
 -- Idempotent: only rows that still have the old key are touched, so running
 -- this migration multiple times is safe.
 UPDATE "images"
-SET "exif" = ("exif" - 'data_time') || jsonb_build_object('dateTime', "exif"->>'data_time')
-WHERE "exif" ? 'data_time';
+SET "exif" = (
+  (("exif"::jsonb) - 'data_time')
+  || jsonb_build_object('dateTime', "exif"->>'data_time')
+)::json
+WHERE ("exif"::jsonb) ? 'data_time';


### PR DESCRIPTION
## Summary

- `images.exif` is `json`, not `jsonb`, so the rename migration `20260519102435_rename_exif_data_time_to_date_time` fails on deploy with `operator does not exist: json ? unknown` (P3009).
- Cast to `jsonb` for `?`, `-`, `||`, then cast the result back to `json` on write so the `data_time` → `dateTime` key rename actually applies.
- Logic is unchanged (still idempotent via `WHERE ... ? 'data_time'`); only the operand types are fixed.

## Production recovery

The migration aborted before modifying any rows, so on any database where it is currently in the failed state:

1. `pnpm prisma migrate resolve --rolled-back 20260519102435_rename_exif_data_time_to_date_time`
2. Redeploy — `prisma migrate deploy` will reapply the fixed SQL.

## Test plan

- [ ] `pnpm prisma migrate deploy` succeeds on a database that still has `exif.data_time`
- [ ] Affected rows have `exif.dateTime` populated and no `exif.data_time` after migration
- [ ] Re-running the migration is a no-op (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)