### PR TITLE
fix: invalid hsl(oklch) color in sidebar rail box-shadow

### DIFF
--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -487,7 +487,7 @@ const sidebarMenuButtonVariants = cva(
       variant: {
         default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
         outline:
-          'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
+          'bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]',
       },
       size: {
         default: 'h-8 text-sm',


### PR DESCRIPTION
## Problem
The sidebar rail's `outline` variant built its 1px ring with `shadow-[0_0_0_1px_hsl(var(--sidebar-border))]` / `hsl(var(--sidebar-accent))`. But `--sidebar-border` / `--sidebar-accent` are **OKLCH** values (`style/globals.css`), so `hsl()` can't parse them — the browser discards the box-shadow and the ring never renders (same bug class fixed for `--primary` in #472).

## Fix
Use the tokens directly: `var(--sidebar-border)` / `var(--sidebar-accent)`.

## Verification
`pnpm lint` — 0 errors. Single-line className change; no behavioral/type impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)