### PR TITLE
feat(scripts): image variant backfill CLI (BE-3 part 3c)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prisma:dev": "npx prisma migrate dev",
     "prisma:deploy": "npx prisma migrate deploy",
     "prisma:seed": "npx prisma db seed",
+    "preprocess:backfill": "tsx --conditions=react-server scripts/preprocess-backfill.ts",
     "prebuild": "npx prisma generate"
   },
   "prisma": {

--- a/scripts/preprocess-backfill.ts
+++ b/scripts/preprocess-backfill.ts
@@ -63,13 +63,9 @@ async function main() {
   }
 
   // Drain: each tick processes one batch and returns the active run summary.
-  let lastId: string | null = null
   for (;;) {
     const { activeRun } = await tickPreprocessTaskRuns()
     if (!activeRun) break
-    if (activeRun.id !== lastId) {
-      lastId = activeRun.id
-    }
     logProgress(activeRun)
     if (TERMINAL_STATUSES.has(activeRun.status)) break
   }

--- a/scripts/preprocess-backfill.ts
+++ b/scripts/preprocess-backfill.ts
@@ -1,0 +1,98 @@
+/**
+ * Image variant backfill CLI (BE-3 part 3c).
+ *
+ * Generates responsive variants for existing images by creating a
+ * `preprocess-images` task run and draining it to completion in-process — a
+ * one-shot, headless alternative to clicking through the /admin/tasks button.
+ * Best for the initial bulk backfill of an existing library.
+ *
+ * Run with the react-server export condition so `server-only` modules import
+ * cleanly under tsx:
+ *
+ *   pnpm run preprocess:backfill           # only images missing variants
+ *   pnpm run preprocess:backfill -- --force  # regenerate every image
+ *
+ * Requires DATABASE_URL (read by Prisma) and a configured `variant_storage`
+ * backend (Admin → Settings → Storages → Variant storage).
+ */
+
+import { db } from '~/server/lib/db'
+import {
+  createPreprocessTaskRun,
+  listPreprocessTaskRuns,
+  tickPreprocessTaskRuns,
+  type PreprocessTaskRunSummary,
+} from '~/server/tasks/image-preprocess-service'
+import { normalizePreprocessTaskScope } from '~/types/admin-tasks'
+
+const TERMINAL_STATUSES = new Set(['succeeded', 'failed', 'cancelled'])
+
+function logProgress(run: PreprocessTaskRunSummary) {
+  const { processedCount, totalCount, successCount, failedCount, status } = run
+  console.info(
+    `  [${status}] ${processedCount}/${totalCount} processed `
+    + `(${successCount} ok, ${failedCount} failed)`,
+  )
+}
+
+async function main() {
+  const force = process.argv.slice(2).includes('--force')
+  const scope = normalizePreprocessTaskScope({ force })
+
+  console.info(`Image variant backfill — scope: ${force ? 'all images (force)' : 'images missing variants'}`)
+
+  // Create a run, or reuse an already-active one (e.g. left over from a prior
+  // partial run or the admin UI) so we never double-create.
+  try {
+    const created = await createPreprocessTaskRun(scope)
+    if (created) {
+      console.info(`Created run ${created.id} — ${created.totalCount} image(s) to process.`)
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (message === 'No images matched the selected filters') {
+      console.info('Nothing to do: no images need variant generation.')
+      return
+    }
+    if (message === 'Another preprocess task is already active') {
+      console.info('A preprocess run is already active — draining it.')
+    } else {
+      // e.g. "Variant storage backend is not configured"
+      throw error
+    }
+  }
+
+  // Drain: each tick processes one batch and returns the active run summary.
+  let lastId: string | null = null
+  for (;;) {
+    const { activeRun } = await tickPreprocessTaskRuns()
+    if (!activeRun) break
+    if (activeRun.id !== lastId) {
+      lastId = activeRun.id
+    }
+    logProgress(activeRun)
+    if (TERMINAL_STATUSES.has(activeRun.status)) break
+  }
+
+  // Report the final state of the most recent run.
+  const { recentRuns, activeRun } = await listPreprocessTaskRuns()
+  const finalRun = activeRun ?? recentRuns[0]
+  if (finalRun) {
+    console.info(
+      `Done — ${finalRun.status}: ${finalRun.successCount} ok, `
+      + `${finalRun.failedCount} failed, ${finalRun.processedCount}/${finalRun.totalCount} processed.`,
+    )
+    if (finalRun.status === 'failed') {
+      process.exitCode = 1
+    }
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error('Backfill failed:', error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await db.$disconnect()
+  })


### PR DESCRIPTION
## BE-3 part 3c — backfill CLI

A one-shot, headless way to generate variants for an existing image library — the most direct path for the initial bulk backfill (the original "集中生成已有图片缩略图" ask).

### What
- **`scripts/preprocess-backfill.ts`** + **`pnpm run preprocess:backfill`**: creates a `preprocess-images` run (or reuses an already-active one so it never double-creates), then **drains it to completion in-process** via `tickPreprocessTaskRuns`, printing per-batch progress. `--force` regenerates every image; default = only images missing variants. Exits non-zero on a failed run; always `db.$disconnect()`.
- Run with **`--conditions=react-server`** so the `server-only` module graph (queue engine + sharp + storage clients) imports cleanly under `tsx`.

### Why CLI
Unlike the (upcoming) `/admin/tasks` button — which drives batches from the browser and needs the tab open — the CLI drains the whole backlog server-side in one command, ideal for thousands of existing images.

### Verification
- Confirmed the full server module graph **imports cleanly** under `tsx --conditions=react-server` (server-only resolves to its no-op, no throw).
- `tsc --noEmit` + `eslint` clean.
- The actual drain needs a live `DATABASE_URL` + a configured `variant_storage` backend — that's the real end-to-end backfill test, run against the deployment.

### Remaining
Part 3b — the `/admin/tasks` button (GUI trigger) — follows. Then the end-to-end backfill validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)