### PR TITLE
fix: check response.ok when saving variant storage setting

### DIFF
--- a/components/admin/settings/storages/variant-storage-card.tsx
+++ b/components/admin/settings/storages/variant-storage-card.tsx
@@ -47,11 +47,17 @@ export default function VariantStorageCard() {
     setSaving(true)
     try {
       const payload: VariantStorageInfo = { variantStorage: selection === OFF ? '' : selection }
-      await fetch('/api/v1/settings/variant-storage', {
+      const res = await fetch('/api/v1/settings/variant-storage', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       })
+      // fetch doesn't throw on 4xx/5xx, so check explicitly — otherwise a failed
+      // PUT would wrongly toast success and the admin would think the backend is
+      // set while variantBaseUrl stays empty and backfill can't run.
+      if (!res.ok) {
+        throw new Error(`Request failed: ${res.status}`)
+      }
       toast.success(t('Config.updateSuccess'))
       mutate()
     } catch {


### PR DESCRIPTION
## Problem
Post-merge review of #483 (raised by both @Picimpact-Design design review and @Picimpact-Review code review): `variant-storage-card.tsx`'s `save()` did `await fetch(PUT)` then always toasted success. `fetch` doesn't reject on 4xx/5xx, so a failed PUT wrongly reports success — and for this setting that's especially misleading: the admin believes they selected S3/R2 while `variant_storage` stays empty, `variantBaseUrl` is blank, and the backfill can't run.

## Fix
Capture the response and `throw` on `!res.ok` so it routes to the existing `Config.updateFailed` toast.

## Verification
`pnpm lint` — 0 errors. `npx tsc --noEmit` — no errors in `variant-storage-card.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)