### PR TITLE
feat(api): preprocess-images task endpoints (BE-3 part 3a)

### DIFF
--- a/hono/index.ts
+++ b/hono/index.ts
@@ -7,6 +7,7 @@ import albums from '~/hono/albums'
 import openList from '~/hono/storage/open-list.ts'
 import daily from '~/hono/daily'
 import tasks from '~/hono/tasks'
+import preprocessTasks from '~/hono/preprocess-tasks'
 import backup from '~/hono/backup'
 import { HTTPException } from 'hono/http-exception'
 import { sessionMiddleware } from '~/hono/_lib/context'
@@ -31,6 +32,7 @@ route.route('/albums', albums)
 route.route('/storage/open-list', openList)
 route.route('/daily', daily)
 route.route('/tasks', tasks)
+route.route('/preprocess-tasks', preprocessTasks)
 route.route('/backup', backup)
 
 export default route

--- a/hono/preprocess-tasks.ts
+++ b/hono/preprocess-tasks.ts
@@ -1,0 +1,147 @@
+import 'server-only'
+
+import { Hono } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+
+import {
+  cancelPreprocessTaskRun,
+  createPreprocessTaskRun,
+  getPreprocessTaskPreviewCount,
+  getPreprocessTaskRunDetail,
+  kickPreprocessTaskRun,
+  listPreprocessTaskRuns,
+  tickPreprocessTaskRuns,
+} from '~/server/tasks/image-preprocess-service'
+import { ADMIN_TASK_KEY_PREPROCESS_IMAGES, normalizePreprocessTaskScope } from '~/types/admin-tasks'
+import { ok } from '~/hono/_lib/response'
+import { badRequest, conflict, notFound, serverError } from '~/hono/_lib/errors'
+
+const app = new Hono()
+
+function ensureTaskKey(taskKey: unknown) {
+  if (taskKey !== ADMIN_TASK_KEY_PREPROCESS_IMAGES) {
+    throw badRequest('Unsupported task key')
+  }
+  return taskKey
+}
+
+function getScopeFromQuery(query: Record<string, string | undefined>) {
+  return normalizePreprocessTaskScope({ force: query.force === 'true' })
+}
+
+function getScopeFromBody(body: Record<string, unknown> | null) {
+  return normalizePreprocessTaskScope(body?.scope)
+}
+
+function rethrowTaskError(error: unknown): never {
+  if (error instanceof HTTPException) {
+    throw error
+  }
+
+  const message = error instanceof Error ? error.message : 'Task request failed'
+
+  if (message === 'Another preprocess task is already active') {
+    throw conflict(message)
+  }
+
+  if (message === 'No images matched the selected filters' || message === 'Variant storage backend is not configured') {
+    throw badRequest(message)
+  }
+
+  throw serverError(message, error)
+}
+
+app.get('/preview-count', async (c) => {
+  try {
+    const scope = getScopeFromQuery(c.req.query())
+    const data = await getPreprocessTaskPreviewCount(scope)
+    return ok(c, data)
+  } catch (error) {
+    rethrowTaskError(error)
+  }
+})
+
+app.get('/runs', async (c) => {
+  try {
+    const data = await listPreprocessTaskRuns()
+    return ok(c, data)
+  } catch (error) {
+    rethrowTaskError(error)
+  }
+})
+
+app.get('/runs/:id', async (c) => {
+  try {
+    const data = await getPreprocessTaskRunDetail(c.req.param('id'))
+
+    if (!data) {
+      throw notFound('Task run not found')
+    }
+
+    return ok(c, data)
+  } catch (error) {
+    rethrowTaskError(error)
+  }
+})
+
+app.post('/runs', async (c) => {
+  const body = await c.req.json<Record<string, unknown>>().catch(() => null)
+
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw badRequest('Invalid task request body')
+  }
+
+  try {
+    ensureTaskKey(body.taskKey)
+    const scope = getScopeFromBody(body)
+    const data = await createPreprocessTaskRun(scope)
+
+    if (!data) {
+      throw conflict('Task system is busy, please retry shortly')
+    }
+
+    return ok(c, data)
+  } catch (error) {
+    rethrowTaskError(error)
+  }
+})
+
+app.post('/runs/:id/kick', async (c) => {
+  try {
+    const data = await kickPreprocessTaskRun(c.req.param('id'))
+
+    if (!data) {
+      throw notFound('Task run not found')
+    }
+
+    return ok(c, data)
+  } catch (error) {
+    rethrowTaskError(error)
+  }
+})
+
+app.post('/runs/:id/cancel', async (c) => {
+  try {
+    const data = await cancelPreprocessTaskRun(c.req.param('id'))
+
+    if (!data) {
+      throw notFound('Task run not found')
+    }
+
+    return ok(c, data)
+  } catch (error) {
+    rethrowTaskError(error)
+  }
+})
+
+app.post('/tick', async (c) => {
+  try {
+    const data = await tickPreprocessTaskRuns()
+    return ok(c, data)
+  } catch (error) {
+    console.error('Preprocess task tick failed:', error)
+    rethrowTaskError(error)
+  }
+})
+
+export default app


### PR DESCRIPTION
## BE-3 part 3a — preprocess task API endpoints

Exposes the variant preprocessing queue engine (merged in #481) over the protected `/api/v1/preprocess-tasks` routes, mirroring the existing `/api/v1/tasks` (metadata) endpoints:

`GET /preview-count`, `GET /runs`, `GET /runs/:id`, `POST /runs` (create), `POST /runs/:id/kick`, `POST /runs/:id/cancel`, `POST /tick`.

- Delegates to `server/tasks/image-preprocess-service.ts`.
- Scope carries the `force` flag (`normalizePreprocessTaskScope`).
- Maps service errors to 4xx: "Variant storage backend is not configured" / "Another preprocess task is already active" → 400/409 / "No images matched" → 400.
- Mounted under the v1 (session-protected) group alongside `tasks`.

This is the drivable API that BE-3 **part 3b** (the `/admin/tasks` button) and **part 3c** (the `preprocess:backfill` CLI) will use to create + drain a backfill run, and it's what enables the real end-to-end backfill test once `variant_storage` is set (#483).

### Verification
`tsc --noEmit` + `eslint` clean. Pure additive mirror of the reviewed `hono/tasks.ts` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)