### PR TITLE
feat(admin): show variant preprocess tasks in /admin/tasks (reusable TaskRunPanel)

### DIFF
--- a/components/admin/tasks/task-run-panel.tsx
+++ b/components/admin/tasks/task-run-panel.tsx
@@ -1,0 +1,829 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import useSWR from 'swr'
+import { useLocale, useTranslations } from 'next-intl'
+import { ChevronRight, Clock3, LoaderCircle, MapPinned, RefreshCw, TriangleAlert, Wrench } from 'lucide-react'
+import { toast } from 'sonner'
+
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '~/components/ui/dialog'
+import { Progress } from '~/components/ui/progress'
+import { ScrollArea } from '~/components/ui/scroll-area'
+import { cn } from '~/lib/utils'
+import type {
+  AdminTaskError,
+  AdminTaskIssue,
+  AdminTaskKey,
+  AdminTaskPreviewCount,
+  AdminTaskRunBase,
+  AdminTaskRunDetail,
+  AdminTaskRunSummary,
+  AdminTaskRunsResponse,
+  AdminTaskStatus,
+} from '~/types/admin-tasks'
+
+type ApiEnvelope<T> = { code: number; message: string; data: T }
+
+const HISTORY_RECENT_LIMIT = 10
+const HISTORY_VISIBLE_ROWS = 3
+const HISTORY_CARD_MIN_HEIGHT_REM = 10.75
+const HISTORY_SCROLL_MAX_HEIGHT = `${HISTORY_VISIBLE_ROWS * HISTORY_CARD_MIN_HEIGHT_REM}rem`
+const panelClass = 'show-up-motion relative overflow-hidden rounded-[1.7rem] border border-border/70 bg-card/82 shadow-sm backdrop-blur-sm'
+
+export function statusClass(status: AdminTaskStatus) {
+  switch (status) {
+    case 'queued':
+    case 'cancelling':
+      return 'border-amber-400/35 bg-amber-500/12 text-amber-700 dark:text-amber-300'
+    case 'running':
+      return 'border-primary/30 bg-primary/10 text-primary'
+    case 'succeeded':
+      return 'border-emerald-400/35 bg-emerald-500/12 text-emerald-700 dark:text-emerald-300'
+    case 'failed':
+      return 'border-rose-400/35 bg-rose-500/12 text-rose-700 dark:text-rose-300'
+    case 'cancelled':
+    default:
+      return 'border-border/80 bg-secondary text-secondary-foreground'
+  }
+}
+
+export function issueClass(level: AdminTaskIssue['level']) {
+  if (level === 'error') {
+    return 'border-rose-400/35 bg-rose-500/12 text-rose-700 dark:text-rose-300'
+  }
+
+  if (level === 'warning') {
+    return 'border-amber-400/35 bg-amber-500/12 text-amber-700 dark:text-amber-300'
+  }
+
+  return 'border-slate-400/35 bg-slate-500/10 text-slate-700 dark:text-slate-300'
+}
+
+export function progressOf(run: AdminTaskRunBase | null) {
+  if (!run || run.totalCount <= 0) return 0
+  return Math.min(100, Math.round((run.processedCount / run.totalCount) * 100))
+}
+
+export function formatDate(value: string | null, formatter: Intl.DateTimeFormat, fallback: string) {
+  if (!value) return fallback
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? fallback : formatter.format(date)
+}
+
+async function readApi<T>(response: Response): Promise<T> {
+  const payload = (await response.json().catch(() => null)) as ApiEnvelope<T> | null
+  if (!response.ok || !payload) throw new Error(payload?.message || 'Request failed')
+  return payload.data
+}
+
+export async function getJson<T>(url: string) {
+  const response = await fetch(url)
+  return readApi<T>(response)
+}
+
+export async function postJson<T>(url: string, body?: unknown) {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  return readApi<T>(response)
+}
+
+function formatStageToken(stage: string) {
+  return stage.replace(/-/g, ' ').toUpperCase()
+}
+
+function formatCodeToken(code: string) {
+  return code.replace(/_/g, ' ').toUpperCase()
+}
+
+function normalizeIssueText(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[\s.,:;!?()[\]{}"'`_-]+/g, ' ')
+    .trim()
+}
+
+function isGenericTimeoutDetail(detail: string) {
+  const normalized = normalizeIssueText(detail)
+  return normalized === 'the operation was aborted due to timeout'
+    || normalized === 'this operation was aborted'
+    || normalized === 'signal is aborted without reason'
+}
+
+function issueDetailText(issue: AdminTaskIssue, httpLabel: string | null) {
+  const detail = issue.detail?.trim()
+  if (!detail) return null
+
+  const normalizedDetail = normalizeIssueText(detail)
+  if (!normalizedDetail) return null
+
+  if (normalizedDetail === normalizeIssueText(issue.summary)) return null
+  if (httpLabel && normalizedDetail === normalizeIssueText(httpLabel)) return null
+  if (issue.code === 'timeout' && isGenericTimeoutDetail(detail)) return null
+
+  return detail
+}
+
+function DetailMetaRow({ items }: { items: Array<string | null | undefined> }) {
+  const filtered = items.filter((item): item is string => Boolean(item))
+  if (filtered.length === 0) return null
+
+  return (
+    <div className='flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.72rem] tracking-[0.12em] text-muted-foreground'>
+      {filtered.map((item, index) => (
+        <span key={`${item}-${index}`} className='inline-flex items-center gap-2'>
+          {index > 0 ? <span className='h-1 w-1 rounded-full bg-border/80' /> : null}
+          <span>{item}</span>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function DetailSkeleton() {
+  return (
+    <div className='animate-pulse space-y-5'>
+      <div className='grid gap-5 xl:grid-cols-[minmax(0,0.84fr)_minmax(0,1.16fr)] xl:items-start'>
+        <div className='space-y-5'>
+          <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
+            <div className='h-4 w-28 rounded-full bg-border/55' />
+            <div className='mt-4 grid gap-3 sm:grid-cols-2'>
+              <div className='h-20 rounded-[1.15rem] bg-background/75' />
+              <div className='h-20 rounded-[1.15rem] bg-background/75' />
+              <div className='h-20 rounded-[1.15rem] bg-background/75' />
+              <div className='h-20 rounded-[1.15rem] bg-background/75' />
+            </div>
+          </section>
+          <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
+            <div className='h-4 w-24 rounded-full bg-border/55' />
+            <div className='mt-4 h-24 rounded-[1.15rem] bg-background/75' />
+          </section>
+        </div>
+        <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
+          <div className='h-4 w-24 rounded-full bg-border/55' />
+          <div className='mt-4 space-y-3'>
+            <div className='h-32 rounded-[1.15rem] bg-background/75' />
+            <div className='h-32 rounded-[1.15rem] bg-background/75' />
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function ErrorDetailCard({
+  title,
+  error,
+  dateFormatter,
+  fallback,
+}: {
+  title: string
+  error: AdminTaskError
+  dateFormatter: Intl.DateTimeFormat
+  fallback: string
+}) {
+  return (
+    <section className='rounded-[1.45rem] border border-rose-400/35 bg-rose-500/10 p-4 sm:p-5 text-rose-700 dark:text-rose-300'>
+      <div className='flex items-center gap-2'>
+        <TriangleAlert className='size-4' />
+        <h3 className='font-medium'>{title}</h3>
+      </div>
+      <div className='mt-4 space-y-3'>
+        <DetailMetaRow items={[
+          formatStageToken(error.stage),
+          formatCodeToken(error.code),
+          formatDate(error.at, dateFormatter, fallback),
+        ]}
+        />
+        <p className='text-sm leading-6 text-rose-800 dark:text-rose-200'>{error.message}</p>
+        {error.detail ? (
+          <div className='rounded-[1rem] border border-rose-400/25 bg-background/70 px-3 py-2.5 text-sm leading-6 text-rose-900/80 whitespace-pre-wrap break-words dark:text-rose-100/85'>
+            {error.detail}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+function IssueDetailCard({
+  issue,
+  dateFormatter,
+  fallback,
+  infoLabel,
+  warningLabel,
+  errorLabel,
+}: {
+  issue: AdminTaskIssue
+  dateFormatter: Intl.DateTimeFormat
+  fallback: string
+  infoLabel: string
+  warningLabel: string
+  errorLabel: string
+}) {
+  const httpLabel = issue.httpStatus
+    ? `HTTP ${issue.httpStatus}${issue.httpStatusText ? ` ${issue.httpStatusText}` : ''}`
+    : null
+  const detailText = issueDetailText(issue, httpLabel)
+
+  return (
+    <article className='overflow-hidden rounded-[1.15rem] border border-border/70 bg-background/78'>
+      <div className='space-y-2.5 p-3.5 sm:p-4'>
+          <div className='flex flex-wrap items-start justify-between gap-2'>
+            <div className='min-w-0'>
+              <p className='truncate text-sm font-medium text-foreground sm:text-[0.98rem]'>{issue.imageTitle}</p>
+              <p className='mt-1 truncate text-xs text-muted-foreground'>{issue.imageId}</p>
+            </div>
+            <Badge variant='outline' className={cn('rounded-full px-2.5 py-0.5', issueClass(issue.level))}>
+              {issue.level === 'error' ? errorLabel : issue.level === 'warning' ? warningLabel : infoLabel}
+            </Badge>
+          </div>
+
+          <DetailMetaRow items={[
+            formatStageToken(issue.stage),
+            formatCodeToken(issue.code),
+            formatDate(issue.at, dateFormatter, fallback),
+            httpLabel,
+          ]}
+          />
+
+          <p className='text-sm leading-6 text-foreground/88'>{issue.summary}</p>
+
+          {detailText ? (
+            <div className='rounded-[1rem] border border-border/60 bg-background/72 px-3 py-2.5 text-sm leading-6 text-muted-foreground whitespace-pre-wrap break-words'>
+              {detailText}
+            </div>
+          ) : null}
+      </div>
+    </article>
+  )
+}
+
+/**
+ * Render-prop arguments handed to a task's pluggable scope control. The control
+ * owns the inputs that produce the task scope (album/show selectors for
+ * metadata, a force toggle for preprocess) and reports changes back through
+ * `setScope`.
+ */
+export type ScopeControlProps<Scope> = {
+  scope: Scope
+  setScope: (updater: (current: Scope) => Scope) => void
+  disabled: boolean
+}
+
+/**
+ * Per-task configuration consumed by {@link TaskRunPanel}. Everything that
+ * differs between the metadata and preprocess tasks is funnelled through here so
+ * the panel body, SWR wiring, polling and handlers stay shared.
+ */
+export type TaskRunPanelConfig<Scope> = {
+  basePath: '/api/v1/tasks' | '/api/v1/preprocess-tasks'
+  taskKey: AdminTaskKey
+  defaultScope: Scope
+  /** Builds the preview-count query string (without leading `?`) from the scope. */
+  previewCountQuery: (scope: Scope) => string
+  /** Human-readable label for a scope, shown on badges / run rows / detail. */
+  scopeLabel: (scope: Scope) => string
+  /** Renders the scope inputs. */
+  ScopeControl: (props: ScopeControlProps<Scope>) => ReactNode
+  /** Whether the given scope permits starting a run regardless of preview count. */
+  canStartWithoutPreview?: (scope: Scope) => boolean
+  /** Maps a start error to a friendly message; return null to fall back. */
+  mapStartError?: (error: Error) => string | null
+  /** Extra hint nodes rendered under the start button (e.g. albums loading). */
+  renderExtraHints?: (ctx: { activeRun: boolean; previewLoading: boolean }) => ReactNode
+  /** Optional booting flag (e.g. metadata waits for albums to load). */
+  extraBooting?: boolean
+}
+
+export default function TaskRunPanel<Scope>({ config }: { config: TaskRunPanelConfig<Scope> }) {
+  const { basePath, taskKey } = config
+  const t = useTranslations('Tasks')
+  const tx = useTranslations()
+  const locale = useLocale()
+  const numberFormatter = new Intl.NumberFormat(locale)
+  const dateFormatter = new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'medium' })
+  const [scope, setScope] = useState<Scope>(config.defaultScope)
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
+  const [isStarting, setIsStarting] = useState(false)
+  const [isCancelling, setIsCancelling] = useState(false)
+  const kickingRef = useRef(false)
+  const previewQuery = config.previewCountQuery(scope)
+
+  const { data: runsData, isLoading: runsLoading, mutate: mutateRuns } = useSWR<AdminTaskRunsResponse>(
+    `${basePath}/runs`,
+    getJson,
+    { refreshInterval: 5000 }
+  )
+  const { data: previewData, isLoading: previewLoading } = useSWR<AdminTaskPreviewCount>(
+    `${basePath}/preview-count${previewQuery ? `?${previewQuery}` : ''}`,
+    getJson
+  )
+  const { data: selectedRunDetail, isLoading: detailLoading, error: detailError } = useSWR<AdminTaskRunDetail>(
+    selectedRunId ? `${basePath}/runs/${selectedRunId}` : null,
+    getJson
+  )
+
+  const activeRun = runsData?.activeRun ?? null
+  const recentRuns = runsData?.recentRuns ?? []
+  const selectedRunSummary = recentRuns.find((run) => run.id === selectedRunId) ?? null
+  const selectedRun = selectedRunDetail ?? selectedRunSummary
+
+  const statusLabel = (status: AdminTaskStatus) =>
+    status === 'queued'
+      ? t('statusQueued')
+      : status === 'running'
+        ? t('statusRunning')
+        : status === 'cancelling'
+          ? t('statusCancelling')
+          : status === 'succeeded'
+            ? t('statusSucceeded')
+            : status === 'failed'
+              ? t('statusFailed')
+              : t('statusCancelled')
+
+  // Run scopes come back from the server typed as the metadata shape; cast to
+  // the panel's scope type so each task labels its own scope correctly.
+  const labelForRunScope = (runScope: AdminTaskRunBase['scope']) => config.scopeLabel(runScope as unknown as Scope)
+
+  async function refreshTaskData() {
+    await mutateRuns()
+  }
+
+  useEffect(() => {
+    if (!activeRun?.id || activeRun.status === 'cancelling') return
+
+    let cancelled = false
+
+    const runKick = async () => {
+      if (kickingRef.current) return
+      kickingRef.current = true
+
+      try {
+        await postJson<AdminTaskRunSummary>(`${basePath}/runs/${activeRun.id}/kick`)
+        if (!cancelled) {
+          await mutateRuns()
+        }
+      } catch (error) {
+        if (!cancelled) toast.error(error instanceof Error ? error.message : t('kickFailed'))
+      } finally {
+        kickingRef.current = false
+      }
+    }
+
+    void runKick()
+    const timer = window.setInterval(() => {
+      void runKick()
+    }, 4500)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(timer)
+    }
+  }, [activeRun?.id, activeRun?.status, mutateRuns, t, basePath])
+
+  async function handleStartTask() {
+    try {
+      setIsStarting(true)
+      await postJson<AdminTaskRunSummary>(`${basePath}/runs`, {
+        taskKey,
+        scope,
+      })
+      toast.success(t('startSuccess'))
+      await refreshTaskData()
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(t('startFailed'))
+      const mapped = config.mapStartError?.(err) ?? null
+      toast.error(mapped ?? err.message ?? t('startFailed'))
+    } finally {
+      setIsStarting(false)
+    }
+  }
+
+  async function handleCancelTask() {
+    if (!activeRun?.id || activeRun.status === 'cancelling') return
+
+    try {
+      setIsCancelling(true)
+      await postJson<AdminTaskRunSummary>(`${basePath}/runs/${activeRun.id}/cancel`)
+      toast.success(t('cancelSuccess'))
+      await refreshTaskData()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('cancelFailed'))
+    } finally {
+      setIsCancelling(false)
+    }
+  }
+
+  const previewCount = previewData?.totalCount ?? 0
+  const activeProgress = progressOf(activeRun)
+  const cancelPending = isCancelling || activeRun?.status === 'cancelling'
+  const allowEmptyPreview = config.canStartWithoutPreview?.(scope) ?? false
+  const canStart = !activeRun && (allowEmptyPreview || previewCount > 0) && !isStarting
+  const booting = Boolean(config.extraBooting) || (!runsData && runsLoading)
+  const detailBooting = Boolean(selectedRunId) && detailLoading && !selectedRunDetail
+  return (
+    <>
+      <div className='relative overflow-hidden px-1 py-2 sm:px-2'>
+        <div className='pointer-events-none absolute inset-0 overflow-hidden'>
+          <div className='absolute -left-10 top-8 h-48 w-48 rounded-full bg-primary/10 blur-3xl' />
+          <div className='absolute right-[-4rem] top-16 h-64 w-64 rounded-full bg-secondary blur-3xl' />
+          <div className='absolute bottom-6 left-1/3 h-44 w-44 rounded-full bg-primary/8 blur-3xl' />
+        </div>
+
+        <div className='relative space-y-6'>
+          <section className={cn(panelClass, 'px-5 py-4 sm:px-6 sm:py-5')}>
+            <div className='pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent' />
+            <div className='flex flex-col gap-4'>
+              <div className={cn('flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between', !activeRun && 'hidden')}>
+                {activeRun ? (
+                  <div className='flex flex-wrap items-center gap-2 xl:justify-end'>
+                    <Badge variant='outline' className={cn('rounded-full px-3 py-1', statusClass(activeRun.status))}>
+                      {statusLabel(activeRun.status)}
+                    </Badge>
+                    <Badge variant='outline' className='rounded-full border-border/80 bg-background/70 px-3 py-1 text-muted-foreground'>
+                      {taskKey}
+                    </Badge>
+                    <Badge variant='outline' className='rounded-full border-border/80 bg-background/70 px-3 py-1 text-muted-foreground'>
+                      {labelForRunScope(activeRun.scope)}
+                    </Badge>
+                    <Button
+                      variant='outline'
+                      onClick={handleCancelTask}
+                      disabled={cancelPending}
+                      className='min-w-32 rounded-full px-4'
+                    >
+                      {cancelPending ? <LoaderCircle className='animate-spin' /> : <TriangleAlert />}
+                      {cancelPending ? t('cancelling') : t('cancel')}
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+
+              <div
+                className={cn(
+                  'grid gap-4 xl:items-start',
+                  activeRun ? 'xl:grid-cols-[minmax(0,1.04fr)_minmax(19rem,0.96fr)]' : 'xl:grid-cols-1'
+                )}
+              >
+                {activeRun ? (
+                  <div className='space-y-4 xl:border-r xl:border-border/55 xl:pr-5'>
+                    <div className='grid gap-3 rounded-[1.35rem] border border-border/70 bg-background/62 p-4'>
+                      <div className='grid gap-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-end'>
+                        <div>
+                          <p className='text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground'>
+                            {t('progressLabel')}
+                          </p>
+                          <p className='mt-1.5 font-display text-[2.15rem] leading-none tracking-tight text-foreground sm:text-[2.45rem]'>
+                            {activeProgress}%
+                          </p>
+                        </div>
+                        <div className='grid gap-2 text-sm leading-6 text-muted-foreground sm:grid-cols-3'>
+                          <div className='rounded-[0.95rem] bg-background/78 px-3 py-2.5'>
+                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('matchedCount')}</p>
+                            <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(activeRun.totalCount)}</p>
+                          </div>
+                          <div className='rounded-[0.95rem] bg-background/78 px-3 py-2.5'>
+                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('processedLabel')}</p>
+                            <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(activeRun.processedCount)}</p>
+                          </div>
+                          <div className='rounded-[0.95rem] bg-background/78 px-3 py-2.5'>
+                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('startedAtLabel')}</p>
+                            <p className='mt-1 text-base font-medium text-foreground'>
+                              {formatDate(activeRun.startedAt || activeRun.createdAt, dateFormatter, t('notAvailable'))}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      <Progress value={activeProgress} className='h-2 bg-primary/15' />
+                    </div>
+
+                    <div className='grid gap-2 sm:grid-cols-2 xl:grid-cols-4'>
+                      <div className='rounded-[1rem] border border-border/60 bg-background/70 px-3 py-2.5'>
+                        <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('processedLabel')}</p>
+                        <p className='mt-1.5 font-display text-[1.55rem] leading-none tracking-tight text-foreground'>{numberFormatter.format(activeRun.processedCount)}</p>
+                      </div>
+                      <div className='rounded-[1rem] border border-border/60 bg-emerald-500/8 px-3 py-2.5 text-emerald-700 dark:text-emerald-300'>
+                        <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('successLabel')}</p>
+                        <p className='mt-1.5 font-display text-[1.55rem] leading-none tracking-tight'>{numberFormatter.format(activeRun.successCount)}</p>
+                      </div>
+                      <div className='rounded-[1rem] border border-border/60 bg-amber-500/10 px-3 py-2.5 text-amber-700 dark:text-amber-300'>
+                        <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('skippedLabel')}</p>
+                        <p className='mt-1.5 font-display text-[1.55rem] leading-none tracking-tight'>{numberFormatter.format(activeRun.skippedCount)}</p>
+                      </div>
+                      <div className='rounded-[1rem] border border-border/60 bg-rose-500/10 px-3 py-2.5 text-rose-700 dark:text-rose-300'>
+                        <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('failedLabel')}</p>
+                        <p className='mt-1.5 font-display text-[1.55rem] leading-none tracking-tight'>{numberFormatter.format(activeRun.failedCount)}</p>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+
+                <div className={cn('space-y-4', activeRun ? 'xl:pl-1' : 'min-w-0')}>
+                  <config.ScopeControl scope={scope} setScope={setScope} disabled={Boolean(activeRun)} />
+
+                  <div className='grid gap-3 rounded-[1.3rem] border border-primary/15 bg-primary/7 p-3 lg:grid-cols-[minmax(8.5rem,0.32fr)_minmax(0,1fr)] lg:items-stretch'>
+                    <div className='flex min-h-[8.5rem] flex-col justify-between rounded-[1rem] bg-background/82 px-3.5 py-3'>
+                      <p className='text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground'>{t('previewLabel')}</p>
+                      <p className='font-display text-[2.15rem] leading-none tracking-tight text-foreground sm:text-[2.35rem]'>{previewLoading ? '...' : numberFormatter.format(previewCount)}</p>
+                    </div>
+
+                    <div className='grid min-h-[8.5rem] gap-3 rounded-[1rem] border border-border/70 bg-background/78 px-3.5 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-stretch'>
+                      <div className='space-y-2 md:flex md:h-full md:flex-col md:justify-between md:space-y-0'>
+                        <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('currentSelection')}</p>
+                        <div className='flex flex-wrap items-center gap-2'>
+                          <span className='rounded-full border border-border/70 bg-background/90 px-3 py-1.5 text-sm font-medium text-foreground'>{config.scopeLabel(scope)}</span>
+                        </div>
+                      </div>
+
+                      <Button onClick={handleStartTask} disabled={!canStart} className='h-10 w-full rounded-full md:min-w-40 md:self-center md:w-auto'>
+                        {isStarting ? <LoaderCircle className='animate-spin' /> : <RefreshCw />}
+                        {isStarting ? t('starting') : t('start')}
+                      </Button>
+
+                      {!activeRun && previewCount < 1 && !previewLoading && !allowEmptyPreview ? (
+                        <div className='md:col-span-2 flex flex-wrap gap-x-4 gap-y-1 text-sm leading-6 text-muted-foreground'>
+                          <p>{t('noMatchHint')}</p>
+                          {config.renderExtraHints?.({ activeRun: false, previewLoading })}
+                        </div>
+                      ) : null}
+                      {activeRun ? (
+                        <div className='md:col-span-2 flex flex-wrap gap-x-4 gap-y-1 text-sm leading-6 text-muted-foreground'>
+                          <p>{t('runningHint')}</p>
+                          {config.renderExtraHints?.({ activeRun: true, previewLoading })}
+                        </div>
+                      ) : config.renderExtraHints?.({ activeRun: false, previewLoading }) ? (
+                        <div className='md:col-span-2 flex flex-wrap gap-x-4 gap-y-1 text-sm leading-6 text-muted-foreground'>
+                          {config.renderExtraHints?.({ activeRun: false, previewLoading })}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className={cn(panelClass, 'px-5 py-5 sm:px-6 sm:py-6')}>
+            <div className='pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent' />
+            <div className='flex flex-col gap-5'>
+              <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+                <p className='text-sm font-medium text-primary/80'>{t('historyEyebrow')}</p>
+                <div className='flex flex-wrap items-center gap-2'>
+                  <div className='inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/70 px-3 py-1.5 text-sm text-muted-foreground'>
+                    {t('historyRecentLimit', { count: HISTORY_RECENT_LIMIT })}
+                  </div>
+                  <Button variant='outline' size='sm' onClick={() => void refreshTaskData()} className='rounded-full'>
+                    <RefreshCw />
+                    {tx('Button.refresh')}
+                  </Button>
+                </div>
+              </div>
+              {recentRuns.length > 0 ? (
+                <div className='overflow-hidden rounded-[1.45rem] border border-border/70 bg-background/50'>
+                  <ScrollArea className='w-full' type='always' style={recentRuns.length > HISTORY_VISIBLE_ROWS ? { height: HISTORY_SCROLL_MAX_HEIGHT } : { maxHeight: HISTORY_SCROLL_MAX_HEIGHT }}>
+                    <div>
+                      {recentRuns.map((run, index) => (
+                        <button
+                          key={run.id}
+                          type='button'
+                          onClick={() => setSelectedRunId(run.id)}
+                          className={cn(
+                            'group grid w-full gap-4 px-4 py-4 text-left transition-colors hover:bg-primary/6 sm:px-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)_auto] lg:items-center',
+                            index > 0 ? 'border-t border-border/60' : null
+                          )}
+                          style={{ minHeight: `${HISTORY_CARD_MIN_HEIGHT_REM}rem` }}
+                        >
+                          <div className='min-w-0 space-y-3'>
+                            <div className='flex flex-wrap items-center gap-2'>
+                              <Badge variant='outline' className={cn('rounded-full px-2.5 py-0.5', statusClass(run.status))}>
+                                {statusLabel(run.status)}
+                              </Badge>
+                              <span className='text-xs uppercase tracking-[0.14em] text-muted-foreground'>
+                                {formatDate(run.createdAt, dateFormatter, t('notAvailable'))}
+                              </span>
+                            </div>
+
+                            <div className='space-y-1'>
+                              <p className='truncate text-base font-medium text-foreground'>{labelForRunScope(run.scope)}</p>
+                              <p className='text-sm leading-6 text-muted-foreground'>{t('matchedCount')}: {numberFormatter.format(run.totalCount)}</p>
+                            </div>
+
+                            <Progress value={progressOf(run)} className='h-2 bg-primary/12' />
+                          </div>
+
+                          <div className='grid gap-2 text-sm text-muted-foreground sm:grid-cols-3 lg:grid-cols-3'>
+                            <div className='rounded-[1rem] bg-background/70 px-3 py-2'>
+                              <p className='text-[0.68rem] uppercase tracking-[0.14em]'>{t('successLabel')}</p>
+                              <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(run.successCount)}</p>
+                            </div>
+                            <div className='rounded-[1rem] bg-background/70 px-3 py-2'>
+                              <p className='text-[0.68rem] uppercase tracking-[0.14em]'>{t('skippedLabel')}</p>
+                              <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(run.skippedCount)}</p>
+                            </div>
+                            <div className='rounded-[1rem] bg-background/70 px-3 py-2'>
+                              <p className='text-[0.68rem] uppercase tracking-[0.14em]'>{t('failedLabel')}</p>
+                              <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(run.failedCount)}</p>
+                            </div>
+                          </div>
+
+                          <div className='flex items-center justify-between gap-3 lg:justify-end'>
+                            <span className='inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/75 px-3 py-1.5 text-sm font-medium text-foreground/80 transition-colors group-hover:border-primary/25 group-hover:text-foreground'>
+                              {t('detailView')}
+                              <ChevronRight className='size-4 transition-transform group-hover:translate-x-0.5' />
+                            </span>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  </ScrollArea>
+
+                </div>
+              ) : (
+                <div className='rounded-[1.35rem] border border-dashed border-border/80 bg-background/55 px-4 py-5 text-sm leading-6 text-muted-foreground'>
+                  {booting ? t('loading') : t('noHistory')}
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <Dialog open={Boolean(selectedRunId)} onOpenChange={(open) => { if (!open) setSelectedRunId(null) }}>
+        {selectedRunId ? (
+          <DialogContent className='grid h-[min(92dvh,56rem)] max-h-[calc(100dvh-1.5rem)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden border-border/70 bg-background/95 p-0 shadow-[0_24px_80px_rgba(90,56,25,0.18)] sm:max-w-[56rem]'>
+            <div className='relative grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden'>
+              <div className='pointer-events-none absolute inset-0 overflow-hidden'>
+                <div className='absolute -left-6 top-4 h-28 w-28 rounded-full bg-primary/8 blur-3xl' />
+                <div className='absolute right-[-2rem] top-0 h-36 w-36 rounded-full bg-secondary/70 blur-3xl' />
+              </div>
+
+              <DialogHeader className='relative gap-4 border-b border-border/60 px-5 py-5 text-left sm:px-6'>
+                {selectedRun ? (
+                  <>
+                    <div className='space-y-2'>
+                      <p className='text-[0.68rem] uppercase tracking-[0.22em] text-primary/75'>{t('detailEyebrow')}</p>
+                      <DialogTitle className='font-display text-[1.45rem] leading-none text-foreground sm:text-[1.7rem]'>{labelForRunScope(selectedRun.scope)}</DialogTitle>
+                      <DialogDescription className='max-w-2xl text-sm leading-6 text-muted-foreground'>{t('detailDescription')}</DialogDescription>
+                    </div>
+
+                    <div className='flex flex-wrap items-center gap-2 pr-8 sm:pr-10'>
+                      <Badge variant='outline' className={cn('rounded-full px-3 py-1', statusClass(selectedRun.status))}>
+                        {statusLabel(selectedRun.status)}
+                      </Badge>
+                      <Badge variant='outline' className='rounded-full border-border/80 bg-background/75 px-3 py-1 text-muted-foreground'>
+                        {formatDate(selectedRun.createdAt, dateFormatter, t('notAvailable'))}
+                      </Badge>
+                      <Badge variant='outline' className='rounded-full border-border/80 bg-background/75 px-3 py-1 text-muted-foreground'>
+                        {taskKey}
+                      </Badge>
+                    </div>
+                  </>
+                ) : (
+                  <div className='animate-pulse space-y-3'>
+                    <div className='h-3 w-20 rounded-full bg-border/55' />
+                    <div className='h-8 w-56 rounded-full bg-border/60' />
+                    <div className='h-4 w-72 rounded-full bg-border/50' />
+                  </div>
+                )}
+              </DialogHeader>
+
+              <ScrollArea className='min-h-0'>
+                <div className='space-y-5 px-5 py-5 sm:px-6 sm:py-6'>
+                  {selectedRun ? (
+                    <section className='rounded-[1.6rem] border border-border/70 bg-background/68 p-4 sm:p-5'>
+                      <div className='grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(15rem,0.8fr)] lg:items-end'>
+                        <div className='space-y-4'>
+                          <div className='flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between'>
+                            <div>
+                              <p className='text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground'>{t('progressLabel')}</p>
+                              <p className='mt-2 font-display text-[3rem] leading-none tracking-tight text-foreground sm:text-[3.5rem]'>{progressOf(selectedRun)}%</p>
+                            </div>
+                            <div className='space-y-1 text-sm leading-6 text-muted-foreground sm:text-right'>
+                              <p>{t('matchedCount')}: {numberFormatter.format(selectedRun.totalCount)}</p>
+                              <p>{t('processedLabel')}: {numberFormatter.format(selectedRun.processedCount)}</p>
+                            </div>
+                          </div>
+                          <Progress value={progressOf(selectedRun)} className='h-2.5 bg-primary/15' />
+                        </div>
+
+                        <div className='grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3'>
+                          <div className='rounded-[1.2rem] border border-border/60 bg-emerald-500/8 px-4 py-3 text-emerald-700 dark:text-emerald-300'>
+                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('successLabel')}</p>
+                            <p className='mt-2 font-display text-[1.9rem] leading-none tracking-tight'>{numberFormatter.format(selectedRun.successCount)}</p>
+                          </div>
+                          <div className='rounded-[1.2rem] border border-border/60 bg-amber-500/10 px-4 py-3 text-amber-700 dark:text-amber-300'>
+                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('skippedLabel')}</p>
+                            <p className='mt-2 font-display text-[1.9rem] leading-none tracking-tight'>{numberFormatter.format(selectedRun.skippedCount)}</p>
+                          </div>
+                          <div className='rounded-[1.2rem] border border-border/60 bg-rose-500/10 px-4 py-3 text-rose-700 dark:text-rose-300'>
+                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('failedLabel')}</p>
+                            <p className='mt-2 font-display text-[1.9rem] leading-none tracking-tight'>{numberFormatter.format(selectedRun.failedCount)}</p>
+                          </div>
+                        </div>
+                      </div>
+                    </section>
+                  ) : (
+                    <section className='rounded-[1.6rem] border border-border/70 bg-background/68 p-4 sm:p-5'>
+                      <div className='animate-pulse space-y-4'>
+                        <div className='h-4 w-24 rounded-full bg-border/55' />
+                        <div className='h-12 w-32 rounded-full bg-border/60' />
+                        <div className='h-2.5 rounded-full bg-border/45' />
+                      </div>
+                    </section>
+                  )}
+
+                  {detailBooting ? (
+                    <DetailSkeleton />
+                  ) : detailError ? (
+                    <section className='rounded-[1.45rem] border border-rose-400/35 bg-rose-500/10 p-4 sm:p-5 text-rose-700 dark:text-rose-300'>
+                      <p className='text-sm leading-6'>{detailError instanceof Error ? detailError.message : t('kickFailed')}</p>
+                    </section>
+                  ) : selectedRunDetail ? (
+                    <div className='grid gap-5 xl:grid-cols-[minmax(0,0.84fr)_minmax(0,1.16fr)] xl:items-start'>
+                      <div className='space-y-5'>
+                        <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
+                          <div className='flex items-center gap-2 text-foreground'>
+                            <Wrench className='size-4 text-primary' />
+                            <h3 className='font-medium'>{t('countsTitle')}</h3>
+                          </div>
+                          <div className='mt-4 grid gap-3 sm:grid-cols-2'>
+                            <div className='rounded-[1.15rem] bg-background/75 px-4 py-3 text-sm leading-6 text-muted-foreground'>
+                              <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('matchedCount')}</p>
+                              <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(selectedRunDetail.totalCount)}</p>
+                            </div>
+                            <div className='rounded-[1.15rem] bg-background/75 px-4 py-3 text-sm leading-6 text-muted-foreground'>
+                              <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('processedLabel')}</p>
+                              <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(selectedRunDetail.processedCount)}</p>
+                            </div>
+                          </div>
+                        </section>
+
+                        <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
+                          <div className='flex items-center gap-2 text-foreground'>
+                            <Clock3 className='size-4 text-primary' />
+                            <h3 className='font-medium'>{t('timelineTitle')}</h3>
+                          </div>
+                          <div className='mt-4 space-y-3'>
+                            <div className='rounded-[1.15rem] bg-background/75 px-4 py-3 text-sm leading-6 text-muted-foreground'>
+                              <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('startedAtLabel')}</p>
+                              <p className='mt-1 text-foreground'>{formatDate(selectedRunDetail.startedAt || selectedRunDetail.createdAt, dateFormatter, t('notAvailable'))}</p>
+                            </div>
+                            <div className='rounded-[1.15rem] bg-background/75 px-4 py-3 text-sm leading-6 text-muted-foreground'>
+                              <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('finishedAtLabel')}</p>
+                              <p className='mt-1 text-foreground'>{formatDate(selectedRunDetail.finishedAt, dateFormatter, t('unfinished'))}</p>
+                            </div>
+                          </div>
+                        </section>
+
+                        {selectedRunDetail.lastError ? (
+                          <ErrorDetailCard
+                            title={t('lastErrorTitle')}
+                            error={selectedRunDetail.lastError}
+                            dateFormatter={dateFormatter}
+                            fallback={t('notAvailable')}
+                          />
+                        ) : null}
+                      </div>
+
+                      <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
+                        <div className='flex items-center gap-2 text-foreground'>
+                          <MapPinned className='size-4 text-primary' />
+                          <h3 className='font-medium'>{t('issuesTitle')}</h3>
+                        </div>
+                        <div className='mt-4 space-y-3'>
+                          {selectedRunDetail.recentIssues.length > 0 ? (
+                            selectedRunDetail.recentIssues.map((issue, index) => (
+                              <IssueDetailCard
+                                key={`${issue.imageId}-${issue.code}-${index}`}
+                                issue={issue}
+                                dateFormatter={dateFormatter}
+                                fallback={t('notAvailable')}
+                                infoLabel={t('issueInfo')}
+                                warningLabel={t('issueWarning')}
+                                errorLabel={t('issueError')}
+                              />
+                            ))
+                          ) : (
+                            <div className='rounded-[1.15rem] border border-dashed border-border/80 bg-background/60 px-4 py-4 text-sm leading-6 text-muted-foreground'>
+                              {t('noIssues')}
+                            </div>
+                          )}
+                        </div>
+                      </section>
+                    </div>
+                  ) : null}
+                </div>
+              </ScrollArea>
+            </div>
+          </DialogContent>
+        ) : null}
+      </Dialog>
+    </>
+  )
+}

--- a/components/admin/tasks/tasks-page.tsx
+++ b/components/admin/tasks/tasks-page.tsx
@@ -1,827 +1,146 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useMemo } from 'react'
 import useSWR from 'swr'
-import { useLocale, useTranslations } from 'next-intl'
-import { ChevronRight, Clock3, LoaderCircle, MapPinned, RefreshCw, TriangleAlert, Wrench } from 'lucide-react'
-import { toast } from 'sonner'
+import { useTranslations } from 'next-intl'
 
-import { Badge } from '~/components/ui/badge'
-import { Button } from '~/components/ui/button'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '~/components/ui/dialog'
-import { Progress } from '~/components/ui/progress'
-import { ScrollArea } from '~/components/ui/scroll-area'
+import { Switch } from '~/components/ui/switch'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
-import { cn } from '~/lib/utils'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import { fetcher } from '~/lib/utils/fetcher'
 import type { AlbumType } from '~/types'
-import type {
-  AdminTaskError,
-  AdminTaskIssue,
-  AdminTaskPreviewCount,
-  AdminTaskRunBase,
-  AdminTaskRunDetail,
-  AdminTaskRunSummary,
-  AdminTaskRunsResponse,
-  AdminTaskScope,
-  AdminTaskStatus,
-} from '~/types/admin-tasks'
-import { ADMIN_TASK_KEY_REFRESH_IMAGE_METADATA } from '~/types/admin-tasks'
+import type { AdminTaskScope, PreprocessTaskScope } from '~/types/admin-tasks'
+import { ADMIN_TASK_KEY_PREPROCESS_IMAGES, ADMIN_TASK_KEY_REFRESH_IMAGE_METADATA } from '~/types/admin-tasks'
+import TaskRunPanel, { type ScopeControlProps, type TaskRunPanelConfig } from '~/components/admin/tasks/task-run-panel'
 
-type ApiEnvelope<T> = { code: number; message: string; data: T }
 type AlbumOption = Pick<AlbumType, 'id' | 'name' | 'album_value'>
 
-const DEFAULT_SCOPE: AdminTaskScope = { albumValue: 'all', showStatus: -1 }
-const HISTORY_RECENT_LIMIT = 10
-const HISTORY_VISIBLE_ROWS = 3
-const HISTORY_CARD_MIN_HEIGHT_REM = 10.75
-const HISTORY_SCROLL_MAX_HEIGHT = `${HISTORY_VISIBLE_ROWS * HISTORY_CARD_MIN_HEIGHT_REM}rem`
-const panelClass = 'show-up-motion relative overflow-hidden rounded-[1.7rem] border border-border/70 bg-card/82 shadow-sm backdrop-blur-sm'
+const METADATA_DEFAULT_SCOPE: AdminTaskScope = { albumValue: 'all', showStatus: -1 }
+const PREPROCESS_DEFAULT_SCOPE: PreprocessTaskScope = { force: false }
 
-function statusClass(status: AdminTaskStatus) {
-  switch (status) {
-    case 'queued':
-    case 'cancelling':
-      return 'border-amber-400/35 bg-amber-500/12 text-amber-700 dark:text-amber-300'
-    case 'running':
-      return 'border-primary/30 bg-primary/10 text-primary'
-    case 'succeeded':
-      return 'border-emerald-400/35 bg-emerald-500/12 text-emerald-700 dark:text-emerald-300'
-    case 'failed':
-      return 'border-rose-400/35 bg-rose-500/12 text-rose-700 dark:text-rose-300'
-    case 'cancelled':
-    default:
-      return 'border-border/80 bg-secondary text-secondary-foreground'
-  }
-}
+// The server raises this exact message (HTTP 400) when no variant storage
+// backend has been chosen; surface a friendlier hint instead of the raw error.
+const VARIANT_STORAGE_NOT_CONFIGURED = 'Variant storage backend is not configured'
 
-function issueClass(level: AdminTaskIssue['level']) {
-  if (level === 'error') {
-    return 'border-rose-400/35 bg-rose-500/12 text-rose-700 dark:text-rose-300'
-  }
-
-  if (level === 'warning') {
-    return 'border-amber-400/35 bg-amber-500/12 text-amber-700 dark:text-amber-300'
-  }
-
-  return 'border-slate-400/35 bg-slate-500/10 text-slate-700 dark:text-slate-300'
-}
-
-function progressOf(run: AdminTaskRunBase | null) {
-  if (!run || run.totalCount <= 0) return 0
-  return Math.min(100, Math.round((run.processedCount / run.totalCount) * 100))
-}
-
-function formatDate(value: string | null, formatter: Intl.DateTimeFormat, fallback: string) {
-  if (!value) return fallback
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? fallback : formatter.format(date)
-}
-
-async function readApi<T>(response: Response): Promise<T> {
-  const payload = (await response.json().catch(() => null)) as ApiEnvelope<T> | null
-  if (!response.ok || !payload) throw new Error(payload?.message || 'Request failed')
-  return payload.data
-}
-
-async function getJson<T>(url: string) {
-  const response = await fetch(url)
-  return readApi<T>(response)
-}
-
-async function postJson<T>(url: string, body?: unknown) {
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: body ? { 'Content-Type': 'application/json' } : undefined,
-    body: body ? JSON.stringify(body) : undefined,
-  })
-  return readApi<T>(response)
-}
-
-function formatStageToken(stage: string) {
-  return stage.replace(/-/g, ' ').toUpperCase()
-}
-
-function formatCodeToken(code: string) {
-  return code.replace(/_/g, ' ').toUpperCase()
-}
-
-function normalizeIssueText(value: string) {
-  return value
-    .toLowerCase()
-    .replace(/[\s.,:;!?()[\]{}"'`_-]+/g, ' ')
-    .trim()
-}
-
-function isGenericTimeoutDetail(detail: string) {
-  const normalized = normalizeIssueText(detail)
-  return normalized === 'the operation was aborted due to timeout'
-    || normalized === 'this operation was aborted'
-    || normalized === 'signal is aborted without reason'
-}
-
-function issueDetailText(issue: AdminTaskIssue, httpLabel: string | null) {
-  const detail = issue.detail?.trim()
-  if (!detail) return null
-
-  const normalizedDetail = normalizeIssueText(detail)
-  if (!normalizedDetail) return null
-
-  if (normalizedDetail === normalizeIssueText(issue.summary)) return null
-  if (httpLabel && normalizedDetail === normalizeIssueText(httpLabel)) return null
-  if (issue.code === 'timeout' && isGenericTimeoutDetail(detail)) return null
-
-  return detail
-}
-
-function DetailMetaRow({ items }: { items: Array<string | null | undefined> }) {
-  const filtered = items.filter((item): item is string => Boolean(item))
-  if (filtered.length === 0) return null
+function MetadataScopeControl({ scope, setScope, disabled }: ScopeControlProps<AdminTaskScope>) {
+  const tx = useTranslations()
+  const { data: albums } = useSWR<AlbumOption[]>('/api/v1/albums', fetcher)
 
   return (
-    <div className='flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.72rem] tracking-[0.12em] text-muted-foreground'>
-      {filtered.map((item, index) => (
-        <span key={`${item}-${index}`} className='inline-flex items-center gap-2'>
-          {index > 0 ? <span className='h-1 w-1 rounded-full bg-border/80' /> : null}
-          <span>{item}</span>
-        </span>
-      ))}
+    <div className='flex w-fit flex-wrap items-end gap-3'>
+      <label className='flex w-[8.75rem] shrink-0 flex-col gap-1.5'>
+        <span className='text-sm font-medium text-foreground'>{tx('Words.album')}</span>
+        <Select value={scope.albumValue} onValueChange={(albumValue) => setScope((current) => ({ ...current, albumValue }))} disabled={disabled}>
+          <SelectTrigger className='h-10 w-full rounded-[0.95rem] bg-background/75'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value='all'>{tx('Words.all')}</SelectItem>
+            {albums?.map((album) => (
+              <SelectItem key={album.id} value={album.album_value}>{album.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </label>
+
+      <label className='flex w-[8.75rem] shrink-0 flex-col gap-1.5'>
+        <span className='text-sm font-medium text-foreground'>{tx('Words.showStatus')}</span>
+        <Select
+          value={String(scope.showStatus)}
+          onValueChange={(value) => setScope((current) => ({
+            ...current,
+            showStatus: value === '0' ? 0 : value === '1' ? 1 : -1,
+          }))}
+          disabled={disabled}
+        >
+          <SelectTrigger className='h-10 w-full rounded-[0.95rem] bg-background/75'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value='-1'>{tx('Words.all')}</SelectItem>
+            <SelectItem value='0'>{tx('Words.public')}</SelectItem>
+            <SelectItem value='1'>{tx('Words.private')}</SelectItem>
+          </SelectContent>
+        </Select>
+      </label>
     </div>
   )
 }
 
-function DetailSkeleton() {
-  return (
-    <div className='animate-pulse space-y-5'>
-      <div className='grid gap-5 xl:grid-cols-[minmax(0,0.84fr)_minmax(0,1.16fr)] xl:items-start'>
-        <div className='space-y-5'>
-          <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
-            <div className='h-4 w-28 rounded-full bg-border/55' />
-            <div className='mt-4 grid gap-3 sm:grid-cols-2'>
-              <div className='h-20 rounded-[1.15rem] bg-background/75' />
-              <div className='h-20 rounded-[1.15rem] bg-background/75' />
-              <div className='h-20 rounded-[1.15rem] bg-background/75' />
-              <div className='h-20 rounded-[1.15rem] bg-background/75' />
-            </div>
-          </section>
-          <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
-            <div className='h-4 w-24 rounded-full bg-border/55' />
-            <div className='mt-4 h-24 rounded-[1.15rem] bg-background/75' />
-          </section>
-        </div>
-        <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
-          <div className='h-4 w-24 rounded-full bg-border/55' />
-          <div className='mt-4 space-y-3'>
-            <div className='h-32 rounded-[1.15rem] bg-background/75' />
-            <div className='h-32 rounded-[1.15rem] bg-background/75' />
-          </div>
-        </section>
-      </div>
-    </div>
-  )
-}
-
-function ErrorDetailCard({
-  title,
-  error,
-  dateFormatter,
-  fallback,
-}: {
-  title: string
-  error: AdminTaskError
-  dateFormatter: Intl.DateTimeFormat
-  fallback: string
-}) {
-  return (
-    <section className='rounded-[1.45rem] border border-rose-400/35 bg-rose-500/10 p-4 sm:p-5 text-rose-700 dark:text-rose-300'>
-      <div className='flex items-center gap-2'>
-        <TriangleAlert className='size-4' />
-        <h3 className='font-medium'>{title}</h3>
-      </div>
-      <div className='mt-4 space-y-3'>
-        <DetailMetaRow items={[
-          formatStageToken(error.stage),
-          formatCodeToken(error.code),
-          formatDate(error.at, dateFormatter, fallback),
-        ]}
-        />
-        <p className='text-sm leading-6 text-rose-800 dark:text-rose-200'>{error.message}</p>
-        {error.detail ? (
-          <div className='rounded-[1rem] border border-rose-400/25 bg-background/70 px-3 py-2.5 text-sm leading-6 text-rose-900/80 whitespace-pre-wrap break-words dark:text-rose-100/85'>
-            {error.detail}
-          </div>
-        ) : null}
-      </div>
-    </section>
-  )
-}
-
-function IssueDetailCard({
-  issue,
-  dateFormatter,
-  fallback,
-  infoLabel,
-  warningLabel,
-  errorLabel,
-}: {
-  issue: AdminTaskIssue
-  dateFormatter: Intl.DateTimeFormat
-  fallback: string
-  infoLabel: string
-  warningLabel: string
-  errorLabel: string
-}) {
-  const httpLabel = issue.httpStatus
-    ? `HTTP ${issue.httpStatus}${issue.httpStatusText ? ` ${issue.httpStatusText}` : ''}`
-    : null
-  const detailText = issueDetailText(issue, httpLabel)
+function PreprocessScopeControl({ scope, setScope, disabled }: ScopeControlProps<PreprocessTaskScope>) {
+  const t = useTranslations('Tasks')
 
   return (
-    <article className='overflow-hidden rounded-[1.15rem] border border-border/70 bg-background/78'>
-      <div className='space-y-2.5 p-3.5 sm:p-4'>
-          <div className='flex flex-wrap items-start justify-between gap-2'>
-            <div className='min-w-0'>
-              <p className='truncate text-sm font-medium text-foreground sm:text-[0.98rem]'>{issue.imageTitle}</p>
-              <p className='mt-1 truncate text-xs text-muted-foreground'>{issue.imageId}</p>
-            </div>
-            <Badge variant='outline' className={cn('rounded-full px-2.5 py-0.5', issueClass(issue.level))}>
-              {issue.level === 'error' ? errorLabel : issue.level === 'warning' ? warningLabel : infoLabel}
-            </Badge>
-          </div>
-
-          <DetailMetaRow items={[
-            formatStageToken(issue.stage),
-            formatCodeToken(issue.code),
-            formatDate(issue.at, dateFormatter, fallback),
-            httpLabel,
-          ]}
-          />
-
-          <p className='text-sm leading-6 text-foreground/88'>{issue.summary}</p>
-
-          {detailText ? (
-            <div className='rounded-[1rem] border border-border/60 bg-background/72 px-3 py-2.5 text-sm leading-6 text-muted-foreground whitespace-pre-wrap break-words'>
-              {detailText}
-            </div>
-          ) : null}
-      </div>
-    </article>
+    <label className='flex w-fit items-center gap-3 rounded-[0.95rem] border border-border/70 bg-background/75 px-3.5 py-2.5'>
+      <Switch
+        checked={scope.force}
+        onCheckedChange={(force) => setScope((current) => ({ ...current, force }))}
+        disabled={disabled}
+      />
+      <span className='flex flex-col'>
+        <span className='text-sm font-medium text-foreground'>{t('preprocessForceLabel')}</span>
+        <span className='text-xs leading-5 text-muted-foreground'>{t('preprocessForceHint')}</span>
+      </span>
+    </label>
   )
 }
 
 export default function TasksPage() {
   const t = useTranslations('Tasks')
   const tx = useTranslations()
-  const locale = useLocale()
-  const numberFormatter = new Intl.NumberFormat(locale)
-  const dateFormatter = new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'medium' })
-  const [scope, setScope] = useState<AdminTaskScope>(DEFAULT_SCOPE)
-  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
-  const [isStarting, setIsStarting] = useState(false)
-  const [isCancelling, setIsCancelling] = useState(false)
-  const kickingRef = useRef(false)
-  const previewQuery = new URLSearchParams({ albumValue: scope.albumValue, showStatus: String(scope.showStatus) }).toString()
 
-  const { data: albums, isLoading: albumsLoading } = useSWR<AlbumOption[]>('/api/v1/albums', fetcher)
-  const { data: runsData, isLoading: runsLoading, mutate: mutateRuns } = useSWR<AdminTaskRunsResponse>(
-    '/api/v1/tasks/runs',
-    getJson,
-    { refreshInterval: 5000 }
-  )
-  const { data: previewData, isLoading: previewLoading } = useSWR<AdminTaskPreviewCount>(
-    `/api/v1/tasks/preview-count?${previewQuery}`,
-    getJson
-  )
-  const { data: selectedRunDetail, isLoading: detailLoading, error: detailError } = useSWR<AdminTaskRunDetail>(
-    selectedRunId ? `/api/v1/tasks/runs/${selectedRunId}` : null,
-    getJson
-  )
+  const albumName = useMemo(() => {
+    return (albumValue: string, albums: AlbumOption[] | undefined) =>
+      albumValue === 'all' ? tx('Words.all') : albums?.find((album) => album.album_value === albumValue)?.name || albumValue
+  }, [tx])
 
-  const activeRun = runsData?.activeRun ?? null
-  const recentRuns = runsData?.recentRuns ?? []
-  const selectedRunSummary = recentRuns.find((run) => run.id === selectedRunId) ?? null
-  const selectedRun = selectedRunDetail ?? selectedRunSummary
+  const showLabel = useMemo(() => {
+    return (showStatus: AdminTaskScope['showStatus']) =>
+      showStatus === 0 ? tx('Words.public') : showStatus === 1 ? tx('Words.private') : tx('Words.all')
+  }, [tx])
 
-  const albumName = (albumValue: string) =>
-    albumValue === 'all' ? tx('Words.all') : albums?.find((album) => album.album_value === albumValue)?.name || albumValue
-  const showLabel = (showStatus: AdminTaskScope['showStatus']) =>
-    showStatus === 0 ? tx('Words.public') : showStatus === 1 ? tx('Words.private') : tx('Words.all')
-  const statusLabel = (status: AdminTaskStatus) =>
-    status === 'queued'
-      ? t('statusQueued')
-      : status === 'running'
-        ? t('statusRunning')
-        : status === 'cancelling'
-          ? t('statusCancelling')
-          : status === 'succeeded'
-            ? t('statusSucceeded')
-            : status === 'failed'
-              ? t('statusFailed')
-              : t('statusCancelled')
-  const scopeLabel = (taskScope: AdminTaskScope) => `${albumName(taskScope.albumValue)} / ${showLabel(taskScope.showStatus)}`
+  // Metadata scope labels need album names, so read the (already cached) album
+  // list here to keep `scopeLabel` synchronous and matching prior behaviour.
+  const { data: metadataAlbums } = useSWR<AlbumOption[]>('/api/v1/albums', fetcher)
+  const albumsLoading = !metadataAlbums
 
-  async function refreshTaskData() {
-    await mutateRuns()
-  }
+  const metadataConfig = useMemo<TaskRunPanelConfig<AdminTaskScope>>(() => ({
+    basePath: '/api/v1/tasks',
+    taskKey: ADMIN_TASK_KEY_REFRESH_IMAGE_METADATA,
+    defaultScope: METADATA_DEFAULT_SCOPE,
+    previewCountQuery: (scope) =>
+      new URLSearchParams({ albumValue: scope.albumValue, showStatus: String(scope.showStatus) }).toString(),
+    scopeLabel: (scope) => `${albumName(scope.albumValue, metadataAlbums)} / ${showLabel(scope.showStatus)}`,
+    ScopeControl: MetadataScopeControl,
+    renderExtraHints: () => (albumsLoading ? <p>{t('albumsLoading')}</p> : null),
+    extraBooting: albumsLoading,
+  }), [albumName, showLabel, metadataAlbums, albumsLoading, t])
 
-  useEffect(() => {
-    if (!activeRun?.id || activeRun.status === 'cancelling') return
+  const preprocessConfig = useMemo<TaskRunPanelConfig<PreprocessTaskScope>>(() => ({
+    basePath: '/api/v1/preprocess-tasks',
+    taskKey: ADMIN_TASK_KEY_PREPROCESS_IMAGES,
+    defaultScope: PREPROCESS_DEFAULT_SCOPE,
+    previewCountQuery: (scope) => (scope.force ? 'force=true' : ''),
+    scopeLabel: (scope) => (scope.force ? t('preprocessScopeForce') : t('preprocessScopeMissing')),
+    ScopeControl: PreprocessScopeControl,
+    // With `force` on, every image is reprocessed even when the preview-count of
+    // missing-variant images is 0, so the start button must stay enabled.
+    canStartWithoutPreview: (scope) => scope.force,
+    mapStartError: (error) => (error.message === VARIANT_STORAGE_NOT_CONFIGURED ? t('preprocessStorageMissing') : null),
+  }), [t])
 
-    let cancelled = false
-
-    const runKick = async () => {
-      if (kickingRef.current) return
-      kickingRef.current = true
-
-      try {
-        await postJson<AdminTaskRunSummary>(`/api/v1/tasks/runs/${activeRun.id}/kick`)
-        if (!cancelled) {
-          await mutateRuns()
-        }
-      } catch (error) {
-        if (!cancelled) toast.error(error instanceof Error ? error.message : t('kickFailed'))
-      } finally {
-        kickingRef.current = false
-      }
-    }
-
-    void runKick()
-    const timer = window.setInterval(() => {
-      void runKick()
-    }, 4500)
-
-    return () => {
-      cancelled = true
-      window.clearInterval(timer)
-    }
-  }, [activeRun?.id, activeRun?.status, mutateRuns, t])
-
-  async function handleStartTask() {
-    try {
-      setIsStarting(true)
-      await postJson<AdminTaskRunSummary>('/api/v1/tasks/runs', {
-        taskKey: ADMIN_TASK_KEY_REFRESH_IMAGE_METADATA,
-        scope,
-      })
-      toast.success(t('startSuccess'))
-      await refreshTaskData()
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : t('startFailed'))
-    } finally {
-      setIsStarting(false)
-    }
-  }
-
-  async function handleCancelTask() {
-    if (!activeRun?.id || activeRun.status === 'cancelling') return
-
-    try {
-      setIsCancelling(true)
-      await postJson<AdminTaskRunSummary>(`/api/v1/tasks/runs/${activeRun.id}/cancel`)
-      toast.success(t('cancelSuccess'))
-      await refreshTaskData()
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : t('cancelFailed'))
-    } finally {
-      setIsCancelling(false)
-    }
-  }
-
-  const previewCount = previewData?.totalCount ?? 0
-  const activeProgress = progressOf(activeRun)
-  const cancelPending = isCancelling || activeRun?.status === 'cancelling'
-  const canStart = !activeRun && previewCount > 0 && !isStarting
-  const booting = albumsLoading || (!runsData && runsLoading)
-  const detailBooting = Boolean(selectedRunId) && detailLoading && !selectedRunDetail
   return (
-    <>
-      <div className='relative overflow-hidden px-1 py-2 sm:px-2'>
-        <div className='pointer-events-none absolute inset-0 overflow-hidden'>
-          <div className='absolute -left-10 top-8 h-48 w-48 rounded-full bg-primary/10 blur-3xl' />
-          <div className='absolute right-[-4rem] top-16 h-64 w-64 rounded-full bg-secondary blur-3xl' />
-          <div className='absolute bottom-6 left-1/3 h-44 w-44 rounded-full bg-primary/8 blur-3xl' />
-        </div>
-
-        <div className='relative space-y-6'>
-          <section className={cn(panelClass, 'px-5 py-4 sm:px-6 sm:py-5')}>
-            <div className='pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent' />
-            <div className='flex flex-col gap-4'>
-              <div className={cn('flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between', !activeRun && 'hidden')}>
-                {activeRun ? (
-                  <div className='flex flex-wrap items-center gap-2 xl:justify-end'>
-                    <Badge variant='outline' className={cn('rounded-full px-3 py-1', statusClass(activeRun.status))}>
-                      {statusLabel(activeRun.status)}
-                    </Badge>
-                    <Badge variant='outline' className='rounded-full border-border/80 bg-background/70 px-3 py-1 text-muted-foreground'>
-                      {ADMIN_TASK_KEY_REFRESH_IMAGE_METADATA}
-                    </Badge>
-                    <Badge variant='outline' className='rounded-full border-border/80 bg-background/70 px-3 py-1 text-muted-foreground'>
-                      {scopeLabel(activeRun.scope)}
-                    </Badge>
-                    <Button
-                      variant='outline'
-                      onClick={handleCancelTask}
-                      disabled={cancelPending}
-                      className='min-w-32 rounded-full px-4'
-                    >
-                      {cancelPending ? <LoaderCircle className='animate-spin' /> : <TriangleAlert />}
-                      {cancelPending ? t('cancelling') : t('cancel')}
-                    </Button>
-                  </div>
-                ) : null}
-              </div>
-
-              <div
-                className={cn(
-                  'grid gap-4 xl:items-start',
-                  activeRun ? 'xl:grid-cols-[minmax(0,1.04fr)_minmax(19rem,0.96fr)]' : 'xl:grid-cols-1'
-                )}
-              >
-                {activeRun ? (
-                  <div className='space-y-4 xl:border-r xl:border-border/55 xl:pr-5'>
-                    <div className='grid gap-3 rounded-[1.35rem] border border-border/70 bg-background/62 p-4'>
-                      <div className='grid gap-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-end'>
-                        <div>
-                          <p className='text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground'>
-                            {t('progressLabel')}
-                          </p>
-                          <p className='mt-1.5 font-display text-[2.15rem] leading-none tracking-tight text-foreground sm:text-[2.45rem]'>
-                            {activeProgress}%
-                          </p>
-                        </div>
-                        <div className='grid gap-2 text-sm leading-6 text-muted-foreground sm:grid-cols-3'>
-                          <div className='rounded-[0.95rem] bg-background/78 px-3 py-2.5'>
-                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('matchedCount')}</p>
-                            <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(activeRun.totalCount)}</p>
-                          </div>
-                          <div className='rounded-[0.95rem] bg-background/78 px-3 py-2.5'>
-                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('processedLabel')}</p>
-                            <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(activeRun.processedCount)}</p>
-                          </div>
-                          <div className='rounded-[0.95rem] bg-background/78 px-3 py-2.5'>
-                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('startedAtLabel')}</p>
-                            <p className='mt-1 text-base font-medium text-foreground'>
-                              {formatDate(activeRun.startedAt || activeRun.createdAt, dateFormatter, t('notAvailable'))}
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                      <Progress value={activeProgress} className='h-2 bg-primary/15' />
-                    </div>
-
-                    <div className='grid gap-2 sm:grid-cols-2 xl:grid-cols-4'>
-                      <div className='rounded-[1rem] border border-border/60 bg-background/70 px-3 py-2.5'>
-                        <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('processedLabel')}</p>
-                        <p className='mt-1.5 font-display text-[1.55rem] leading-none tracking-tight text-foreground'>{numberFormatter.format(activeRun.processedCount)}</p>
-                      </div>
-                      <div className='rounded-[1rem] border border-border/60 bg-emerald-500/8 px-3 py-2.5 text-emerald-700 dark:text-emerald-300'>
-                        <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('successLabel')}</p>
-                        <p className='mt-1.5 font-display text-[1.55rem] leading-none tracking-tight'>{numberFormatter.format(activeRun.successCount)}</p>
-                      </div>
-                      <div className='rounded-[1rem] border border-border/60 bg-amber-500/10 px-3 py-2.5 text-amber-700 dark:text-amber-300'>
-                        <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('skippedLabel')}</p>
-                        <p className='mt-1.5 font-display text-[1.55rem] leading-none tracking-tight'>{numberFormatter.format(activeRun.skippedCount)}</p>
-                      </div>
-                      <div className='rounded-[1rem] border border-border/60 bg-rose-500/10 px-3 py-2.5 text-rose-700 dark:text-rose-300'>
-                        <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('failedLabel')}</p>
-                        <p className='mt-1.5 font-display text-[1.55rem] leading-none tracking-tight'>{numberFormatter.format(activeRun.failedCount)}</p>
-                      </div>
-                    </div>
-                  </div>
-                ) : null}
-
-                <div className={cn('space-y-4', activeRun ? 'xl:pl-1' : 'min-w-0')}>
-                  <div className='flex w-fit flex-wrap items-end gap-3'>
-                    <label className='flex w-[8.75rem] shrink-0 flex-col gap-1.5'>
-                      <span className='text-sm font-medium text-foreground'>{tx('Words.album')}</span>
-                      <Select value={scope.albumValue} onValueChange={(albumValue) => setScope((current) => ({ ...current, albumValue }))}>
-                        <SelectTrigger className='h-10 w-full rounded-[0.95rem] bg-background/75'>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value='all'>{tx('Words.all')}</SelectItem>
-                          {albums?.map((album) => (
-                            <SelectItem key={album.id} value={album.album_value}>{album.name}</SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </label>
-
-                    <label className='flex w-[8.75rem] shrink-0 flex-col gap-1.5'>
-                      <span className='text-sm font-medium text-foreground'>{tx('Words.showStatus')}</span>
-                      <Select
-                        value={String(scope.showStatus)}
-                        onValueChange={(value) => setScope((current) => ({
-                          ...current,
-                          showStatus: value === '0' ? 0 : value === '1' ? 1 : -1,
-                        }))}
-                      >
-                        <SelectTrigger className='h-10 w-full rounded-[0.95rem] bg-background/75'>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value='-1'>{tx('Words.all')}</SelectItem>
-                          <SelectItem value='0'>{tx('Words.public')}</SelectItem>
-                          <SelectItem value='1'>{tx('Words.private')}</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </label>
-                  </div>
-
-                  <div className='grid gap-3 rounded-[1.3rem] border border-primary/15 bg-primary/7 p-3 lg:grid-cols-[minmax(8.5rem,0.32fr)_minmax(0,1fr)] lg:items-stretch'>
-                    <div className='flex min-h-[8.5rem] flex-col justify-between rounded-[1rem] bg-background/82 px-3.5 py-3'>
-                      <p className='text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground'>{t('previewLabel')}</p>
-                      <p className='font-display text-[2.15rem] leading-none tracking-tight text-foreground sm:text-[2.35rem]'>{previewLoading ? '...' : numberFormatter.format(previewCount)}</p>
-                    </div>
-
-                    <div className='grid min-h-[8.5rem] gap-3 rounded-[1rem] border border-border/70 bg-background/78 px-3.5 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-stretch'>
-                      <div className='space-y-2 md:flex md:h-full md:flex-col md:justify-between md:space-y-0'>
-                        <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('currentSelection')}</p>
-                        <div className='flex flex-wrap items-center gap-2'>
-                          <span className='rounded-full border border-border/70 bg-background/90 px-3 py-1.5 text-sm font-medium text-foreground'>{scopeLabel(scope)}</span>
-                        </div>
-                      </div>
-
-                      <Button onClick={handleStartTask} disabled={!canStart} className='h-10 w-full rounded-full md:min-w-40 md:self-center md:w-auto'>
-                        {isStarting ? <LoaderCircle className='animate-spin' /> : <RefreshCw />}
-                        {isStarting ? t('starting') : t('start')}
-                      </Button>
-
-                      {!activeRun && previewCount < 1 && !previewLoading ? (
-                        <div className='md:col-span-2 flex flex-wrap gap-x-4 gap-y-1 text-sm leading-6 text-muted-foreground'>
-                          <p>{t('noMatchHint')}</p>
-                          {albumsLoading ? <p>{t('albumsLoading')}</p> : null}
-                        </div>
-                      ) : null}
-                      {activeRun || albumsLoading ? (
-                        <div className='md:col-span-2 flex flex-wrap gap-x-4 gap-y-1 text-sm leading-6 text-muted-foreground'>
-                          {activeRun ? <p>{t('runningHint')}</p> : null}
-                          {albumsLoading ? <p>{t('albumsLoading')}</p> : null}
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section className={cn(panelClass, 'px-5 py-5 sm:px-6 sm:py-6')}>
-            <div className='pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent' />
-            <div className='flex flex-col gap-5'>
-              <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
-                <p className='text-sm font-medium text-primary/80'>{t('historyEyebrow')}</p>
-                <div className='flex flex-wrap items-center gap-2'>
-                  <div className='inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/70 px-3 py-1.5 text-sm text-muted-foreground'>
-                    {t('historyRecentLimit', { count: HISTORY_RECENT_LIMIT })}
-                  </div>
-                  <Button variant='outline' size='sm' onClick={() => void refreshTaskData()} className='rounded-full'>
-                    <RefreshCw />
-                    {tx('Button.refresh')}
-                  </Button>
-                </div>
-              </div>
-              {recentRuns.length > 0 ? (
-                <div className='overflow-hidden rounded-[1.45rem] border border-border/70 bg-background/50'>
-                  <ScrollArea className='w-full' type='always' style={recentRuns.length > HISTORY_VISIBLE_ROWS ? { height: HISTORY_SCROLL_MAX_HEIGHT } : { maxHeight: HISTORY_SCROLL_MAX_HEIGHT }}>
-                    <div>
-                      {recentRuns.map((run, index) => (
-                        <button
-                          key={run.id}
-                          type='button'
-                          onClick={() => setSelectedRunId(run.id)}
-                          className={cn(
-                            'group grid w-full gap-4 px-4 py-4 text-left transition-colors hover:bg-primary/6 sm:px-5 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)_auto] lg:items-center',
-                            index > 0 ? 'border-t border-border/60' : null
-                          )}
-                          style={{ minHeight: `${HISTORY_CARD_MIN_HEIGHT_REM}rem` }}
-                        >
-                          <div className='min-w-0 space-y-3'>
-                            <div className='flex flex-wrap items-center gap-2'>
-                              <Badge variant='outline' className={cn('rounded-full px-2.5 py-0.5', statusClass(run.status))}>
-                                {statusLabel(run.status)}
-                              </Badge>
-                              <span className='text-xs uppercase tracking-[0.14em] text-muted-foreground'>
-                                {formatDate(run.createdAt, dateFormatter, t('notAvailable'))}
-                              </span>
-                            </div>
-
-                            <div className='space-y-1'>
-                              <p className='truncate text-base font-medium text-foreground'>{scopeLabel(run.scope)}</p>
-                              <p className='text-sm leading-6 text-muted-foreground'>{t('matchedCount')}: {numberFormatter.format(run.totalCount)}</p>
-                            </div>
-
-                            <Progress value={progressOf(run)} className='h-2 bg-primary/12' />
-                          </div>
-
-                          <div className='grid gap-2 text-sm text-muted-foreground sm:grid-cols-3 lg:grid-cols-3'>
-                            <div className='rounded-[1rem] bg-background/70 px-3 py-2'>
-                              <p className='text-[0.68rem] uppercase tracking-[0.14em]'>{t('successLabel')}</p>
-                              <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(run.successCount)}</p>
-                            </div>
-                            <div className='rounded-[1rem] bg-background/70 px-3 py-2'>
-                              <p className='text-[0.68rem] uppercase tracking-[0.14em]'>{t('skippedLabel')}</p>
-                              <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(run.skippedCount)}</p>
-                            </div>
-                            <div className='rounded-[1rem] bg-background/70 px-3 py-2'>
-                              <p className='text-[0.68rem] uppercase tracking-[0.14em]'>{t('failedLabel')}</p>
-                              <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(run.failedCount)}</p>
-                            </div>
-                          </div>
-
-                          <div className='flex items-center justify-between gap-3 lg:justify-end'>
-                            <span className='inline-flex items-center gap-2 rounded-full border border-border/70 bg-background/75 px-3 py-1.5 text-sm font-medium text-foreground/80 transition-colors group-hover:border-primary/25 group-hover:text-foreground'>
-                              {t('detailView')}
-                              <ChevronRight className='size-4 transition-transform group-hover:translate-x-0.5' />
-                            </span>
-                          </div>
-                        </button>
-                      ))}
-                    </div>
-                  </ScrollArea>
-
-                </div>
-              ) : (
-                <div className='rounded-[1.35rem] border border-dashed border-border/80 bg-background/55 px-4 py-5 text-sm leading-6 text-muted-foreground'>
-                  {booting ? t('loading') : t('noHistory')}
-                </div>
-              )}
-            </div>
-          </section>
-        </div>
-      </div>
-
-      <Dialog open={Boolean(selectedRunId)} onOpenChange={(open) => { if (!open) setSelectedRunId(null) }}>
-        {selectedRunId ? (
-          <DialogContent className='grid h-[min(92dvh,56rem)] max-h-[calc(100dvh-1.5rem)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden border-border/70 bg-background/95 p-0 shadow-[0_24px_80px_rgba(90,56,25,0.18)] sm:max-w-[56rem]'>
-            <div className='relative grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] overflow-hidden'>
-              <div className='pointer-events-none absolute inset-0 overflow-hidden'>
-                <div className='absolute -left-6 top-4 h-28 w-28 rounded-full bg-primary/8 blur-3xl' />
-                <div className='absolute right-[-2rem] top-0 h-36 w-36 rounded-full bg-secondary/70 blur-3xl' />
-              </div>
-
-              <DialogHeader className='relative gap-4 border-b border-border/60 px-5 py-5 text-left sm:px-6'>
-                {selectedRun ? (
-                  <>
-                    <div className='space-y-2'>
-                      <p className='text-[0.68rem] uppercase tracking-[0.22em] text-primary/75'>{t('detailEyebrow')}</p>
-                      <DialogTitle className='font-display text-[1.45rem] leading-none text-foreground sm:text-[1.7rem]'>{scopeLabel(selectedRun.scope)}</DialogTitle>
-                      <DialogDescription className='max-w-2xl text-sm leading-6 text-muted-foreground'>{t('detailDescription')}</DialogDescription>
-                    </div>
-
-                    <div className='flex flex-wrap items-center gap-2 pr-8 sm:pr-10'>
-                      <Badge variant='outline' className={cn('rounded-full px-3 py-1', statusClass(selectedRun.status))}>
-                        {statusLabel(selectedRun.status)}
-                      </Badge>
-                      <Badge variant='outline' className='rounded-full border-border/80 bg-background/75 px-3 py-1 text-muted-foreground'>
-                        {formatDate(selectedRun.createdAt, dateFormatter, t('notAvailable'))}
-                      </Badge>
-                      <Badge variant='outline' className='rounded-full border-border/80 bg-background/75 px-3 py-1 text-muted-foreground'>
-                        {ADMIN_TASK_KEY_REFRESH_IMAGE_METADATA}
-                      </Badge>
-                    </div>
-                  </>
-                ) : (
-                  <div className='animate-pulse space-y-3'>
-                    <div className='h-3 w-20 rounded-full bg-border/55' />
-                    <div className='h-8 w-56 rounded-full bg-border/60' />
-                    <div className='h-4 w-72 rounded-full bg-border/50' />
-                  </div>
-                )}
-              </DialogHeader>
-
-              <ScrollArea className='min-h-0'>
-                <div className='space-y-5 px-5 py-5 sm:px-6 sm:py-6'>
-                  {selectedRun ? (
-                    <section className='rounded-[1.6rem] border border-border/70 bg-background/68 p-4 sm:p-5'>
-                      <div className='grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(15rem,0.8fr)] lg:items-end'>
-                        <div className='space-y-4'>
-                          <div className='flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between'>
-                            <div>
-                              <p className='text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground'>{t('progressLabel')}</p>
-                              <p className='mt-2 font-display text-[3rem] leading-none tracking-tight text-foreground sm:text-[3.5rem]'>{progressOf(selectedRun)}%</p>
-                            </div>
-                            <div className='space-y-1 text-sm leading-6 text-muted-foreground sm:text-right'>
-                              <p>{t('matchedCount')}: {numberFormatter.format(selectedRun.totalCount)}</p>
-                              <p>{t('processedLabel')}: {numberFormatter.format(selectedRun.processedCount)}</p>
-                            </div>
-                          </div>
-                          <Progress value={progressOf(selectedRun)} className='h-2.5 bg-primary/15' />
-                        </div>
-
-                        <div className='grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3'>
-                          <div className='rounded-[1.2rem] border border-border/60 bg-emerald-500/8 px-4 py-3 text-emerald-700 dark:text-emerald-300'>
-                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('successLabel')}</p>
-                            <p className='mt-2 font-display text-[1.9rem] leading-none tracking-tight'>{numberFormatter.format(selectedRun.successCount)}</p>
-                          </div>
-                          <div className='rounded-[1.2rem] border border-border/60 bg-amber-500/10 px-4 py-3 text-amber-700 dark:text-amber-300'>
-                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('skippedLabel')}</p>
-                            <p className='mt-2 font-display text-[1.9rem] leading-none tracking-tight'>{numberFormatter.format(selectedRun.skippedCount)}</p>
-                          </div>
-                          <div className='rounded-[1.2rem] border border-border/60 bg-rose-500/10 px-4 py-3 text-rose-700 dark:text-rose-300'>
-                            <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('failedLabel')}</p>
-                            <p className='mt-2 font-display text-[1.9rem] leading-none tracking-tight'>{numberFormatter.format(selectedRun.failedCount)}</p>
-                          </div>
-                        </div>
-                      </div>
-                    </section>
-                  ) : (
-                    <section className='rounded-[1.6rem] border border-border/70 bg-background/68 p-4 sm:p-5'>
-                      <div className='animate-pulse space-y-4'>
-                        <div className='h-4 w-24 rounded-full bg-border/55' />
-                        <div className='h-12 w-32 rounded-full bg-border/60' />
-                        <div className='h-2.5 rounded-full bg-border/45' />
-                      </div>
-                    </section>
-                  )}
-
-                  {detailBooting ? (
-                    <DetailSkeleton />
-                  ) : detailError ? (
-                    <section className='rounded-[1.45rem] border border-rose-400/35 bg-rose-500/10 p-4 sm:p-5 text-rose-700 dark:text-rose-300'>
-                      <p className='text-sm leading-6'>{detailError instanceof Error ? detailError.message : t('kickFailed')}</p>
-                    </section>
-                  ) : selectedRunDetail ? (
-                    <div className='grid gap-5 xl:grid-cols-[minmax(0,0.84fr)_minmax(0,1.16fr)] xl:items-start'>
-                      <div className='space-y-5'>
-                        <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
-                          <div className='flex items-center gap-2 text-foreground'>
-                            <Wrench className='size-4 text-primary' />
-                            <h3 className='font-medium'>{t('countsTitle')}</h3>
-                          </div>
-                          <div className='mt-4 grid gap-3 sm:grid-cols-2'>
-                            <div className='rounded-[1.15rem] bg-background/75 px-4 py-3 text-sm leading-6 text-muted-foreground'>
-                              <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('matchedCount')}</p>
-                              <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(selectedRunDetail.totalCount)}</p>
-                            </div>
-                            <div className='rounded-[1.15rem] bg-background/75 px-4 py-3 text-sm leading-6 text-muted-foreground'>
-                              <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('processedLabel')}</p>
-                              <p className='mt-1 text-base font-medium text-foreground'>{numberFormatter.format(selectedRunDetail.processedCount)}</p>
-                            </div>
-                          </div>
-                        </section>
-
-                        <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
-                          <div className='flex items-center gap-2 text-foreground'>
-                            <Clock3 className='size-4 text-primary' />
-                            <h3 className='font-medium'>{t('timelineTitle')}</h3>
-                          </div>
-                          <div className='mt-4 space-y-3'>
-                            <div className='rounded-[1.15rem] bg-background/75 px-4 py-3 text-sm leading-6 text-muted-foreground'>
-                              <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('startedAtLabel')}</p>
-                              <p className='mt-1 text-foreground'>{formatDate(selectedRunDetail.startedAt || selectedRunDetail.createdAt, dateFormatter, t('notAvailable'))}</p>
-                            </div>
-                            <div className='rounded-[1.15rem] bg-background/75 px-4 py-3 text-sm leading-6 text-muted-foreground'>
-                              <p className='text-[0.68rem] uppercase tracking-[0.14em] text-muted-foreground'>{t('finishedAtLabel')}</p>
-                              <p className='mt-1 text-foreground'>{formatDate(selectedRunDetail.finishedAt, dateFormatter, t('unfinished'))}</p>
-                            </div>
-                          </div>
-                        </section>
-
-                        {selectedRunDetail.lastError ? (
-                          <ErrorDetailCard
-                            title={t('lastErrorTitle')}
-                            error={selectedRunDetail.lastError}
-                            dateFormatter={dateFormatter}
-                            fallback={t('notAvailable')}
-                          />
-                        ) : null}
-                      </div>
-
-                      <section className='rounded-[1.45rem] border border-border/70 bg-background/62 p-4 sm:p-5'>
-                        <div className='flex items-center gap-2 text-foreground'>
-                          <MapPinned className='size-4 text-primary' />
-                          <h3 className='font-medium'>{t('issuesTitle')}</h3>
-                        </div>
-                        <div className='mt-4 space-y-3'>
-                          {selectedRunDetail.recentIssues.length > 0 ? (
-                            selectedRunDetail.recentIssues.map((issue, index) => (
-                              <IssueDetailCard
-                                key={`${issue.imageId}-${issue.code}-${index}`}
-                                issue={issue}
-                                dateFormatter={dateFormatter}
-                                fallback={t('notAvailable')}
-                                infoLabel={t('issueInfo')}
-                                warningLabel={t('issueWarning')}
-                                errorLabel={t('issueError')}
-                              />
-                            ))
-                          ) : (
-                            <div className='rounded-[1.15rem] border border-dashed border-border/80 bg-background/60 px-4 py-4 text-sm leading-6 text-muted-foreground'>
-                              {t('noIssues')}
-                            </div>
-                          )}
-                        </div>
-                      </section>
-                    </div>
-                  ) : null}
-                </div>
-              </ScrollArea>
-            </div>
-          </DialogContent>
-        ) : null}
-      </Dialog>
-    </>
+    <Tabs defaultValue='metadata' className='gap-4'>
+      <TabsList className='grid w-full max-w-md grid-cols-2'>
+        <TabsTrigger value='metadata'>{t('tabMetadata')}</TabsTrigger>
+        <TabsTrigger value='preprocess'>{t('tabPreprocess')}</TabsTrigger>
+      </TabsList>
+      <TabsContent value='metadata'>
+        <TaskRunPanel config={metadataConfig} />
+      </TabsContent>
+      <TabsContent value='preprocess'>
+        <TaskRunPanel config={preprocessConfig} />
+      </TabsContent>
+    </Tabs>
   )
 }
-

--- a/messages/en.json
+++ b/messages/en.json
@@ -562,7 +562,14 @@
     "detailDescription": "Inspect the scope, progress, outcome counts, timeline, and recent logs from this run.",
     "detailEyebrow": "Run details",
     "unfinished": "Still running",
-    "countsTitle": "Outcome counts"
+    "countsTitle": "Outcome counts",
+    "tabMetadata": "Metadata",
+    "tabPreprocess": "Variant preprocessing",
+    "preprocessForceLabel": "Regenerate all",
+    "preprocessForceHint": "Reprocess every image, not just those missing variants.",
+    "preprocessScopeForce": "All images (force)",
+    "preprocessScopeMissing": "Images missing variants",
+    "preprocessStorageMissing": "Select a variant storage backend in storage settings first."
   },
   "Backup": {
     "pageDescription": "Export and import versioned PicImpact business backups. Backups include all site configuration records and business data, but exclude authentication tables and object storage files.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -562,7 +562,14 @@
     "detailDescription": "この実行の対象範囲、進行状況、結果、タイムライン、最近のログを確認します。",
     "detailEyebrow": "実行詳細",
     "unfinished": "継続中",
-    "countsTitle": "結果"
+    "countsTitle": "結果",
+    "tabMetadata": "メタデータ",
+    "tabPreprocess": "バリアント前処理",
+    "preprocessForceLabel": "すべて再生成",
+    "preprocessForceHint": "バリアントが未生成の画像だけでなく、すべての画像を再処理します。",
+    "preprocessScopeForce": "すべての画像（強制）",
+    "preprocessScopeMissing": "バリアント未生成の画像",
+    "preprocessStorageMissing": "先にストレージ設定でバリアントストレージのバックエンドを選択してください。"
   },
   "Backup": {
     "pageDescription": "Export and import versioned PicImpact backups. The package includes site configuration and business data, but excludes auth tables and object storage files.",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -562,7 +562,14 @@
     "detailDescription": "查看本次任務的範圍、進度、結果統計、時間線和最近日誌。",
     "detailEyebrow": "任務詳情",
     "unfinished": "未結束",
-    "countsTitle": "結果統計"
+    "countsTitle": "結果統計",
+    "tabMetadata": "中繼資料",
+    "tabPreprocess": "變體預處理",
+    "preprocessForceLabel": "重新產生全部",
+    "preprocessForceHint": "重新處理全部圖片，而不僅是缺少變體的圖片。",
+    "preprocessScopeForce": "全部圖片（強制）",
+    "preprocessScopeMissing": "缺少變體的圖片",
+    "preprocessStorageMissing": "先在儲存設定裡選擇變體儲存後端後再試。"
   },
   "Backup": {
     "pageDescription": "Export and import versioned PicImpact backups. These packages include full site configuration and business data, but exclude auth tables and object storage files.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -562,7 +562,14 @@
     "detailDescription": "查看本次任务的范围、进度、结果统计、时间线和最近日志。",
     "detailEyebrow": "任务详情",
     "unfinished": "未结束",
-    "countsTitle": "结果统计"
+    "countsTitle": "结果统计",
+    "tabMetadata": "元数据",
+    "tabPreprocess": "变体预处理",
+    "preprocessForceLabel": "重新生成全部",
+    "preprocessForceHint": "重新处理全部图片，而不仅是缺少变体的图片。",
+    "preprocessScopeForce": "全部图片（强制）",
+    "preprocessScopeMissing": "缺少变体的图片",
+    "preprocessStorageMissing": "先在存储设置里选择变体存储后端后再试。"
   },
   "Backup": {
     "pageDescription": "导出和导入版本化的 PicImpact 业务备份包。备份会包含站点配置和业务数据，但不包含认证表和对象存储文件。",


### PR DESCRIPTION
## Problem

`/admin/tasks` only exposed the **image-metadata-refresh** task. Admins had no way to trigger or observe the **image-variant preprocess** task (variant backfill / the upload-enqueued preprocess runs) from the UI.

## Approach

Extracted a reusable, parameterized **`TaskRunPanel`** from the existing 800-line metadata page and render two instances under shadcn `Tabs` (**Metadata | Variant preprocessing**). This is an extract-and-reuse refactor, not a page duplication.

### What moved into `TaskRunPanel`
- All shared helpers (`statusClass`, `issueClass`, `progressOf`, `formatDate`, issue/error formatting, `DetailMetaRow`, `DetailSkeleton`, `ErrorDetailCard`, `IssueDetailCard`, `getJson`/`postJson`).
- The per-task SWR wiring (`/runs`, `/preview-count`, `/runs/:id`), the kick-poll `useEffect`, and the start/cancel handlers.
- The full render: active-run panel, history list, and the detail dialog with issues.

Per-task differences flow through a generic `config` prop:
- `basePath` (`/api/v1/tasks` | `/api/v1/preprocess-tasks`), `taskKey`, `defaultScope`
- a pluggable **`ScopeControl`** render-prop
- `previewCountQuery(scope)`, `scopeLabel(scope)`
- `canStartWithoutPreview(scope)` and `mapStartError(error)`

### Metadata tab — unchanged
Byte-identical behaviour: same album + show-status `Select` scope, same `/api/v1/tasks` endpoints, same 5s polling and 4.5s kick loop, same visuals. The album list is read via the same `/api/v1/albums` SWR key (deduped).

### Preprocess tab
- Scope is a `{ force }` `Switch` ("重新生成全部" / "Regenerate all"). When off, only images missing variants are counted/started; when `force` is on, the start button stays enabled even if the missing-variant preview is 0 (every image is reprocessed).
- Starts a run via `POST /api/v1/preprocess-tasks/runs` with `taskKey + { force }`.
- **Storage-not-configured handling**: the server returns HTTP 400 `Variant storage backend is not configured`; this is mapped to a clear hint toast ("先在存储设置里选择变体存储后端后再试。") instead of a raw error.

### i18n — 4 languages
Added flat `Tasks.*` keys in `messages/{en,zh,ja,zh-TW}.json`: `tabMetadata`, `tabPreprocess`, `preprocessForceLabel`, `preprocessForceHint`, `preprocessScopeForce`, `preprocessScopeMissing`, `preprocessStorageMissing`.

## Verification
- `pnpm lint` — 0 errors (pre-existing warnings only; 4 new warnings are unused-name-in-type-signature notices matching the repo's existing pattern).
- `npx tsc --noEmit` — no new errors in the changed files (pre-existing unrelated errors in `server/`, `prisma/`, `components/ui/resizable.tsx`, `stores/` remain).
- `pnpm build` — compiled successfully; `/admin/tasks` builds and SSRs. The `BetterAuthError` default-secret message is the known harmless env warning.
- All four message JSON files validated.

## Caveats
- `AdminTaskRunBase.scope` is typed as the metadata scope shape; preprocess run scopes (`{ force }`) are labeled via a narrow cast inside the panel rather than a shared-type change, to avoid touching `types/admin-tasks.ts`.
- Both panels stay mounted across tabs (Radix keeps tab content mounted), so the preprocess panel also polls its `/runs` endpoint while the metadata tab is active. This is additive observability and does not change metadata behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)