### PR TITLE
feat(images): add image variant pipeline fields (BE-1)

### DIFF
--- a/prisma/migrations/20260530000000_add_image_variant_fields/migration.sql
+++ b/prisma/migrations/20260530000000_add_image_variant_fields/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "images" ADD COLUMN     "image_key" TEXT,
+ADD COLUMN     "variants_ready" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "ready_max_width" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE INDEX "images_variants_ready_del_idx" ON "images"("variants_ready", "del");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,9 @@ model Images {
   preview_url          String?                @db.Text
   video_url            String?                @db.Text
   blurhash             String?                @db.Text
+  image_key            String?                @db.Text
+  variants_ready       Boolean                @default(false)
+  ready_max_width      Int                    @default(0)
   exif                 Json?                  @db.Json
   labels               Json?                  @db.Json
   width                Int                    @default(0)
@@ -35,6 +38,7 @@ model Images {
   del                  Int                    @default(0) @db.SmallInt
   imagesAlbumsRelation ImagesAlbumsRelation[]
 
+  @@index([variants_ready, del])
   @@map("images")
 }
 
@@ -175,23 +179,23 @@ model Passkey {
 }
 
 model AdminTaskRun {
-  id              String    @id @default(cuid()) @db.VarChar(50)
-  taskKey         String    @map("task_key") @db.VarChar(100)
-  status          String    @default("queued") @db.VarChar(50)
-  scope           Json      @db.Json
-  totalCount      Int       @default(0) @map("total_count")
-  processedCount  Int       @default(0) @map("processed_count")
-  successCount    Int       @default(0) @map("success_count")
-  skippedCount    Int       @default(0) @map("skipped_count")
-  failedCount     Int       @default(0) @map("failed_count")
-  nextCursor      String?   @map("next_cursor") @db.VarChar(50)
-  recentIssues    Json      @default("[]") @map("recent_issues") @db.Json
-  lastError       Json?     @map("last_error") @db.Json
-  leaseExpiresAt  DateTime? @map("lease_expires_at") @db.Timestamp
-  startedAt       DateTime? @map("started_at") @db.Timestamp
-  finishedAt      DateTime? @map("finished_at") @db.Timestamp
-  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamp
-  updatedAt       DateTime? @updatedAt @map("updated_at") @db.Timestamp
+  id             String    @id @default(cuid()) @db.VarChar(50)
+  taskKey        String    @map("task_key") @db.VarChar(100)
+  status         String    @default("queued") @db.VarChar(50)
+  scope          Json      @db.Json
+  totalCount     Int       @default(0) @map("total_count")
+  processedCount Int       @default(0) @map("processed_count")
+  successCount   Int       @default(0) @map("success_count")
+  skippedCount   Int       @default(0) @map("skipped_count")
+  failedCount    Int       @default(0) @map("failed_count")
+  nextCursor     String?   @map("next_cursor") @db.VarChar(50)
+  recentIssues   Json      @default("[]") @map("recent_issues") @db.Json
+  lastError      Json?     @map("last_error") @db.Json
+  leaseExpiresAt DateTime? @map("lease_expires_at") @db.Timestamp
+  startedAt      DateTime? @map("started_at") @db.Timestamp
+  finishedAt     DateTime? @map("finished_at") @db.Timestamp
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamp
+  updatedAt      DateTime? @updatedAt @map("updated_at") @db.Timestamp
 
   @@index([taskKey, status])
   @@index([status])

--- a/types/index.ts
+++ b/types/index.ts
@@ -42,6 +42,9 @@ export type ImageType = {
   preview_url: string;
   video_url: string;
   blurhash: string;
+  image_key: string;
+  variants_ready: boolean;
+  ready_max_width: number;
   exif: ExifType;
   labels: any;
   width: number;


### PR DESCRIPTION
## BE-1 — DB variant fields (foundational, unblocks FE-3)

Part of the image-performance overhaul (parent task #1 in #picimpact). This is the foundational schema change the rest of the pipeline + the frontend variant-consumption work depend on.

### What
Adds three columns to `images`:
- **`image_key`** (`TEXT?`) — stable content-addressed base key; all derived variant URLs are built as `{baseKey}_{width}.{avif|webp}`.
- **`variants_ready`** (`bool`, default `false`) — gate flag, flipped to `true` **only after all variants are uploaded** (no half-baked images in the gallery).
- **`ready_max_width`** (`int`, default `0`) — ascending-generation watermark. A tier is ready iff `width <= ready_max_width`, so the frontend can render partial backfill state (soft-but-never-broken) without 404s.

Adds index `(variants_ready, del)` to support the backfill queue scan (`WHERE variants_ready = false AND del = 0`).

### Notes
- **Reuses the existing `blurhash` column** as the placeholder (it already holds a thumbhash-encoded string consumed by `hooks/use-blurhash.ts`) — no duplicate `thumbhash` column added.
- `width`/`height` already exist on the model (used for aspect-ratio placeholders → reduces CLS).
- Gallery queries select `image.*`, so the new fields flow to `ImageType` consumers automatically; `types/index.ts` updated to declare them.

### Test plan
- `prisma validate` + `prisma format` pass.
- Migration is additive only (new nullable/defaulted columns + index) — safe on existing data, no backfill required at migrate time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)