### PR TITLE
feat(images): auto-generate variants on upload (auto-enqueue)

### DIFF
--- a/hono/images.ts
+++ b/hono/images.ts
@@ -8,6 +8,7 @@ import {
   updateImageAlbum
 } from '~/server/db/operate/images'
 import { fetchCameraAndLensList } from '~/server/db/query/images'
+import { preprocessImageById } from '~/server/tasks/image-preprocess-service'
 import { Hono } from 'hono'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
@@ -39,7 +40,14 @@ app.post('/', async (c) => {
     if (body?.exif?.dateTime && !dayjs(body?.exif?.dateTime, 'YYYY:MM:DD HH:mm:ss', true).isValid()) {
       body.exif.dateTime = ''
     }
-    await insertImage(body)
+    const newImageId = await insertImage(body)
+    // Auto-enqueue variant generation for the new upload (fire-and-forget;
+    // never blocks the response). No-op when the variant pipeline is
+    // unconfigured; on failure the image stays variants_ready=false and a
+    // backfill run covers it later.
+    if (newImageId) {
+      void preprocessImageById(newImageId).catch(() => {})
+    }
     return okEmpty(c)
   } catch (e) {
     throw serverError('Failed', e)

--- a/server/db/operate/images.ts
+++ b/server/db/operate/images.ts
@@ -9,10 +9,11 @@ import type { ImageType } from '~/types'
  * 新增图片
  * @param image 图片数据
  */
-export async function insertImage(image: ImageType) {
+export async function insertImage(image: ImageType): Promise<string> {
   if (!image.sort || image.sort < 0) {
     image.sort = 0
   }
+  let createdId = ''
   await db.$transaction(async (tx) => {
     const resultRow = await tx.images.create({
       data: {
@@ -38,6 +39,7 @@ export async function insertImage(image: ImageType) {
     })
 
     if (resultRow) {
+      createdId = resultRow.id
       await tx.imagesAlbumsRelation.create({
         data: {
           imageId: resultRow.id,
@@ -48,6 +50,7 @@ export async function insertImage(image: ImageType) {
       throw new Error('事务处理失败！')
     }
   })
+  return createdId
 }
 
 /**

--- a/server/tasks/image-preprocess-service.ts
+++ b/server/tasks/image-preprocess-service.ts
@@ -814,3 +814,35 @@ export async function tickPreprocessTaskRuns() {
   if (!activeRecord) return { activeRun: null }
   return { activeRun: toSummary(activeRecord) }
 }
+
+/**
+ * Best-effort variant generation for a single image, used to auto-process a
+ * freshly uploaded image without the batch run/cursor machinery (which a new
+ * insert could slip past). Intended to be fire-and-forget from the upload
+ * path: it never throws — if the variant pipeline is unconfigured, the image
+ * is gone, or generation/upload fails, it leaves the image `variants_ready=false`
+ * so a later backfill run picks it up. Re-processing is idempotent (variants are
+ * content-addressed), so overlapping with a backfill run is safe.
+ */
+export async function preprocessImageById(imageId: string): Promise<void> {
+  try {
+    const storage = await resolveVariantStorage()
+    if (!storage) return
+
+    const rows = await db.$queryRaw<PreprocessImage[]>`
+      SELECT image.id, image.image_name, image.title, image.url
+      FROM "public"."images" AS image
+      WHERE image.id = ${imageId} AND image.del = 0
+      LIMIT 1
+    `
+    const image = rows[0]
+    if (!image) return
+
+    const result = await preprocessImage(image, storage)
+    if (result.updates) {
+      await applyPreprocessUpdates(imageId, result.updates)
+    }
+  } catch (error) {
+    console.warn(`preprocessImageById(${imageId}) failed:`, error instanceof Error ? error.message : error)
+  }
+}


### PR DESCRIPTION
## Auto-enqueue: new uploads generate variants automatically

Previously a newly uploaded image stayed `variants_ready=false` until someone manually ran a backfill (CLI / `/admin/tasks`). Now uploads auto-trigger variant generation, so new photos get responsive variants (incl. AVIF) on their own. (Answers @Manjusaka's "新上传会自动 AVIF 吗" — now yes.)

### What
- **`insertImage()`** now returns the created image id.
- **`preprocessImageById(id)`** (new, in `image-preprocess-service`): best-effort single-image processing — resolve storage → `preprocessImage` → persist updates. Deliberately **bypasses the batch run/cursor machinery** (a fresh insert with a non-time-ordered cuid could slip past an active run's cursor — the orphan trap @Picimpact-Review flagged). **Never throws**; no-op when `variant_storage` is unconfigured; on failure leaves `variants_ready=false` for the next backfill. Idempotent with a concurrent backfill (content-addressed keys).
- **`POST /api/v1/images`** fires it **fire-and-forget** after insert (`void preprocessImageById(id).catch(() => {})`) — never blocks the upload response. Reuses #489's presigned-original fetch → works with private buckets.

### Caveats (per review)
- Background work completes on long-lived **Node/Docker** deployments. On **serverless** (Vercel) the function may freeze after the response returns → the image is then covered by the next backfill run (graceful fallback).
- Each upload runs real work (fetch + 8-tier×2 encode + upload) on the web instance → possible CPU spike under bulk uploads; acceptable since it's async/non-blocking. The pending speedup PR (decode-once + lower AVIF effort) will also lighten this.
- Frontend needs no change — the gallery's degradation ladder shows preview/blurhash during the few-second async window, then upgrades to variants once ready (confirmed by @Picimpact-Design).

### Verification
`tsc --noEmit` + `eslint` clean; module graph imports cleanly under `tsx --conditions=react-server`. Runtime confirmation = upload an image on a configured deployment and watch `variants_ready` flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)