### PR TITLE
feat(images): async background ticker for variant generation

### DIFF
--- a/hono/images.ts
+++ b/hono/images.ts
@@ -8,7 +8,6 @@ import {
   updateImageAlbum
 } from '~/server/db/operate/images'
 import { fetchCameraAndLensList } from '~/server/db/query/images'
-import { preprocessImageById } from '~/server/tasks/image-preprocess-service'
 import { Hono } from 'hono'
 import dayjs from 'dayjs'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
@@ -40,14 +39,11 @@ app.post('/', async (c) => {
     if (body?.exif?.dateTime && !dayjs(body?.exif?.dateTime, 'YYYY:MM:DD HH:mm:ss', true).isValid()) {
       body.exif.dateTime = ''
     }
-    const newImageId = await insertImage(body)
-    // Auto-enqueue variant generation for the new upload (fire-and-forget;
-    // never blocks the response). No-op when the variant pipeline is
-    // unconfigured; on failure the image stays variants_ready=false and a
-    // backfill run covers it later.
-    if (newImageId) {
-      void preprocessImageById(newImageId).catch(() => {})
-    }
+    // New images are stored with variants_ready=false; the background
+    // preprocess ticker (see instrumentation.ts) picks them up asynchronously
+    // and generates variants via a tracked /admin/tasks run — no inline work
+    // on the upload request.
+    await insertImage(body)
     return okEmpty(c)
   } catch (e) {
     throw serverError('Failed', e)

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,14 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'edge') {
     console.info('Runtime is edge, skipping instrumentation setup.')
+    return
+  }
+
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    // Start the background image-preprocessing ticker, which turns newly
+    // uploaded (and backlogged) images into responsive variants asynchronously
+    // via the AdminTaskRun queue. No-ops when disabled or unconfigured.
+    const { startPreprocessTicker } = await import('~/server/tasks/preprocess-ticker')
+    startPreprocessTicker()
   }
 }

--- a/server/db/operate/images.ts
+++ b/server/db/operate/images.ts
@@ -9,11 +9,10 @@ import type { ImageType } from '~/types'
  * 新增图片
  * @param image 图片数据
  */
-export async function insertImage(image: ImageType): Promise<string> {
+export async function insertImage(image: ImageType) {
   if (!image.sort || image.sort < 0) {
     image.sort = 0
   }
-  let createdId = ''
   await db.$transaction(async (tx) => {
     const resultRow = await tx.images.create({
       data: {
@@ -39,7 +38,6 @@ export async function insertImage(image: ImageType): Promise<string> {
     })
 
     if (resultRow) {
-      createdId = resultRow.id
       await tx.imagesAlbumsRelation.create({
         data: {
           imageId: resultRow.id,
@@ -50,7 +48,6 @@ export async function insertImage(image: ImageType): Promise<string> {
       throw new Error('事务处理失败！')
     }
   })
-  return createdId
 }
 
 /**

--- a/server/tasks/image-preprocess-service.ts
+++ b/server/tasks/image-preprocess-service.ts
@@ -814,35 +814,3 @@ export async function tickPreprocessTaskRuns() {
   if (!activeRecord) return { activeRun: null }
   return { activeRun: toSummary(activeRecord) }
 }
-
-/**
- * Best-effort variant generation for a single image, used to auto-process a
- * freshly uploaded image without the batch run/cursor machinery (which a new
- * insert could slip past). Intended to be fire-and-forget from the upload
- * path: it never throws — if the variant pipeline is unconfigured, the image
- * is gone, or generation/upload fails, it leaves the image `variants_ready=false`
- * so a later backfill run picks it up. Re-processing is idempotent (variants are
- * content-addressed), so overlapping with a backfill run is safe.
- */
-export async function preprocessImageById(imageId: string): Promise<void> {
-  try {
-    const storage = await resolveVariantStorage()
-    if (!storage) return
-
-    const rows = await db.$queryRaw<PreprocessImage[]>`
-      SELECT image.id, image.image_name, image.title, image.url
-      FROM "public"."images" AS image
-      WHERE image.id = ${imageId} AND image.del = 0
-      LIMIT 1
-    `
-    const image = rows[0]
-    if (!image) return
-
-    const result = await preprocessImage(image, storage)
-    if (result.updates) {
-      await applyPreprocessUpdates(imageId, result.updates)
-    }
-  } catch (error) {
-    console.warn(`preprocessImageById(${imageId}) failed:`, error instanceof Error ? error.message : error)
-  }
-}

--- a/server/tasks/preprocess-ticker.ts
+++ b/server/tasks/preprocess-ticker.ts
@@ -1,0 +1,83 @@
+import 'server-only'
+
+import { createPreprocessTaskRun, tickPreprocessTaskRuns } from '~/server/tasks/image-preprocess-service'
+
+/**
+ * Background driver for the image-preprocessing queue.
+ *
+ * Uploads no longer process variants inline — a new image is simply stored with
+ * `variants_ready=false`. This ticker periodically (a) creates a preprocess
+ * AdminTaskRun when images are pending and none is active, then (b) drains the
+ * active run a batch at a time. So new uploads (and any backlog) are turned into
+ * variants asynchronously, with every run visible/cancellable in /admin/tasks.
+ *
+ * Driving here (rather than only when the admin opens /admin/tasks) is what
+ * makes it truly hands-off. Requires a long-lived process (Node/Docker); on
+ * serverless there is no persistent process, so this no-ops and an external cron
+ * hitting POST /api/v1/preprocess-tasks/tick should drive the queue instead.
+ */
+
+const TERMINAL_STATUSES = new Set(['succeeded', 'failed', 'cancelled'])
+const FIRST_RUN_DELAY_MS = 30_000
+const INTERVAL_MS = 10_000
+// Upper bound on batches drained per cycle so one cycle can't monopolise the
+// process indefinitely; the next cycle continues any remaining work.
+const MAX_BATCHES_PER_CYCLE = 100
+
+let started = false
+let running = false
+
+function tickerEnabled(): boolean {
+  const flag = process.env.PREPROCESS_TICKER_ENABLED
+  // Explicit env wins; otherwise default to production only so `next dev`
+  // doesn't silently start generating variants locally.
+  if (flag != null && flag !== '') return flag === 'true'
+  return process.env.NODE_ENV === 'production'
+}
+
+async function drainCycle(): Promise<void> {
+  // In-process guard: if the previous cycle is still draining (a batch can take
+  // longer than the interval), skip rather than stack overlapping cycles. The
+  // advisory lock inside the tick path additionally guards across processes.
+  if (running) return
+  running = true
+  try {
+    // Create a run for pending images when none is active. Expected throws are
+    // benign: variant_storage unconfigured, a run already active, or no images
+    // pending — all mean "nothing to start right now".
+    try {
+      await createPreprocessTaskRun({ force: false })
+    } catch {
+      // ignore
+    }
+
+    for (let i = 0; i < MAX_BATCHES_PER_CYCLE; i += 1) {
+      const { activeRun } = await tickPreprocessTaskRuns()
+      if (!activeRun || TERMINAL_STATUSES.has(activeRun.status)) break
+    }
+  } catch (error) {
+    console.warn('Preprocess ticker cycle failed:', error instanceof Error ? error.message : error)
+  } finally {
+    running = false
+  }
+}
+
+/**
+ * Start the background preprocess ticker. Safe to call multiple times (only the
+ * first call starts it). No-ops outside the Node.js runtime or when disabled.
+ */
+export function startPreprocessTicker(): void {
+  if (started) return
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return
+  if (!tickerEnabled()) return
+  started = true
+
+  // Delay the first cycle so a cold start with a large backlog doesn't spike
+  // CPU before the app has finished booting.
+  setTimeout(() => {
+    void drainCycle()
+    setInterval(() => {
+      void drainCycle()
+    }, INTERVAL_MS)
+  }, FIRST_RUN_DELAY_MS)
+}


### PR DESCRIPTION
## Make variant generation an async task visible in /admin/tasks

Per @Manjusaka: upload auto-processing should be an **async task tracked in /admin/tasks**, not inline work on the upload request (which burdened the web process / wasn't visible). This replaces #490's inline fire-and-forget single-image processing with a background queue driver.

### Changes
- **Upload no longer processes inline.** `POST /api/v1/images` just stores the image (`variants_ready=false`) — zero variant work on the request. (Reverts #490's inline `preprocessImageById` call + the now-unused `insertImage` return value + the `preprocessImageById` helper.)
- **`server/tasks/preprocess-ticker.ts`** — a background ticker started from `instrumentation.register()`. Each cycle: create a preprocess `AdminTaskRun` if images are pending and none is active, then drain the active run a batch at a time. New uploads (and any backlog) become variants asynchronously, and every run is visible/cancellable in **/admin/tasks** (Design's FE-5 surfaces them).

### Review checklist (all addressed)
1. **Node-runtime guard** — `NEXT_RUNTIME === 'nodejs'` only.
2. **In-flight guard** — a cycle taking longer than the interval won't stack; the next interval skips while one is running.
3. **Multi-replica safe** — drains via the advisory-locked tick path (lock `42012`); extra replicas' tickers bail.
4. **Dev switch** — `PREPROCESS_TICKER_ENABLED`; defaults to production-only so `next dev` doesn't auto-generate locally.
5. **Startup spike** — 30s first-run delay before the first cycle.

### Cursor-orphan / "already active" (Review's other points)
Handled by design: the upload creates no run, so it can't throw on an active run; and each cycle **re-creates a run scoped to `variants_ready=false`**, so a newly uploaded image is caught the next cycle (latency ≈ interval).

### Serverless note
Requires a long-lived process. On Vercel this no-ops; drive the queue with an external cron hitting `POST /api/v1/preprocess-tasks/tick`.

### Verification
`tsc --noEmit` + `eslint` clean; module graph imports cleanly under `tsx --conditions=react-server`. Runtime confirmation = upload on a configured Node deployment → a preprocess run appears in /admin/tasks and `variants_ready` flips within ~a cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)