### PR TITLE
feat: serve image variants in the tag gallery (no original in grid)

### DIFF
--- a/app/(default)/tag/[...tag]/page.tsx
+++ b/app/(default)/tag/[...tag]/page.tsx
@@ -1,5 +1,6 @@
 import type { ImageHandleProps } from '~/types/props'
 import { fetchClientImagesListByTag, fetchClientImagesPageTotalByTag } from '~/server/db/query/images'
+import { getDisplayConfig } from '~/server/actions/images'
 import TagGallery from '~/components/album/tag-gallery'
 
 import 'react-photo-album/masonry.css'
@@ -23,6 +24,7 @@ export default async function Label({params}: { params: any }) {
     args: 'getImages-client-tag',
     album: `${decodeURIComponent(tag)}`,
     totalHandle: getPageTotal,
+    configHandle: getDisplayConfig,
   }
 
   return (

--- a/components/album/blur-image.tsx
+++ b/components/album/blur-image.tsx
@@ -6,12 +6,38 @@ import { MotionImage } from '~/components/album/motion-image'
 import { Skeleton } from '~/components/ui/skeleton'
 import { useState } from 'react'
 import { cn } from '~/lib/utils'
+import { hasReadyVariants, makeVariantLoader } from '~/lib/image/loader'
+import { useAvifSupport } from '~/hooks/use-avif-support'
 
-export default function BlurImage({ photo, dataList }: { photo: any, dataList: any }) {
+export default function BlurImage({ photo }: { photo: any }) {
   const router = useRouter()
   const [isLoading, setIsLoading] = useState(true)
+  const avifOk = useAvifSupport()
+  const [variantFailed, setVariantFailed] = useState(false)
 
   const dataURL = useBlurImageDataUrl(photo.blurhash)
+  const hasRealBlurhash = !!photo.blurhash && photo.blurhash !== DEFAULT_HASH
+
+  // Variant ladder (same policy as the main gallery): responsive variant →
+  // preview thumbnail → blurhash. Never the full original in the tag grid.
+  const variantBaseUrl = photo.variantBaseUrl ?? ''
+  const variantReady = !variantFailed && hasReadyVariants(photo.image_key, photo.ready_max_width, variantBaseUrl)
+  const previewSrc = photo.preview_url || ''
+  const imageProps = variantReady
+    ? {
+        src: photo.image_key,
+        sizes: '(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw',
+        loader: makeVariantLoader({
+          base: variantBaseUrl,
+          imageKey: photo.image_key,
+          readyMaxWidth: photo.ready_max_width,
+          format: (avifOk ? 'avif' : 'webp') as 'avif' | 'webp',
+        }),
+      }
+    : previewSrc
+      ? { src: previewSrc, overrideSrc: previewSrc, unoptimized: true }
+      : null
+  const blurhashOnly = !imageProps && hasRealBlurhash
 
   return (
     <div
@@ -25,27 +51,45 @@ export default function BlurImage({ photo, dataList }: { photo: any, dataList: a
       }}
       className="relative inline-block select-none shadow-sm transition-transform duration-500 ease-out hover:scale-[1.02]">
       {
-        isLoading && (
+        imageProps && isLoading && (
           <Skeleton className="absolute inset-0 z-10 rounded-none" />
         )
       }
-      <MotionImage
-        className={cn('cursor-pointer', isLoading && 'animate-pulse')}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.5 }}
-        src={photo.src}
-        overrideSrc={photo.src}
-        alt={photo.alt || 'Photo'}
-        width={photo.width}
-        height={photo.height}
-        loading="lazy"
-        unoptimized={!!photo.preview_url}
-        placeholder={(photo.blurhash === DEFAULT_HASH || !photo.blurhash) ? 'empty' : 'blur'}
-        blurDataURL={dataURL}
-        onClick={() => router.push(`/preview/${photo?.id}`)}
-        onLoad={() => setIsLoading(false)}
-      />
+      {imageProps ? (
+        <MotionImage
+          {...imageProps}
+          key={variantReady ? 'variant' : 'preview'}
+          className={cn('cursor-pointer', isLoading && 'animate-pulse')}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.5 }}
+          alt={photo.alt || 'Photo'}
+          width={photo.width}
+          height={photo.height}
+          loading="lazy"
+          placeholder={hasRealBlurhash ? 'blur' : 'empty'}
+          blurDataURL={dataURL}
+          onClick={() => router.push(`/preview/${photo?.id}`)}
+          onLoad={() => setIsLoading(false)}
+          onError={() => {
+            // A ready variant failed → fall to preview/blurhash, never the original.
+            if (variantReady) {
+              setVariantFailed(true)
+              return
+            }
+            setIsLoading(false)
+          }}
+        />
+      ) : blurhashOnly ? (
+        <div
+          aria-hidden
+          className="bg-cover bg-center"
+          style={{ backgroundImage: `url(${dataURL})`, width: photo.width, height: photo.height, maxWidth: '100%' }}
+          onClick={() => router.push(`/preview/${photo?.id}`)}
+        />
+      ) : (
+        <Skeleton style={{ width: photo.width, height: photo.height, maxWidth: '100%' }} className="rounded-none" />
+      )}
       {
         photo.type === 2 &&
         <div className="absolute top-2 left-2 p-5 rounded-full">

--- a/components/album/tag-gallery.tsx
+++ b/components/album/tag-gallery.tsx
@@ -3,9 +3,10 @@
 import type { ImageHandleProps } from '~/types/props'
 import { useSwrPageTotalHook } from '~/hooks/use-swr-page-total-hook'
 import useSWRInfinite from 'swr/infinite'
+import { useSwrHydrated } from '~/hooks/use-swr-hydrated'
 import { useTranslations } from 'next-intl'
 import { MasonryPhotoAlbum, RenderImageContext, RenderImageProps } from 'react-photo-album'
-import type { ImageType } from '~/types'
+import type { GalleryDisplayConfig, ImageType } from '~/types'
 import { ReloadIcon } from '@radix-ui/react-icons'
 import { Button } from '~/components/ui/button'
 import BlurImage from '~/components/album/blur-image'
@@ -17,10 +18,9 @@ import { AnimatedIconTrigger, mergeAnimatedTriggerProps } from '~/components/ico
 function renderNextImage(
   _: RenderImageProps,
   { photo }: RenderImageContext,
-  dataList: never[],
 ) {
   return (
-    <BlurImage photo={photo} dataList={dataList} />
+    <BlurImage photo={photo} />
   )
 }
 
@@ -37,6 +37,15 @@ export default function TagGallery(props : Readonly<ImageHandleProps>) {
       revalidateIfStale: false,
       revalidateOnReconnect: false,
     })
+  const emptyConfig: GalleryDisplayConfig = {
+    customIndexDownloadEnable: false,
+    customIndexOriginEnable: false,
+  }
+  const { data: configData } = useSwrHydrated<GalleryDisplayConfig>({
+    handle: props.configHandle ?? (async () => emptyConfig),
+    args: 'system-config',
+  })
+  const variantBaseUrl = configData?.variantBaseUrl ?? ''
   const dataList = data?.flat() ?? []
   const t = useTranslations()
   const router = useRouter()
@@ -60,10 +69,11 @@ export default function TagGallery(props : Readonly<ImageHandleProps>) {
               dataList?.map((item: ImageType) => ({
                 src: item.preview_url || item.url,
                 alt: item.detail,
-                ...item
+                ...item,
+                variantBaseUrl,
               })) || []
             }
-            render={{image: (...args) => renderNextImage(...args, dataList)}}
+            render={{image: (...args) => renderNextImage(...args)}}
           />
         </div>
         <div className="order-1 sm:order-3 flex flex-wrap justify-center space-x-2 sm:space-x-0 sm:flex-col flex-1 px-2 py-1 sm:py-0 sm:space-y-1 text-gray-500 sm:sticky top-2 self-start">


### PR DESCRIPTION
## Problem
The tag gallery loaded `preview_url || url` — falling back to the multi-MB **original** when a preview was missing (problem ⑤), and it had no variant path. The main gallery (FE-3) already avoids this.

## What this does
- **tag page** passes `configHandle: getDisplayConfig` so `variantBaseUrl` reaches the client; **tag-gallery** threads it onto each react-photo-album photo object.
- **BlurImage** (used only by the tag gallery) gains the FE-3 variant ladder: **responsive variant via the custom CDN loader → preview thumbnail → blurhash placeholder**. The tag grid **never** loads the full original (removed the `preview_url || url → original` fallback). Null-safe: `image_key === ''` / `ready_max_width === 0` → placeholder only.
- Dropped the vestigial unused `dataList` threading (clears pre-existing `TS6133` + `never[]` mismatch in these files).

## Behaviour
Dormant/safe until BE-4 populates `variantBaseUrl` + the backfill advances `ready_max_width`; degrades to preview/blurhash otherwise (minus the original fallback). Reuses `lib/image/loader.ts` + `useAvifSupport` from FE-3.

## Verification
- `pnpm lint` — 0 errors.
- `npx tsc --noEmit` — no errors in the touched files (also fixed the 2 pre-existing ones).
- `pnpm build` — Compiled successfully; `/tag/[...tag]` emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)