### PR TITLE
fix(images): read originals via presigned URL in preprocessing (private-bucket 403)

### DIFF
--- a/hono/open/download.ts
+++ b/hono/open/download.ts
@@ -3,11 +3,9 @@ import 'server-only'
 import { Hono } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
-import { getClient } from '~/server/lib/s3'
-import { getR2Client } from '~/server/lib/r2'
 import { fetchImageByIdAndAuth } from '~/server/db/query/images'
 import type { Config } from '~/types'
-import { generatePresignedUrl } from '~/server/lib/s3api'
+import { buildOriginalPresignedUrl } from '~/server/lib/original-presign'
 import { ok } from '~/hono/_lib/response'
 import { badRequest, notFound, serverError } from '~/hono/_lib/errors'
 
@@ -53,70 +51,6 @@ async function loadImageOrThrow(id: string) {
   return { imageData, imageUrl }
 }
 
-async function buildPresignedUrlForStorage(storage: string, imageUrl: string): Promise<string> {
-  let key: string
-  if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
-    const urlMatch = imageUrl.match(/^https?:\/\/[^\/]+(\/.*)$/)
-    key = urlMatch ? urlMatch[1].slice(1) : imageUrl
-  } else {
-    key = imageUrl
-  }
-
-  switch (storage) {
-    case 's3': {
-      const folderConfigs = await fetchConfigsByKeys(['storage_folder'])
-      const s3StorageFolder = folderConfigs.find((item: Config) => item.config_key === 'storage_folder')?.config_value || ''
-      if (s3StorageFolder && key.startsWith(s3StorageFolder)) {
-        key = key.slice(s3StorageFolder.length)
-      }
-
-      const configs = await fetchConfigsByKeys([
-        'accesskey_id',
-        'accesskey_secret',
-        'region',
-        'endpoint',
-        'bucket',
-        'storage_folder',
-        'force_path_style',
-        's3_cdn',
-        's3_cdn_url',
-        's3_direct_download'
-      ])
-      const bucket = configs.find((item: Config) => item.config_key === 'bucket')?.config_value || ''
-      const storageFolder = configs.find((item: Config) => item.config_key === 'storage_folder')?.config_value || ''
-
-      const filePath = key.startsWith(storageFolder) ? key : `${storageFolder}${key}`
-      const client = getClient(configs)
-      return await generatePresignedUrl(client, bucket, filePath, '')
-    }
-    case 'r2': {
-      const folderConfigs = await fetchConfigsByKeys(['r2_storage_folder'])
-      const r2StorageFolder = folderConfigs.find((item: Config) => item.config_key === 'r2_storage_folder')?.config_value || ''
-      if (r2StorageFolder && key.startsWith(r2StorageFolder)) {
-        key = key.slice(r2StorageFolder.length)
-      }
-
-      const configs = await fetchConfigsByKeys([
-        'r2_accesskey_id',
-        'r2_accesskey_secret',
-        'r2_account_id',
-        'r2_bucket',
-        'r2_storage_folder',
-        'r2_public_domain',
-        'r2_direct_download'
-      ])
-      const bucket = configs.find((item: Config) => item.config_key === 'r2_bucket')?.config_value || ''
-      const storageFolder = configs.find((item: Config) => item.config_key === 'r2_storage_folder')?.config_value || ''
-
-      const filePath = key.startsWith(storageFolder) ? key : `${storageFolder}${key}`
-      const client = getR2Client(configs)
-      return await generatePresignedUrl(client, bucket, filePath, '')
-    }
-    default:
-      throw badRequest('Unsupported storage type')
-  }
-}
-
 /**
  * GET /api/public/download/config
  *
@@ -156,7 +90,7 @@ app.get('/:id/presigned', async (c) => {
   try {
     const { imageData, imageUrl } = await loadImageOrThrow(id)
     const filename = deriveFilename(imageData.image_name, imageUrl)
-    const url = await buildPresignedUrlForStorage(storage, imageUrl)
+    const url = await buildOriginalPresignedUrl(storage, imageUrl)
     c.header('Cache-Control', 'private, max-age=60')
     return ok(c, { url, filename: encodeURIComponent(filename) })
   } catch (e) {

--- a/server/lib/original-presign.ts
+++ b/server/lib/original-presign.ts
@@ -1,0 +1,86 @@
+import 'server-only'
+
+import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import { getClient } from '~/server/lib/s3'
+import { getR2Client } from '~/server/lib/r2'
+import { generatePresignedUrl } from '~/server/lib/s3api'
+import { badRequest } from '~/hono/_lib/errors'
+import type { Config } from '~/types'
+
+/**
+ * Build a presigned GET URL for an image's **original** object, using stored
+ * storage credentials.
+ *
+ * Originals live in private buckets on many deployments, so a plain public
+ * `fetch(image.url)` is rejected with 403. This derives the object key from the
+ * stored `image.url` (strip scheme+host, handle the storage folder prefix) and
+ * presigns a GET with the backend's credentials — the same approach the
+ * "download original" route uses, extracted here so the download route and the
+ * preprocessing pipeline share one proven implementation.
+ *
+ * `storage` selects the backend (`s3` | `r2`). Open List has no equivalent
+ * credentialed presign and is unsupported.
+ */
+export async function buildOriginalPresignedUrl(storage: string, imageUrl: string): Promise<string> {
+  let key: string
+  if (imageUrl.startsWith('http://') || imageUrl.startsWith('https://')) {
+    const urlMatch = imageUrl.match(/^https?:\/\/[^/]+(\/.*)$/)
+    key = urlMatch ? urlMatch[1].slice(1) : imageUrl
+  } else {
+    key = imageUrl
+  }
+
+  switch (storage) {
+    case 's3': {
+      const folderConfigs = await fetchConfigsByKeys(['storage_folder'])
+      const s3StorageFolder = folderConfigs.find((item: Config) => item.config_key === 'storage_folder')?.config_value || ''
+      if (s3StorageFolder && key.startsWith(s3StorageFolder)) {
+        key = key.slice(s3StorageFolder.length)
+      }
+
+      const configs = await fetchConfigsByKeys([
+        'accesskey_id',
+        'accesskey_secret',
+        'region',
+        'endpoint',
+        'bucket',
+        'storage_folder',
+        'force_path_style',
+        's3_cdn',
+        's3_cdn_url',
+        's3_direct_download',
+      ])
+      const bucket = configs.find((item: Config) => item.config_key === 'bucket')?.config_value || ''
+      const storageFolder = configs.find((item: Config) => item.config_key === 'storage_folder')?.config_value || ''
+
+      const filePath = key.startsWith(storageFolder) ? key : `${storageFolder}${key}`
+      const client = getClient(configs)
+      return await generatePresignedUrl(client, bucket, filePath, '')
+    }
+    case 'r2': {
+      const folderConfigs = await fetchConfigsByKeys(['r2_storage_folder'])
+      const r2StorageFolder = folderConfigs.find((item: Config) => item.config_key === 'r2_storage_folder')?.config_value || ''
+      if (r2StorageFolder && key.startsWith(r2StorageFolder)) {
+        key = key.slice(r2StorageFolder.length)
+      }
+
+      const configs = await fetchConfigsByKeys([
+        'r2_accesskey_id',
+        'r2_accesskey_secret',
+        'r2_account_id',
+        'r2_bucket',
+        'r2_storage_folder',
+        'r2_public_domain',
+        'r2_direct_download',
+      ])
+      const bucket = configs.find((item: Config) => item.config_key === 'r2_bucket')?.config_value || ''
+      const storageFolder = configs.find((item: Config) => item.config_key === 'r2_storage_folder')?.config_value || ''
+
+      const filePath = key.startsWith(storageFolder) ? key : `${storageFolder}${key}`
+      const client = getR2Client(configs)
+      return await generatePresignedUrl(client, bucket, filePath, '')
+    }
+    default:
+      throw badRequest('Unsupported storage type')
+  }
+}

--- a/server/tasks/image-preprocess.ts
+++ b/server/tasks/image-preprocess.ts
@@ -11,6 +11,7 @@ import {
   isMetadataTaskCancelledError,
   throwIfMetadataTaskCancelled,
 } from '~/server/tasks/metadata-refresh'
+import { buildOriginalPresignedUrl } from '~/server/lib/original-presign'
 import type { ResolvedVariantStorage } from '~/server/lib/variant-storage'
 import type { AdminTaskIssue, AdminTaskStage } from '~/types/admin-tasks'
 import { ADMIN_TASK_KEY_PREPROCESS_IMAGES } from '~/types/admin-tasks'
@@ -93,12 +94,18 @@ function variantObjectKey(storageFolder: string, imageKey: string, width: number
   return storageFolder ? `${storageFolder}/${key}` : key
 }
 
-async function fetchOriginal(image: PreprocessImage, signal: AbortSignal | undefined): Promise<Buffer> {
+async function fetchOriginal(image: PreprocessImage, storage: ResolvedVariantStorage, signal: AbortSignal | undefined): Promise<Buffer> {
   const fetchSignal = signal
     ? AbortSignal.any([signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)])
     : AbortSignal.timeout(FETCH_TIMEOUT_MS)
 
-  const response = await fetch(image.url as string, { signal: fetchSignal, cache: 'no-store' })
+  // Originals commonly live in a private bucket, so a plain public
+  // fetch(image.url) is rejected with 403. Read the original through a
+  // credentialed presigned GET (same mechanism as the download route),
+  // resolving the key against the configured variant_storage backend — which,
+  // in a single-backend deployment, is also where the originals live.
+  const presignedUrl = await buildOriginalPresignedUrl(storage.backend, image.url as string)
+  const response = await fetch(presignedUrl, { signal: fetchSignal, cache: 'no-store' })
   if (!response.ok) {
     const error = new Error(`HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ''}`)
     ;(error as { httpStatus?: number }).httpStatus = response.status
@@ -140,7 +147,7 @@ export async function preprocessImage(
 
   let buffer: Buffer
   try {
-    buffer = await fetchOriginal(image, signal)
+    buffer = await fetchOriginal(image, storage, signal)
     throwIfMetadataTaskCancelled(signal)
   } catch (error) {
     if (signal?.aborted || isMetadataTaskCancelledError(error)) {


### PR DESCRIPTION
## Fix: backfill 100% failure — originals fetched via public URL hit 403

**Root cause** (from the first real backfill run, surfaced by #488's issue output): every image failed with
```
[fetch/fetch_error] Failed to fetch the original image. — HTTP 403 Forbidden
```
The processor read originals with a plain public `fetch(image.url)`, but originals commonly live in a **private bucket** → 403. (Note: `metadata-refresh.ts` has the same latent issue — same `fetch(image.url)` — it just hadn't been run here.)

### Fix
Read the original through a **credentialed presigned GET** — exactly what the "download original" route already does for private storage. This covers both private buckets **and** referer/hotlink protection (a presigned URL is authenticated regardless of the cause).

- Extract `download.ts`'s `buildPresignedUrlForStorage` into a shared **`server/lib/original-presign.ts`** (verbatim: key derivation from `image.url`, storage-folder handling, `generatePresignedUrl`). `download.ts` now imports it → the download route and the pipeline share one proven implementation, zero drift.
- The processor resolves the key against the configured `variant_storage` backend (s3/r2). In a **single-backend deployment** (the common case) that's also where originals live — `download.ts` and BE-4 read the same `bucket`/`r2_bucket` key — so **no per-image backend inference** is needed (addresses @Picimpact-Review's concern ③ for the normal case).

### Review notes (per #-thread)
1. **Key-derivation correctness**: reused verbatim from the working download route → if "download original" works on a deployment, this works for the same images.
2. **Known limitation, not silent**: if originals live in a *different* backend than `variant_storage`, or on Open List, the presign targets the wrong bucket → that image fails at **fetch** (visible via #488's issue output, not a silent skip). Multi-backend would need host-based inference (follow-up).
3. **Presign TTL** = `generatePresignedUrl` default **3600s** ≫ the 30s fetch timeout.

### Verification
- `tsc --noEmit` + `eslint` clean on all three files.
- Full server module graph still imports cleanly under `tsx --conditions=react-server`.
- `download.ts` refactor is a **verbatim extraction** (behavior-preserving) — diff `original-presign.ts` against the old inline function.
- Runtime confirmation = re-run `pnpm run preprocess:backfill` on the deployment after merge (needs live DB + storage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)