### PR TITLE
fix(settings): check res.ok in variant-storage save (FU-5)

### DIFF
--- a/components/admin/settings/storages/variant-storage-card.tsx
+++ b/components/admin/settings/storages/variant-storage-card.tsx
@@ -47,11 +47,12 @@ export default function VariantStorageCard() {
     setSaving(true)
     try {
       const payload: VariantStorageInfo = { variantStorage: selection === OFF ? '' : selection }
-      await fetch('/api/v1/settings/variant-storage', {
+      const res = await fetch('/api/v1/settings/variant-storage', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       })
+      if (!res.ok) throw new Error(`Request failed with status ${res.status}`)
       toast.success(t('Config.updateSuccess'))
       mutate()
     } catch {


### PR DESCRIPTION
## Fix: variant-storage save falsely toasted success on HTTP error

Post-merge follow-up to #483 (flagged by both @Picimpact-Design and @Picimpact-Review). `variant-storage-card.tsx`'s `save()` toasted success even on HTTP 4xx/5xx, because `fetch` doesn't throw on error status. For this feature that has real UX cost: an admin could believe they set the backend to S3/R2 while the PUT actually failed, then be confused when `variantBaseUrl` stays empty and backfill produces nothing.

### Change
One line: check `res.ok` after the PUT and throw so it falls through to the `updateFailed` toast.

### Verification
`tsc --noEmit` + `eslint` clean. Diff is the single `save()` change.

(Addresses task #14 / FU-5 — I'd already applied + pushed this when the task was created, so opening it here to avoid duplicate work.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)