### PR TITLE
fix: mobile infinite-scroll crash loop in InfiniteScroll observer

### DIFF
--- a/components/ui/origin/infinite-scroll.tsx
+++ b/components/ui/origin/infinite-scroll.tsx
@@ -19,29 +19,64 @@ export default function InfiniteScroll({
     className,
 }: InfiniteScrollProps) {
     const observerTarget = useRef<HTMLDivElement>(null)
+    // Keep the latest `next` in a ref so the observer never depends on the
+    // caller's closure identity (callers commonly pass a fresh closure every
+    // render, which previously tore down and recreated the observer each render).
+    const nextRef = useRef(next)
+    // Re-entrancy guard: once an intersection triggers a load we must not fire
+    // `next()` again until new data has actually arrived (i.e. loading settles).
+    const loadingRef = useRef(isLoading)
+    const requestedRef = useRef(false)
 
+    // Keep the ref pointing at the latest callback without re-creating the
+    // observer (writing to a ref must happen in an effect, not during render).
     useEffect(() => {
-        const observer = new IntersectionObserver(
-            (entries) => {
-                if (entries[0]?.isIntersecting && hasMore && !isLoading) {
-                    next()
-                }
-            },
-            { threshold: 1.0 }
-        )
+        nextRef.current = next
+    }, [next])
 
-        if (observerTarget.current) {
-            observer.observe(observerTarget.current)
+    // Reset the in-flight guard whenever a load completes, so the next
+    // intersection is allowed to request another page.
+    useEffect(() => {
+        if (!isLoading) {
+            requestedRef.current = false
+        }
+        loadingRef.current = isLoading
+    }, [isLoading])
+
+    // Create the observer once. It only depends on `hasMore` so the sentinel is
+    // re-observed when there is more data to load, but it is immune to changes
+    // in `next`'s identity or to `isLoading` flapping (e.g. SWR keepPreviousData).
+    useEffect(() => {
+        const target = observerTarget.current
+        if (!target) {
+            return
         }
 
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (
+                    entries[0]?.isIntersecting &&
+                    hasMore &&
+                    !loadingRef.current &&
+                    !requestedRef.current
+                ) {
+                    requestedRef.current = true
+                    nextRef.current()
+                }
+            },
+            { threshold: 0, rootMargin: '200px 0px' }
+        )
+
+        observer.observe(target)
+
         return () => observer.disconnect()
-    }, [hasMore, isLoading, next])
+    }, [hasMore])
 
     return (
         <div className={className}>
             {children}
-            <div ref={observerTarget} className="h-4 w-full flex items-center justify-center mt-4">
-                {isLoading && <ReloadIcon className="h-4 w-4 animate-spin" />}
+            <div ref={observerTarget} className='h-4 w-full flex items-center justify-center mt-4'>
+                {isLoading && <ReloadIcon className='h-4 w-4 animate-spin' />}
             </div>
         </div>
     )


### PR DESCRIPTION
## Problem
Opening the gallery on mobile enters a crash / infinite pagination loop.

## Root cause
`components/ui/origin/infinite-scroll.tsx` listed `next` in the IntersectionObserver effect's dependency array. Callers pass a freshly-created closure every render (e.g. `next={() => setSize(size + 1)}` in the gallery themes), so the observer's identity changed each render and the effect tore down + recreated the observer on every render. On short mobile pages the sentinel stayed within the viewport and `threshold: 1.0` kept firing -> `next()` -> state update -> re-render -> new `next` -> observer recreated -> fires again -> runaway loop. SWR `keepPreviousData` made `isValidating` flap, worsening it.

## Fix (internal only — no caller files touched, public API unchanged)
- Hold `next` in a `nextRef` updated via effect; the observer calls `nextRef.current()` and no longer depends on `next`'s identity.
- The observer effect now depends only on `hasMore`, so it is created once and re-created only when there is genuinely more/no more data to load.
- Added a re-entrancy guard (`requestedRef`) plus a `loadingRef` so a single intersection triggers at most one `next()` until new data has actually arrived.
- Lowered `threshold` 1.0 -> 0 and added `rootMargin: '200px 0px'` so the sentinel is not permanently intersecting and prefetches smoothly.

Desktop behavior is unchanged; the only observable difference is slightly earlier prefetch via rootMargin.

## Verification
- `pnpm install` — ok
- `pnpm lint` — 0 errors (186 pre-existing warnings in unrelated files; none in this file)
- `npx tsc --noEmit` — no new type errors introduced. Pre-existing errors remain in unrelated files (prisma client not generated, `react-resizable-panels` typings, unused vars in `template-gallery.tsx`/`tag-gallery.tsx`); confirmed present on the clean base tree. The repo also has `ignoreBuildErrors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)