### PR TITLE
feat(settings): add variant storage backend setting (BE-4 follow-up)

### DIFF
--- a/app/admin/settings/storages/page.tsx
+++ b/app/admin/settings/storages/page.tsx
@@ -3,6 +3,7 @@
 import OpenListTabs from '~/components/admin/settings/storages/open-list-tabs.tsx'
 import S3Tabs from '~/components/admin/settings/storages/s3-tabs'
 import R2Tabs from '~/components/admin/settings/storages/r2-tabs'
+import VariantStorageCard from '~/components/admin/settings/storages/variant-storage-card'
 import {
   Tabs,
   TabsContent,
@@ -14,6 +15,8 @@ export default function Storages() {
 
   return (
     <div className="flex flex-col space-y-2 h-full flex-1">
+      {/* Global (cross-backend) choice of where the variant pipeline uploads. */}
+      <VariantStorageCard />
       <Tabs defaultValue="s3">
         <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="s3">S3 API</TabsTrigger>

--- a/components/admin/settings/storages/variant-storage-card.tsx
+++ b/components/admin/settings/storages/variant-storage-card.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import useSWR from 'swr'
+import { toast } from 'sonner'
+import { useTranslations } from 'next-intl'
+import { ReloadIcon } from '@radix-ui/react-icons'
+
+import { Card } from '~/components/ui/card'
+import { Button } from '~/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select'
+import { fetcher } from '~/lib/utils/fetcher'
+import type { VariantStorageInfo } from '~/types'
+
+// Radix Select forbids an empty-string item value, so the "off" option uses a
+// sentinel that maps to '' on save.
+const OFF = 'off'
+type Selection = typeof OFF | 's3' | 'r2'
+
+export default function VariantStorageCard() {
+  const t = useTranslations()
+  const { data, error, isValidating, mutate } = useSWR<VariantStorageInfo>(
+    '/api/v1/settings/variant-storage',
+    fetcher,
+    { revalidateOnFocus: false },
+  )
+  const [selection, setSelection] = useState<Selection>(OFF)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (data) {
+      setSelection(data.variantStorage === 's3' || data.variantStorage === 'r2' ? data.variantStorage : OFF)
+    }
+  }, [data])
+
+  if (error) {
+    toast.error(t('Config.requestFailed'))
+  }
+
+  async function save() {
+    setSaving(true)
+    try {
+      const payload: VariantStorageInfo = { variantStorage: selection === OFF ? '' : selection }
+      await fetch('/api/v1/settings/variant-storage', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      toast.success(t('Config.updateSuccess'))
+      mutate()
+    } catch {
+      toast.error(t('Config.updateFailed'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const isOff = selection === OFF
+
+  return (
+    <Card className="p-4 space-y-3">
+      <div className="flex flex-col gap-1">
+        <h4 className="text-small font-semibold leading-none text-default-600">{t('Config.variantStorageTitle')}</h4>
+        <p className="text-xs text-muted-foreground">{t('Config.variantStorageDesc')}</p>
+      </div>
+      <div className="flex items-center gap-2">
+        <Select value={selection} onValueChange={(value) => setSelection(value as Selection)}>
+          <SelectTrigger className="w-48" aria-label={t('Config.variantStorageTitle')}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={OFF}>{t('Config.variantStorageOff')}</SelectItem>
+            <SelectItem value="s3">S3 API</SelectItem>
+            <SelectItem value="r2">Cloudflare R2</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button className="cursor-pointer" disabled={saving} onClick={save} aria-label={t('Config.submit')}>
+          {saving && <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />}
+          {t('Config.submit')}
+        </Button>
+        <Button
+          variant="outline"
+          className="cursor-pointer"
+          disabled={isValidating}
+          onClick={() => mutate()}
+          aria-label={t('Config.refresh')}
+        >
+          {isValidating && <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />}
+          {t('Config.refresh')}
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {isOff ? t('Config.variantStorageNotEnabled') : t('Config.variantStorageHelper')}
+      </p>
+    </Card>
+  )
+}

--- a/hono/settings.ts
+++ b/hono/settings.ts
@@ -2,15 +2,16 @@ import 'server-only'
 
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
 import { Hono } from 'hono'
-import { updateOpenListConfig, updateCustomInfo, updateR2Config, updateS3Config } from '~/server/db/operate/configs'
+import { updateOpenListConfig, updateCustomInfo, updateR2Config, updateS3Config, updateVariantStorageConfig } from '~/server/db/operate/configs'
 import { normalizeDefaultTheme } from '~/lib/utils/theme'
 import {
   toAdminConfig,
   toCustomInfo,
   toR2Info,
   toS3Info,
+  toVariantStorageInfo,
 } from '~/server/lib/config-transform'
-import type { CustomInfo, OpenListInfo, R2Info, S3Info } from '~/types'
+import type { CustomInfo, OpenListInfo, R2Info, S3Info, VariantStorageInfo } from '~/types'
 import { ok, okEmpty } from '~/hono/_lib/response'
 import { serverError } from '~/hono/_lib/errors'
 
@@ -91,6 +92,25 @@ app.get('/admin-config', async (c) => {
     return ok(c, toAdminConfig(rows))
   } catch (error) {
     throw serverError('Failed to fetch admin config', error)
+  }
+})
+
+app.get('/variant-storage', async (c) => {
+  try {
+    const rows = await fetchConfigsByKeys(['variant_storage'])
+    return ok(c, toVariantStorageInfo(rows))
+  } catch (error) {
+    throw serverError('Failed to fetch variant storage info', error)
+  }
+})
+
+app.put('/variant-storage', async (c) => {
+  try {
+    const body = await c.req.json<VariantStorageInfo>()
+    await updateVariantStorageConfig(body)
+    return okEmpty(c)
+  } catch (e) {
+    throw serverError('Failed', e)
   }
 })
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -378,6 +378,11 @@
     "inputAvatar": "Please enter the avatar URL."
   },
   "Config": {
+    "variantStorageTitle": "Variant storage",
+    "variantStorageDesc": "Storage backend the thumbnail/variant preprocessing pipeline uploads to. Open List is not supported.",
+    "variantStorageOff": "Off",
+    "variantStorageHelper": "Make sure the selected backend is configured in its tab below.",
+    "variantStorageNotEnabled": "Variant pipeline disabled — the gallery falls back to preview/blurhash.",
     "accesskey_id": "Aliyun OSS / AWS S3 AccessKey_ID",
     "accesskey_secret": "Aliyun OSS / AWS S3 AccessKey_Secret",
     "region": "Aliyun OSS / AWS S3 Region, e.g., oss-cn-hongkong",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -378,6 +378,11 @@
     "inputAvatar": "アバターをアップロードしてください"
   },
   "Config": {
+    "variantStorageTitle": "バリアントストレージ",
+    "variantStorageDesc": "サムネイル / バリアント前処理パイプラインのアップロード先ストレージ。Open List は非対応です。",
+    "variantStorageOff": "無効",
+    "variantStorageHelper": "選択したバックエンドを下のタブで事前に設定してください。",
+    "variantStorageNotEnabled": "バリアントパイプラインは無効です — ギャラリーはプレビュー / blurhash にフォールバックします。",
     "accesskey_id": "Aliyun OSS / AWS S3 AccessKey_ID",
     "accesskey_secret": "Aliyun OSS / AWS S3 AccessKey_Secret",
     "region": "Aliyun OSS / AWS S3 Region、例：oss-cn-hongkong",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -378,6 +378,11 @@
     "inputAvatar": "請輸入新的頭像地址。"
   },
   "Config": {
+    "variantStorageTitle": "變體儲存",
+    "variantStorageDesc": "縮圖 / 變體預處理管線上傳的儲存後端。不支援 Open List。",
+    "variantStorageOff": "關閉",
+    "variantStorageHelper": "請先在下方對應分頁設定好該後端。",
+    "variantStorageNotEnabled": "變體管線未啟用 —— 畫廊回退到預覽圖 / 佔位圖。",
     "accesskey_id": "阿里 OSS / AWS S3 AccessKey_ID",
     "accesskey_secret": "阿里 OSS / AWS S3 AccessKey_Secret",
     "region": "阿里 OSS / AWS S3 Region 地域，如：oss-cn-hongkong",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -378,6 +378,11 @@
     "inputAvatar": "请输入新的头像地址。"
   },
   "Config": {
+    "variantStorageTitle": "变体存储",
+    "variantStorageDesc": "缩略图 / 变体预处理管线上传的存储后端。不支持 Open List。",
+    "variantStorageOff": "关闭",
+    "variantStorageHelper": "请先在下方对应标签页配置好该后端。",
+    "variantStorageNotEnabled": "变体管线未启用 —— 画廊回退到预览图 / 占位图。",
     "accesskey_id": "阿里 OSS / AWS S3 AccessKey_ID",
     "accesskey_secret": "阿里 OSS / AWS S3 AccessKey_Secret",
     "region": "阿里 OSS / AWS S3 Region 地域，如：oss-cn-hongkong",

--- a/server/db/operate/configs.ts
+++ b/server/db/operate/configs.ts
@@ -4,7 +4,7 @@
 
 import { db } from '~/server/lib/db'
 import { normalizeDefaultTheme } from '~/lib/utils/theme'
-import type { CustomInfo, R2Info, S3Info, OpenListInfo } from '~/types'
+import type { CustomInfo, R2Info, S3Info, OpenListInfo, VariantStorageInfo } from '~/types'
 
 // The configs table stores everything as text, so boolean values coming from
 // the API layer (real `boolean`) need to be serialised back to 'true' / 'false'
@@ -83,6 +83,19 @@ export async function updateOpenListConfig(configs: OpenListInfo) {
         updated_at = NOW()
     WHERE config_key IN ('open_list_url', 'open_list_token');
   `
+}
+
+/**
+ * 更新变体存储后端配置（预处理管线上传变体的目标：'' | 's3' | 'r2'）。
+ * upsert 以兼容尚未重新 seed 出 `variant_storage` 行的旧实例。
+ */
+export async function updateVariantStorageConfig(payload: VariantStorageInfo) {
+  const value = payload.variantStorage === 's3' || payload.variantStorage === 'r2' ? payload.variantStorage : ''
+  return await db.configs.upsert({
+    where: { config_key: 'variant_storage' },
+    update: { config_value: value, updatedAt: new Date() },
+    create: { config_key: 'variant_storage', config_value: value },
+  })
 }
 
 /**

--- a/server/lib/config-transform.ts
+++ b/server/lib/config-transform.ts
@@ -8,6 +8,7 @@ import type {
   OpenListInfo,
   R2Info,
   S3Info,
+  VariantStorageInfo,
 } from '~/types'
 import { normalizeDefaultTheme } from '~/lib/utils/theme'
 
@@ -110,6 +111,11 @@ export function toOpenListInfo(configs: Config[]): OpenListInfo {
     openListUrl: str(configs, 'open_list_url'),
     openListToken: str(configs, 'open_list_token'),
   }
+}
+
+export function toVariantStorageInfo(configs: Config[]): VariantStorageInfo {
+  const value = str(configs, 'variant_storage')
+  return { variantStorage: value === 's3' || value === 'r2' ? value : '' }
 }
 
 export function toAdminConfig(configs: Config[]): AdminConfig {

--- a/types/index.ts
+++ b/types/index.ts
@@ -115,6 +115,14 @@ export type S3Info = {
   s3DirectDownload: boolean
 }
 
+/**
+ * Which storage backend the image preprocessing pipeline uploads variants to.
+ * Empty string disables the pipeline (gallery falls back to preview/blurhash).
+ */
+export type VariantStorageInfo = {
+  variantStorage: '' | 's3' | 'r2'
+}
+
 export type R2Info = {
   r2AccesskeyId: string
   r2AccesskeySecret: string


### PR DESCRIPTION
## Variant storage backend setting — the admin entry point to enable the variant pipeline

BE-4 (#477) added the `variant_storage` config key + backend resolution, but there was **no admin UI to set it** — so the variant pipeline couldn't be turned on through normal admin flow (@Manjusaka flagged this). This adds the missing entry point. It's the last gate before the variant path (problem ⑤) can activate.

### What
- **UI** — a "Variant storage" card **above** the three storage tabs in `/admin/settings/storages` (it's a cross-backend global choice, not per-tab):
  - `Select`: **Off / S3 / R2** (default Off).
  - Helper line: configure the chosen backend in its tab first.
  - Empty-state note when Off: "Variant pipeline disabled — gallery falls back to preview/blurhash."
- **API** — `GET`/`PUT /api/v1/settings/variant-storage`, `VariantStorageInfo` type, `toVariantStorageInfo` transform, `updateVariantStorageConfig` (uses `upsert` so it works on installs predating the seed key).
- **i18n** — keys added for zh / en / ja / zh-TW.

### Safety
Off keeps the pipeline disabled, matching the loader's dormant preview/blurhash fallback — safe regardless of backfill state. Once set to S3/R2 (with that backend configured) and BE-3 backfill runs, `variantBaseUrl` resolves and the gallery serves variants.

### Design / UX
Placement, control, helper text, empty state, and i18n follow @Picimpact-Design's guidance — requesting her design/a11y/i18n review.

### Verification
- `tsc --noEmit`: no errors in changed files. `eslint --fix`: clean (0 errors). All 4 message JSON files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)