### PR TITLE
feat: serve responsive image variants in the gallery (fix 20MB-original lag)

### DIFF
--- a/components/gallery/masonry-photo-item.tsx
+++ b/components/gallery/masonry-photo-item.tsx
@@ -8,19 +8,46 @@ import { Aperture, Timer, Focus, Disc3 } from 'lucide-react'
 import { useBlurImageDataUrl, DEFAULT_HASH } from '~/hooks/use-blurhash'
 import { Skeleton } from '~/components/ui/skeleton'
 import { useState } from 'react'
+import { hasReadyVariants, makeVariantLoader } from '~/lib/image/loader'
+import { useAvifSupport } from '~/hooks/use-avif-support'
 
-export default function MasonryPhotoItem({ photo, width }: { photo: ImageType, width?: number }) {
+export default function MasonryPhotoItem({ photo, width, variantBaseUrl = '' }: { photo: ImageType, width?: number, variantBaseUrl?: string }) {
   const router = useRouter()
   const dataURL = useBlurImageDataUrl(photo.blurhash)
-  const preferredSrc = photo.preview_url || photo.url
-  const [imgSrc, setImgSrc] = useState(preferredSrc)
+  const avifOk = useAvifSupport()
   const [isLoading, setIsLoading] = useState(true)
+  // If a (supposedly ready) variant fails to load, fall back down the ladder
+  // rather than retrying the variant forever.
+  const [variantFailed, setVariantFailed] = useState(false)
 
   const exif = photo.exif
   const hasExif = exif && (exif.focal_length || exif.f_number || exif.exposure_time || exif.iso_speed_rating)
   const aspectRatio = photo.width > 0 && photo.height > 0 ? photo.width / photo.height : 1
-  const isUsingPreview = !!photo.preview_url && imgSrc === photo.preview_url
   const hasRealBlurhash = !!photo.blurhash && photo.blurhash !== DEFAULT_HASH
+
+  // Image source ladder — the grid must NEVER load the full-resolution original
+  // (the multi-MB photos that tank scrolling). In order:
+  //   1. responsive variants via the custom CDN loader (bypasses /_next/image),
+  //   2. the small preview thumbnail (unoptimized — it is already sized),
+  //   3. nothing → the blurhash placeholder stays as the final visible state.
+  const variantReady = !variantFailed && hasReadyVariants(photo.image_key, photo.ready_max_width, variantBaseUrl)
+  const previewSrc = photo.preview_url || ''
+  const imageProps = variantReady
+    ? {
+        src: photo.image_key,
+        loader: makeVariantLoader({
+          base: variantBaseUrl,
+          imageKey: photo.image_key,
+          readyMaxWidth: photo.ready_max_width,
+          format: (avifOk ? 'avif' : 'webp') as 'avif' | 'webp',
+        }),
+      }
+    : previewSrc
+      ? { src: previewSrc, unoptimized: true }
+      : null
+  // No servable image (un-backfilled row without a preview, e.g. OpenList) →
+  // show the decoded blurhash itself instead of a perpetual loading skeleton.
+  const blurhashOnly = !imageProps && hasRealBlurhash
   // When rendered inside the virtualized masonry, masonic supplies the column
   // width and measures item height. Deriving an explicit pixel height from the
   // known aspect ratio lets masonic position items immediately and stably
@@ -44,7 +71,7 @@ export default function MasonryPhotoItem({ photo, width }: { photo: ImageType, w
         }
       }}
     >
-      {isLoading && (
+      {imageProps && isLoading && (
         <Skeleton
           className={cn(
             'absolute inset-0 z-10 rounded-none',
@@ -54,28 +81,40 @@ export default function MasonryPhotoItem({ photo, width }: { photo: ImageType, w
           )}
         />
       )}
-      <Image
-        className={cn(
-          'object-cover transition-transform duration-500 group-hover:scale-105',
-          isLoading && !hasRealBlurhash && 'animate-pulse'
-        )}
-        src={imgSrc}
-        alt={photo.detail || photo.title || ''}
-        fill
-        sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
-        loading="lazy"
-        unoptimized={isUsingPreview}
-        placeholder={hasRealBlurhash ? 'blur' : 'empty'}
-        blurDataURL={dataURL}
-        onLoad={() => setIsLoading(false)}
-        onError={() => {
-          if (photo.preview_url && imgSrc !== photo.url) {
-            setImgSrc(photo.url)
-            return
-          }
-          setIsLoading(false)
-        }}
-      />
+      {imageProps ? (
+        <Image
+          {...imageProps}
+          key={variantReady ? 'variant' : 'preview'}
+          className={cn(
+            'object-cover transition-transform duration-500 group-hover:scale-105',
+            isLoading && !hasRealBlurhash && 'animate-pulse'
+          )}
+          alt={photo.detail || photo.title || ''}
+          fill
+          sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
+          loading="lazy"
+          placeholder={hasRealBlurhash ? 'blur' : 'empty'}
+          blurDataURL={dataURL}
+          onLoad={() => setIsLoading(false)}
+          onError={() => {
+            // A ready variant failed → step down the ladder (preview/blurhash);
+            // never escalate to the full original in the grid.
+            if (variantReady) {
+              setVariantFailed(true)
+              return
+            }
+            setIsLoading(false)
+          }}
+        />
+      ) : blurhashOnly ? (
+        <div
+          aria-hidden
+          className="absolute inset-0 bg-cover bg-center"
+          style={{ backgroundImage: `url(${dataURL})` }}
+        />
+      ) : (
+        <Skeleton className="absolute inset-0 rounded-none bg-accent/80" />
+      )}
       {/* Hover gradient overlay */}
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
       {/* Hover content */}

--- a/components/gallery/simple/gallery-image.tsx
+++ b/components/gallery/simple/gallery-image.tsx
@@ -8,15 +8,26 @@ import { MotionImage } from '~/components/album/motion-image'
 import { Skeleton } from '~/components/ui/skeleton'
 import { useState } from 'react'
 import { Badge } from '~/components/ui/badge.tsx'
+import { hasReadyVariants, makeVariantLoader } from '~/lib/image/loader'
+import { useAvifSupport } from '~/hooks/use-avif-support'
 
 export default function GalleryImage({
   photo,
   customIndexOriginEnable,
+  variantBaseUrl = '',
 }: {
   photo: ImageType
   customIndexOriginEnable: boolean
+  variantBaseUrl?: string
 }) {
   const router = useRouter()
+  const avifOk = useAvifSupport()
+  const [variantFailed, setVariantFailed] = useState(false)
+  // When variants are ready they take precedence for in-feed display (small,
+  // fast, never the multi-MB original). The legacy preferred/fallback ladder
+  // (which honours the customIndexOriginEnable opt-in to show originals) only
+  // applies when no variant is available yet.
+  const variantReady = !variantFailed && hasReadyVariants(photo.image_key, photo.ready_max_width, variantBaseUrl)
   const preferredSrc = customIndexOriginEnable ? photo.url || photo.preview_url : photo.preview_url || photo.url
   const fallbackSrc = customIndexOriginEnable ? photo.preview_url || photo.url : photo.url || photo.preview_url
   const [imgSrc, setImgSrc] = useState(preferredSrc)
@@ -67,30 +78,56 @@ export default function GalleryImage({
             )}
           />
         )}
-        <MotionImage
-          key={imgSrc}
-          className={cn('w-full h-auto', isLoading && !hasRealBlurhash && 'animate-pulse')}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.5 }}
-          src={imgSrc}
-          overrideSrc={imgSrc}
-          alt={photo.title}
-          width={photo.width}
-          height={photo.height}
-          loading="lazy"
-          unoptimized={useUnoptimized}
-          placeholder={hasRealBlurhash ? 'blur' : 'empty'}
-          blurDataURL={dataURL}
-          onLoad={() => setIsLoading(false)}
-          onError={() => {
-            if (hasFallbackSrc && imgSrc !== fallbackSrc) {
-              setImgSrc(fallbackSrc)
-              return
-            }
-            setIsLoading(false)
-          }}
-        />
+        {variantReady ? (
+          <MotionImage
+            key="variant"
+            className={cn('w-full h-auto', isLoading && !hasRealBlurhash && 'animate-pulse')}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5 }}
+            src={photo.image_key}
+            alt={photo.title}
+            width={photo.width}
+            height={photo.height}
+            sizes="(min-width: 768px) 75vw, 100vw"
+            loading="lazy"
+            loader={makeVariantLoader({
+              base: variantBaseUrl,
+              imageKey: photo.image_key,
+              readyMaxWidth: photo.ready_max_width,
+              format: (avifOk ? 'avif' : 'webp') as 'avif' | 'webp',
+            })}
+            placeholder={hasRealBlurhash ? 'blur' : 'empty'}
+            blurDataURL={dataURL}
+            onLoad={() => setIsLoading(false)}
+            onError={() => setVariantFailed(true)}
+          />
+        ) : (
+          <MotionImage
+            key={imgSrc}
+            className={cn('w-full h-auto', isLoading && !hasRealBlurhash && 'animate-pulse')}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.5 }}
+            src={imgSrc}
+            overrideSrc={imgSrc}
+            alt={photo.title}
+            width={photo.width}
+            height={photo.height}
+            loading="lazy"
+            unoptimized={useUnoptimized}
+            placeholder={hasRealBlurhash ? 'blur' : 'empty'}
+            blurDataURL={dataURL}
+            onLoad={() => setIsLoading(false)}
+            onError={() => {
+              if (hasFallbackSrc && imgSrc !== fallbackSrc) {
+                setImgSrc(fallbackSrc)
+                return
+              }
+              setIsLoading(false)
+            }}
+          />
+        )}
         {photo.type === 2 && (
           <div className="absolute top-2 left-2 p-5 rounded-full">
             <svg xmlns="http://www.w3.org/2000/svg" className="absolute bottom-3 right-3 text-white opacity-75 z-10"

--- a/components/layout/theme/default/default-gallery.tsx
+++ b/components/layout/theme/default/default-gallery.tsx
@@ -3,20 +3,15 @@
 import type { ImageHandleProps } from '~/types/props.ts'
 import useSWRInfinite from 'swr/infinite'
 import useSWR from 'swr'
+import { useSwrHydrated } from '~/hooks/use-swr-hydrated.ts'
 import { useTranslations } from 'next-intl'
-import type { ImageType } from '~/types'
+import type { GalleryDisplayConfig, ImageType } from '~/types'
 import { useState, useCallback, useEffect, useRef, useMemo, useTransition } from 'react'
 import MasonryPhotoItem from '~/components/gallery/masonry-photo-item'
 import VirtualMasonry from '~/components/gallery/virtual-masonry.tsx'
 import InfiniteScroll from '~/components/ui/origin/infinite-scroll.tsx'
 import FloatingFilterBall from '~/components/album/floating-filter-ball.tsx'
 import { Skeleton } from '~/components/ui/skeleton'
-
-// masonic render adapter: receives the column width and the item data, and
-// renders the shared masonry photo item sized to that column.
-function MasonryRender({ data, width }: { index: number, data: ImageType, width: number }) {
-  return <MasonryPhotoItem photo={data} width={width} />
-}
 
 // Responsive column count matching the previous Tailwind breakpoints
 // (columns-2 / sm:columns-3 / lg:columns-4 / xl:columns-5).
@@ -106,12 +101,32 @@ export default function DefaultGallery(props : Readonly<ImageHandleProps>) {
     }
   )
 
+  // Public display config (carries the variant CDN base url, when configured).
+  const emptyConfig: GalleryDisplayConfig = {
+    customIndexDownloadEnable: false,
+    customIndexOriginEnable: false,
+  }
+  const { data: configData } = useSwrHydrated<GalleryDisplayConfig>({
+    handle: props.configHandle ?? (async () => emptyConfig),
+    args: 'system-config',
+  })
+  const variantBaseUrl = configData?.variantBaseUrl ?? ''
+
   // Memoize dataList to avoid unnecessary recalculations
   const dataList = useMemo(() => data?.flat() ?? [], [data])
   const showInitialSkeleton = dataList.length === 0 && isValidating
   const isPaginating = isValidating && dataList.length > 0
   const columnCount = useResponsiveColumnCount()
   const t = useTranslations()
+
+  // masonic render adapter: receives the column width and item data, renders the
+  // shared photo item sized to that column. Memoized on `variantBaseUrl` so
+  // masonic keeps a stable render-component identity (avoids remounting items).
+  const RenderItem = useMemo(() => {
+    return function RenderItem({ data, width }: { index: number, data: ImageType, width: number }) {
+      return <MasonryPhotoItem photo={data} width={width} variantBaseUrl={variantBaseUrl} />
+    }
+  }, [variantBaseUrl])
 
   // Reset pagination when debounced filters change - SWR key change will auto-refetch
   const prevFiltersRef = useRef({ camera: '', lens: '' })
@@ -165,7 +180,7 @@ export default function DefaultGallery(props : Readonly<ImageHandleProps>) {
           <VirtualMasonry
             className="px-1 sm:px-2"
             items={dataList}
-            render={MasonryRender}
+            render={RenderItem}
             columnGutter={4}
             columnCount={columnCount}
             overscanBy={2}

--- a/components/layout/theme/simple/simple-gallery.tsx
+++ b/components/layout/theme/simple/simple-gallery.tsx
@@ -58,13 +58,14 @@ export default function SimpleGallery(props: Readonly<ImageHandleProps>) {
     () => configData?.customIndexOriginEnable === true,
     [configData]
   )
+  const variantBaseUrl = configData?.variantBaseUrl ?? ''
   // masonic render adapter (single column vertical feed). Memoized on the
-  // config flag so masonic keeps a stable render-component identity.
+  // config flags so masonic keeps a stable render-component identity.
   const SimpleRender = useMemo(() => {
     return function SimpleRender({ data }: { index: number, data: ImageType, width: number }) {
-      return <GalleryImage photo={data} customIndexOriginEnable={customIndexOriginEnable} />
+      return <GalleryImage photo={data} customIndexOriginEnable={customIndexOriginEnable} variantBaseUrl={variantBaseUrl} />
     }
-  }, [customIndexOriginEnable])
+  }, [customIndexOriginEnable, variantBaseUrl])
   const t = useTranslations()
 
   // Debounce filter changes

--- a/hooks/use-avif-support.ts
+++ b/hooks/use-avif-support.ts
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+// 1x1 AVIF test image (canonical feature-detection payload). If a browser can
+// decode this it supports AVIF.
+const AVIF_TEST_IMAGE =
+  'data:image/avif;base64,AAAAIGZ0eXBhdmlmAAAAAGF2aWZtaWYxbWlhZk1BMUIAAADybWV0YQAAAAAAAAAoaGRscgAAAAAAAAAAcGljdAAAAAAAAAAAAAAAAGxpYmF2aWYAAAAADnBpdG0AAAAAAAEAAAAeaWxvYwAAAABEAAABAAEAAAABAAABGgAAAB0AAAAoaWluZgAAAAAAAQAAABppbmZlAgAAAAABAABhdjAxQ29sb3IAAAAAamlwcnAAAABLaXBjbwAAABRpc3BlAAAAAAAAAAEAAAABAAAAEHBpeGkAAAAAAwgICAAAAAxhdjFDgQAMAAAAABNjb2xybmNseAACAAIABoAAAAAXaXBtYQAAAAAAAAABAAEEAQKDBAAAACVtZGF0EgAKCBgABogQEDQgMgkQAAAAB8dSLfI='
+
+// Module-level cache so the detection runs at most once per page load and every
+// gallery item shares the result.
+let cachedSupport: boolean | null = null
+let pendingDetection: Promise<boolean> | null = null
+
+function detectAvifSupport(): Promise<boolean> {
+  if (cachedSupport !== null) {
+    return Promise.resolve(cachedSupport)
+  }
+  if (pendingDetection) {
+    return pendingDetection
+  }
+  pendingDetection = new Promise<boolean>((resolve) => {
+    const img = new globalThis.Image()
+    img.onload = () => {
+      cachedSupport = img.width > 0 && img.height > 0
+      resolve(cachedSupport)
+    }
+    img.onerror = () => {
+      cachedSupport = false
+      resolve(false)
+    }
+    img.src = AVIF_TEST_IMAGE
+  })
+  return pendingDetection
+}
+
+/**
+ * One-time AVIF capability detection shared across the gallery. Optimistically
+ * assumes AVIF (>95% support) until detection settles, then corrects to WebP
+ * for the rare client that can't decode it. The custom image loader reads this
+ * to pick the variant extension — no per-image `<picture>`/onError fallback and
+ * no `Vary: Accept` cache fragmentation on the CDN.
+ */
+export function useAvifSupport(): boolean {
+  const [supported, setSupported] = useState<boolean>(cachedSupport ?? true)
+
+  useEffect(() => {
+    let active = true
+    detectAvifSupport().then((ok) => {
+      if (active) {
+        setSupported(ok)
+      }
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return supported
+}

--- a/lib/image/loader.ts
+++ b/lib/image/loader.ts
@@ -1,0 +1,80 @@
+/**
+ * Client-side responsive variant URL builder for the gallery's custom
+ * next/image loader.
+ *
+ * IMPORTANT: this MUST stay in sync with `server/lib/image-variants.ts`
+ * (`VARIANT_TIER_WIDTHS` + `buildVariantKey`). That module is `server-only`
+ * (it imports sharp), so the naming convention is mirrored here as the single
+ * client-side source of truth. Any change to the tier ladder or the
+ * `{baseKey}_{width}.{format}` key shape must be made in both files.
+ */
+
+export const VARIANT_TIER_WIDTHS = [320, 480, 640, 800, 1080, 1280, 1920, 2560] as const
+
+export type VariantFormat = 'avif' | 'webp'
+
+/**
+ * Round a requested render width up to the nearest generated tier, clamped to
+ * the largest tier. Every width next/image asks the loader for therefore maps
+ * onto a width we actually generated.
+ */
+export function ceilToTier(width: number): number {
+  for (const tier of VARIANT_TIER_WIDTHS) {
+    if (width <= tier) {
+      return tier
+    }
+  }
+  return VARIANT_TIER_WIDTHS[VARIANT_TIER_WIDTHS.length - 1]
+}
+
+/** Variant object key `{baseKey}_{width}.{format}` — mirrors `buildVariantKey`. */
+export function buildVariantKey(baseKey: string, width: number, format: VariantFormat): string {
+  return `${baseKey}_${width}.${format}`
+}
+
+function joinUrl(base: string, key: string): string {
+  return `${base.replace(/\/+$/, '')}/${key}`
+}
+
+/**
+ * Whether a photo has variants that can be served right now. Defensive against
+ * the loose `image_key: string` type — existing rows and just-uploaded rows
+ * that the preprocessing queue has not reached yet carry `image_key === ''`
+ * (or null) and `ready_max_width === 0`, which must degrade to a placeholder
+ * rather than request a non-existent object.
+ */
+export function hasReadyVariants(
+  imageKey: string | null | undefined,
+  readyMaxWidth: number,
+  base: string | null | undefined,
+): boolean {
+  return Boolean(base) && Boolean(imageKey) && readyMaxWidth > 0
+}
+
+interface VariantLoaderOptions {
+  /** Public root for variant objects (no trailing slash needed), from server config. */
+  base: string
+  /** Content-addressed base key from the DB (`image_key`), e.g. `variants/<digest>`. */
+  imageKey: string
+  /**
+   * Monotonic readiness watermark: a tier is available iff its width is
+   * `<= readyMaxWidth`. Always equals a generated tier value, so clamping a
+   * tier to it always yields a generated tier.
+   */
+  readyMaxWidth: number
+  format: VariantFormat
+}
+
+/**
+ * Build a next/image-compatible loader bound to one photo's variant state. The
+ * requested width is rounded up to a tier and then clamped to the readiness
+ * watermark, so during backfill we may temporarily serve a slightly softer tier
+ * but never request an ungenerated object (no 404 / origin miss). The returned
+ * URL points straight at the CDN-hosted variant, bypassing `/_next/image`.
+ */
+export function makeVariantLoader(opts: VariantLoaderOptions) {
+  return ({ width }: { src: string, width: number, quality?: number }): string => {
+    const tier = Math.min(ceilToTier(width), opts.readyMaxWidth)
+    return joinUrl(opts.base, buildVariantKey(opts.imageKey, tier, opts.format))
+  }
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -149,4 +149,10 @@ export type GalleryDisplayConfig = {
   customTitle?: string
   customIndexDownloadEnable: boolean
   customIndexOriginEnable: boolean
+  // Public root (no trailing slash, folder already included) for responsive
+  // image variants. Populated server-side from the configured variant storage
+  // backend. Empty/undefined → the gallery loader stays dormant and degrades to
+  // the preview thumbnail / blurhash placeholder (e.g. OpenList-backed images,
+  // or before the preprocessing backfill has run).
+  variantBaseUrl?: string
 }


### PR DESCRIPTION
## Problem
The gallery loaded multi-MB **originals** in the grid (problem ⑤), tanking scroll/interaction. The fix: consume the responsive variants (BE-1 schema + BE-2 generator + BE-3 backfill) on the client, and **never load the original in the grid**.

## What this does
- **`lib/image/loader.ts`** — pure, client-safe variant URL builder. Mirrors the server's `buildVariantKey` + tier ladder `[320,480,640,800,1080,1280,1920,2560]` (that module is `server-only`). `ceilToTier(width)` then clamps to `ready_max_width`, building `{variantBaseUrl}/{image_key}_{w}.{fmt}`. Used as a per-component next/image **`loader` prop**, so it routes straight to the CDN variant and **bypasses `/_next/image`** (image bytes never funnel through the app server).
- **`hooks/use-avif-support.ts`** — one-time AVIF capability detection (optimistic avif → corrects to webp). The loader picks the extension globally → no per-image `<picture>`/`onError`, no `Vary: Accept` cache fragmentation.
- **`GalleryDisplayConfig.variantBaseUrl`** (optional) — populated server-side from the variant-storage config (BE-4). Empty/undefined → loader dormant.
- **Degradation ladder** in `masonry-photo-item` (default) + `gallery-image` (simple): `variant srcset → preview thumbnail → blurhash placeholder`. The grid **never** loads `photo.url` (removed the prior `onError → photo.url` escalation). Null-safe per Review: `image_key === ''` / `ready_max_width === 0` → placeholder only (existing rows, OpenList-backed images).
- **`default-gallery` / `simple-gallery`** thread `variantBaseUrl` via `configHandle`.

## Scope
Covers the virtualized **default + simple** themes (matching FE-2). `polaroid`/`template`/`tag` deferred. Activates automatically as the BE-3 backfill advances `ready_max_width`; safe to merge before backfill (variant path stays dormant, degrades to today's preview/blurhash, minus the 20MB original fallback).

## Verification
- `pnpm lint` — 0 errors (pre-existing warnings only).
- `npx tsc --noEmit` — no new errors in FE-3 files.
- `pnpm build` — compiles successfully (all routes emitted, incl. `/[...album]`, `/preview/[...id]`).

## Interface contract (locked with BE)
`buildVariantKey`=`{key}_{w}.{fmt}`, tiers as above, `ready_max_width` always equals a generated tier, `variantBaseUrl` already includes the storage folder. BE-4 populates `variantBaseUrl` in `getDisplayConfig`/`getAlbumDisplayConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)