### PR TITLE
fix: detail viewer loads variant on demand, not the original eagerly

### DIFF
--- a/app/(default)/preview/[...id]/page.tsx
+++ b/app/(default)/preview/[...id]/page.tsx
@@ -2,6 +2,7 @@ import { fetchImageByIdAndAuth } from '~/server/db/query/images'
 import type { PreviewImageHandleProps } from '~/types/props'
 import PreviewImage from '~/components/album/preview-image'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
+import { getVariantBaseUrl } from '~/server/lib/variant-storage'
 import type { GalleryDisplayConfig } from '~/types'
 import type { Metadata } from 'next/types'
 
@@ -57,6 +58,7 @@ export default async function PreView({params}: { params: any }) {
     return {
       customIndexDownloadEnable: value === 'true',
       customIndexOriginEnable: false,
+      variantBaseUrl: await getVariantBaseUrl(),
     }
   }
 

--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -199,13 +199,16 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
         <div className="show-up-motion sm:col-span-2 sm:flex sm:justify-center sm:max-h-[90vh] select-none">
           {
             props.data.type === 1 ?
-              <ProgressiveImage 
+              <ProgressiveImage
                 imageUrl={props.data.url}
                 previewUrl={props.data.preview_url}
                 alt={props.data.title}
                 height={props.data.height}
                 width={props.data.width}
                 blurhash={props.data.blurhash}
+                imageKey={props.data.image_key}
+                readyMaxWidth={props.data.ready_max_width}
+                variantBaseUrl={configData?.variantBaseUrl ?? ''}
                 showLightbox={lightboxPhoto}
                 onShowLightboxChange={(value)=>setLightboxPhoto(value)}
               />

--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -8,6 +8,13 @@ import { useBlurImageDataUrl } from '~/hooks/use-blurhash'
 import { WebGLImageViewer } from '~/components/album/webgl-viewer'
 import type { WebGLImageViewerRef } from '~/components/album/webgl-viewer'
 import { isWebGLSupported } from '~/lib/utils/webgl'
+import { hasReadyVariants, makeVariantLoader } from '~/lib/image/loader'
+import { useAvifSupport } from '~/hooks/use-avif-support'
+
+// Width requested for the detail high-res view; the loader clamps it to the
+// largest generated tier (variants go up to 2560), so we never pull the
+// multi-MB original for in-page viewing.
+const DETAIL_HIGH_RES_WIDTH = 2560
 
 /**
  * 渐进式图片展示组件，支持 WebGL 高性能渲染
@@ -21,14 +28,25 @@ export default function ProgressiveImage(
 ) {
   const t = useTranslations()
 
-  const [isMobile] = useState(() => typeof window !== 'undefined' && window.innerWidth < 768)
   const [loadingProgress, setLoadingProgress] = useState(0)
-  const [isLoading, setIsLoading] = useState(!isMobile)
+  const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [highResImageUrl, setHighResImageUrl] = useState<string | null>(null)
   const [highResImageLoaded, setHighResImageLoaded] = useState(false)
   const [showFullScreenViewer, setShowFullScreenViewer] = useState(Boolean(props.showLightbox))
   const [webGLAvailable] = useState(() => isWebGLSupported())
+  const avifOk = useAvifSupport()
+
+  // High-res source for the viewer: the largest generated variant (≤2560) when
+  // available, else the original. Deliberately NOT the multi-MB original.
+  const highResSource = hasReadyVariants(props.imageKey, props.readyMaxWidth ?? 0, props.variantBaseUrl)
+    ? makeVariantLoader({
+        base: props.variantBaseUrl as string,
+        imageKey: props.imageKey as string,
+        readyMaxWidth: props.readyMaxWidth as number,
+        format: avifOk ? 'avif' : 'webp',
+      })({ src: props.imageKey as string, width: DETAIL_HIGH_RES_WIDTH })
+    : props.imageUrl
 
   const webglViewerRef = useRef<WebGLImageViewerRef | null>(null)
   useEffect(() => {
@@ -36,25 +54,36 @@ export default function ProgressiveImage(
       webglViewerRef.current?.destroy()
     }
   }, [])
+
+  // Load the high-res image ONLY when the lightbox is actually opened — never
+  // eagerly on mount. This stops the detail page from fetching a large image
+  // just for being opened (and re-fetching on every open/close re-mount).
   useEffect(() => {
-    setShowFullScreenViewer(Boolean(props.showLightbox))
-    // On mobile, load full-res only when lightbox is requested
-    if (isMobile && props.showLightbox && !highResImageUrl && !isLoading) {
-      loadHighResolutionImage()
+    if (props.showLightbox) {
+      setShowFullScreenViewer(true)
+      if (!highResImageUrl && !isLoading) {
+        loadHighResolutionImage()
+      }
     }
   }, [props.showLightbox])
 
+  // Revoke the object URL on unmount / source change.
   useEffect(() => {
-    // On mobile, defer full-res loading until user requests lightbox
-    if (!isMobile) {
-      loadHighResolutionImage()
-    }
     return () => {
       if (highResImageUrl) {
         URL.revokeObjectURL(highResImageUrl)
       }
     }
-  }, [props.imageUrl])
+  }, [highResSource])
+
+  // Open the full-screen viewer, loading the high-res image on demand.
+  const openFullScreen = () => {
+    setShowFullScreenViewer(true)
+    props.onShowLightboxChange?.(true)
+    if (!highResImageUrl && !isLoading) {
+      loadHighResolutionImage()
+    }
+  }
 
   const loadHighResolutionImage = () => {
     setIsLoading(true)
@@ -62,7 +91,7 @@ export default function ProgressiveImage(
     setError(null)
 
     const xhr = new XMLHttpRequest()
-    xhr.open('GET', props.imageUrl, true)
+    xhr.open('GET', highResSource, true)
     xhr.responseType = 'blob'
 
     xhr.onprogress = (e) => {
@@ -108,7 +137,7 @@ export default function ProgressiveImage(
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 1 }}
-          className="object-contain md:max-h-[90vh]"
+          className="object-contain md:max-h-[90vh] cursor-pointer"
           src={props.previewUrl}
           overrideSrc={props.previewUrl}
           placeholder="blur"
@@ -117,6 +146,7 @@ export default function ProgressiveImage(
           width={props.width}
           height={props.height}
           alt={props.alt || 'image'}
+          onClick={openFullScreen}
         />
         {/* 加载进度条 */}
         {isLoading && (
@@ -148,12 +178,7 @@ export default function ProgressiveImage(
               width={props.width}
               height={props.height}
               alt={props.alt || 'image'}
-              onClick={() => {
-                setShowFullScreenViewer(true)
-                if (props.onShowLightboxChange) {
-                  props.onShowLightboxChange(true)
-                }
-              }}
+              onClick={openFullScreen}
               onLoad={() => {
                 setHighResImageLoaded(true)
               }}

--- a/types/props.ts
+++ b/types/props.ts
@@ -42,6 +42,12 @@ export type ProgressiveImageProps = {
   alt?: string,
   showLightbox?:boolean
   onShowLightboxChange?: (value: boolean) => void
+  // Variant fields so the high-res viewer can load the largest generated variant
+  // (e.g. 2560 avif/webp) instead of the multi-MB original. Empty/missing → falls
+  // back to imageUrl (the original).
+  imageKey?: string
+  readyMaxWidth?: number
+  variantBaseUrl?: string
 }
 
 export type LinkProps = {


### PR DESCRIPTION
## Problem
The photo detail page (`progressive-image.tsx`) eagerly XHR-loaded the **full original** (`props.imageUrl = data.url`) on desktop mount, and re-loaded it on every open/close re-mount — pulling multi-MB originals just for opening detail (problem ⑤; this was visible in the Network panel, including the close-triggered re-fetch).

## Fix
- **Load high-res only when the lightbox is actually opened** (all devices), never eagerly on mount. The inline detail shows the **preview** until the user clicks to zoom; the preview image is now clickable to open the viewer. This removes the open-detail and close-re-mount original fetches.
- **Source the largest generated variant** (≤2560 avif/webp) via the FE-3 loader instead of the 20MB original. Falls back to the original only when no variant exists. The true original stays available via the explicit download path.
- Thread `image_key` / `ready_max_width` / `variantBaseUrl` through `preview-image` and the preview page config (reusing `getVariantBaseUrl`).

## Note / UX change
The desktop detail's inline main image is now the **preview** until the user clicks to open the zoom viewer (previously it auto-loaded full-res inline). This is the agreed "load only on lightbox open" behavior. If a crisper default inline is desired, a mid-tier variant could be loaded inline as a follow-up.

## Scope note
This addresses the confirmed eager-original load. If the "other images' originals" the reporter saw come from a separate source (route prefetch / multiple mounted instances), that needs the Network **initiator** to pinpoint (pending) — I'll address separately.

## Verification
- `pnpm lint` — 0 errors. `npx tsc --noEmit` — no errors in the 4 changed files. `pnpm build` — compiled successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
