### PR TITLE
perf: bound the thumbhash decode cache with an LRU

### DIFF
--- a/hooks/use-blurhash.ts
+++ b/hooks/use-blurhash.ts
@@ -7,16 +7,31 @@ export const DEFAULT_HASH = 'MggCBoBxh4d/eHeIiIiHd3eIAAAAAAA='
 // Decoding runs a canvas/Uint8Array conversion per call, so caching avoids
 // re-decoding the same hash on every remount/reuse (e.g. virtualization
 // recycling items in and out of the viewport).
+//
+// Bounded as an LRU so a long browsing session over many distinct photos can't
+// grow it without limit. A Map preserves insertion order, so the first key is
+// the least-recently-used; re-inserting on a hit keeps hot entries at the back.
+const DECODED_CACHE_LIMIT = 512
 const decodedCache = new Map<string, string>()
 
 function getDecodedDataUrl(hash: string): string {
   const key = !hash || hash === '' ? DEFAULT_HASH : hash
   const cached = decodedCache.get(key)
   if (cached !== undefined) {
+    // Mark as most-recently-used.
+    decodedCache.delete(key)
+    decodedCache.set(key, cached)
     return cached
   }
   const decoded = decodeThumbHash(key)
   decodedCache.set(key, decoded)
+  if (decodedCache.size > DECODED_CACHE_LIMIT) {
+    // Evict the least-recently-used entry (the oldest key).
+    const oldest = decodedCache.keys().next().value
+    if (oldest !== undefined) {
+      decodedCache.delete(oldest)
+    }
+  }
   return decoded
 }
 


### PR DESCRIPTION
## Problem
`use-blurhash`'s module-level `decodedCache` Map was **unbounded** (Review minor on FE-2 #474). A long session browsing many distinct photos could grow it without limit.

## Fix
Cap at 512 entries with simple LRU eviction — `Map` insertion order is LRU order: re-insert on a cache hit to keep hot entries at the back, drop the oldest key once past the cap. Thumbhash data URLs are small, so 512 is ample.

## Verification
`pnpm lint` — 0 errors. `tsc --noEmit` — no errors in `use-blurhash.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)