### PR TITLE
fix(docker): rollback base image to node:24-alpine3.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-alpine3.23 AS base
+FROM node:24-alpine3.23 AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@next/bundle-analyzer": "16.2.4",
     "@next/eslint-plugin-next": "16.2.4",
     "@tailwindcss/postcss": "4.2.2",
-    "@types/node": "25.9.1",
+    "@types/node": "24.12.4",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/rss": "0.0.32",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,8 +266,8 @@ importers:
         specifier: 4.2.2
         version: 4.2.2
       '@types/node':
-        specifier: 25.9.1
-        version: 25.9.1
+        specifier: 24.12.4
+        version: 24.12.4
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
@@ -3808,8 +3808,8 @@ packages:
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -6705,8 +6705,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -11488,7 +11488,7 @@ snapshots:
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 25.9.1
+      '@types/node': 24.12.4
 
   '@types/json-schema@7.0.15': {}
 
@@ -11496,9 +11496,9 @@ snapshots:
 
   '@types/minimatch@5.1.2': {}
 
-  '@types/node@25.9.1':
+  '@types/node@24.12.4':
     dependencies:
-      undici-types: 7.24.6
+      undici-types: 7.16.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -11510,7 +11510,7 @@ snapshots:
 
   '@types/resolve@1.17.1':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.12.4
 
   '@types/rss@0.0.32': {}
 
@@ -13291,13 +13291,13 @@ snapshots:
 
   jest-worker@26.6.2:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.12.4
       merge-stream: 2.0.0
       supports-color: 7.2.0
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.12.4
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -14707,7 +14707,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.24.6: {}
+  undici-types@7.16.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## Summary

The v3.2.0-rc1 tag build failed in the `[linux/arm64 builder]` stage with 37 spurious Prisma schema validation errors. Each affected line is rendered as just its `"` characters (e.g. `\"\"`, `\"\"\"\"`), and the file is unchanged in the repo — this is Prisma 6.19.3's query engine misbehaving under QEMU arm64 emulation on the freshly-released (April 2026, non-LTS) Node 26. linux/amd64 builds the same Dockerfile and same schema cleanly.

Roll back to Node 24 (current Active LTS) and pin `@types/node` to the matching `24.12.4` so the runtime and dev types line up again. Multi-arch image builds were green on Node 22 historically; Node 24 keeps us on a maintained line without re-introducing the issue.

## Test plan

- [ ] `Push And PR Docker Multi-arch Image CI & CD` workflow passes on this PR
- [ ] After merge, a fresh tag (e.g. `v3.2.0-rc2`) triggers `Latest Docker Multi-arch Image CI & CD` and both `linux/amd64` + `linux/arm64` succeed
- [ ] `tsc --noEmit` error count stays at the existing 119 (no new failures from the @types/node change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)