### PR TITLE
perf(images): decode original once + lower AVIF effort + smarter CLI sleep

### DIFF
--- a/scripts/preprocess-backfill.ts
+++ b/scripts/preprocess-backfill.ts
@@ -85,6 +85,10 @@ async function main() {
     if (TERMINAL_STATUSES.has(activeRun.status)) break
 
     if (activeRun.processedCount === prevProcessed) {
+      // No progress: the run is likely held by another process whose lease has
+      // not expired. Back off (sleep) and bail after too many stalls, rather
+      // than spin. The sleep only applies here — while actively making
+      // progress we drain at full speed with no inter-batch delay.
       stalledTicks += 1
       if (stalledTicks >= MAX_STALLED_TICKS) {
         console.error(
@@ -95,12 +99,11 @@ async function main() {
         process.exitCode = 1
         break
       }
+      await sleep(TICK_INTERVAL_MS)
     } else {
       stalledTicks = 0
       prevProcessed = activeRun.processedCount
     }
-
-    await sleep(TICK_INTERVAL_MS)
   }
 
   // Report the final state of the most recent run.

--- a/server/lib/image-variants.ts
+++ b/server/lib/image-variants.ts
@@ -3,7 +3,7 @@ import 'server-only'
 import { createHash } from 'node:crypto'
 
 import { PutObjectCommand, type S3Client } from '@aws-sdk/client-s3'
-import sharp from 'sharp'
+import sharp, { type Sharp } from 'sharp'
 import { rgbaToThumbHash } from 'thumbhash'
 
 import {
@@ -112,7 +112,10 @@ export async function generateImageVariants(
   input: Buffer,
   opts: GenerateOptions = {},
 ): Promise<ImageVariantResult> {
-  const { avifQuality = 50, webpQuality = 72, avifEffort = 4 } = opts
+  // AVIF effort dominates encoding time; effort 2 (vs sharp's default 4) was
+  // ~2.6x faster in a local benchmark for a small size penalty — a good
+  // trade-off for bulk variant generation.
+  const { avifQuality = 50, webpQuality = 72, avifEffort = 2 } = opts
 
   const metadata = await sharp(input, { limitInputPixels: MAX_INPUT_PIXELS, failOn: 'none' }).metadata()
 
@@ -123,13 +126,16 @@ export async function generateImageVariants(
     throw new Error('Unable to read source image dimensions')
   }
 
-  const blurhash = await generateThumbhash(input)
+  // Decode + EXIF-orient the original ONCE; every tier and the thumbhash derive
+  // from clones of this pipeline so a (potentially 20MB+) original is decoded a
+  // single time instead of once per output.
+  const base = sharp(input, { limitInputPixels: MAX_INPUT_PIXELS, failOn: 'none' }).rotate()
+
+  const blurhash = await generateThumbhash(base.clone())
 
   const variants: GeneratedVariant[] = []
   for (const width of tierWidthsForSource(sourceWidth)) {
-    const resized = sharp(input, { limitInputPixels: MAX_INPUT_PIXELS, failOn: 'none' })
-      .rotate()
-      .resize({ width, withoutEnlargement: true })
+    const resized = base.clone().resize({ width, withoutEnlargement: true })
 
     const [avif, webp] = await Promise.all([
       resized.clone().avif({ quality: avifQuality, effort: avifEffort }).toBuffer(),
@@ -144,13 +150,14 @@ export async function generateImageVariants(
 }
 
 /**
- * Compute the base64 thumbhash for an image by sampling it down to a small
- * RGBA bitmap. Cheap and deterministic; the existing `useBlurhash` hook decodes
- * exactly this format from the `blurhash` column.
+ * Compute the base64 thumbhash by sampling an image down to a small RGBA
+ * bitmap. Takes an already-prepared sharp pipeline (e.g. a `base.clone()` that
+ * has been decoded + EXIF-oriented) so it shares the single decode instead of
+ * re-decoding the original. Cheap and deterministic; the `useBlurhash` hook
+ * decodes exactly this format from the `blurhash` column.
  */
-export async function generateThumbhash(input: Buffer): Promise<string> {
-  const { data, info } = await sharp(input, { limitInputPixels: MAX_INPUT_PIXELS, failOn: 'none' })
-    .rotate()
+export async function generateThumbhash(image: Sharp): Promise<string> {
+  const { data, info } = await image
     .resize({ width: THUMBHASH_MAX_EDGE, height: THUMBHASH_MAX_EDGE, fit: 'inside', withoutEnlargement: true })
     .ensureAlpha()
     .raw()


### PR DESCRIPTION
## Speed up variant generation / backfill

Three targeted speedups after the first real backfill ran slowly (@Manjusaka). Costs identified by the team:

### 1. Decode the original once (was decoded 9×) — @Picimpact-Design's catch
`generateImageVariants` created a fresh `sharp(input)` for **every tier** (8) **plus** the thumbhash — decoding a potentially 20MB+ original 9 times. Now it decodes + EXIF-orients a single `base` pipeline and derives every tier and the thumbhash from `base.clone()`. `generateThumbhash` now takes a `Sharp` pipeline (not a Buffer) to share that decode.

### 2. Lower AVIF effort 4 → 2
AVIF encoding dominates total time. Local benchmark (8-tier set): **effort 4 = 1024ms, effort 2 = 372ms (~2.6× faster)** for a small file-size penalty — a good bulk default. Still overridable via `opts.avifEffort`.

### 3. CLI: sleep only when stalled
The backfill drain slept 1s after **every** batch, including while making progress (~4.5 min of pure waiting over ~269 batches for 1075 images). The 1s sleep now applies **only on a no-progress tick** (the #488 busy-spin guard); active draining runs with no inter-batch delay.

### Verification
- Functional run of `generateImageVariants` (1200×900) → correct tiers (≤ source width: 320/480/640/800/1080), both formats (10 variants), valid 28-char thumbhash. AVIF output valid.
- `tsc --noEmit` + `eslint` clean.
- `generateThumbhash`'s signature change is internal-only (sole caller is `generateImageVariants`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)