### PR TITLE
fix: reduce blank cells while fast-scrolling the masonry grid

### DIFF
--- a/components/gallery/masonry-photo-item.tsx
+++ b/components/gallery/masonry-photo-item.tsx
@@ -77,7 +77,9 @@ export default function MasonryPhotoItem({ photo, width, variantBaseUrl = '' }: 
             'absolute inset-0 z-10 rounded-none',
             hasRealBlurhash
               ? 'animate-none bg-black/10 backdrop-blur-[2px] dark:bg-white/10'
-              : 'bg-accent/80'
+              // Neutral muted tone (not the near-white bg-accent) so a cell still
+              // loading during fast scroll reads as a placeholder, not a white gap.
+              : 'bg-muted'
           )}
         />
       )}

--- a/components/gallery/virtual-masonry.tsx
+++ b/components/gallery/virtual-masonry.tsx
@@ -38,7 +38,11 @@ function VirtualMasonryInner<T extends VirtualMasonryItem>({
   columnWidth,
   columnCount,
   maxColumnCount,
-  overscanBy = 2,
+  // Render this many viewport-heights of extra content beyond what's visible.
+  // A larger overscan preloads rows before they scroll into view, so fast
+  // scrolling doesn't outrun item mount + image load/decode (which left blank
+  // cells, especially for slower-decoding AVIF).
+  overscanBy = 5,
 }: Readonly<VirtualMasonryProps<T>>) {
   return (
     <Masonry

--- a/components/layout/theme/default/default-gallery.tsx
+++ b/components/layout/theme/default/default-gallery.tsx
@@ -183,7 +183,7 @@ export default function DefaultGallery(props : Readonly<ImageHandleProps>) {
             render={RenderItem}
             columnGutter={4}
             columnCount={columnCount}
-            overscanBy={2}
+            overscanBy={5}
           />
         )}
         {dataList.length === 0 && !isValidating && (

--- a/components/layout/theme/simple/simple-gallery.tsx
+++ b/components/layout/theme/simple/simple-gallery.tsx
@@ -119,7 +119,7 @@ export default function SimpleGallery(props: Readonly<ImageHandleProps>) {
             render={SimpleRender}
             columnCount={1}
             columnGutter={40}
-            overscanBy={2}
+            overscanBy={5}
           />
         )}
         {dataList.length === 0 && !isValidating && (


### PR DESCRIPTION
## Problem
Fast scrolling the gallery showed white/blank cells (reported with a screenshot) — masonic's item mount + image load/decode couldn't keep up with fast scroll (worse for slower-decoding AVIF), so cells showed the bare loading placeholder.

## Fix
- **Raise `overscanBy` 2 → 5** (VirtualMasonry default + the default/simple gallery call sites) so rows preload before they scroll into view, giving images time to load/decode.
- **Neutral `bg-muted` loading skeleton** for images without a real blurhash, instead of the near-white `bg-accent` (so any residual loading cell reads as a placeholder, not a white gap).

## Notes
- Images gain a real blurhash once the preprocess backfill runs (`applyPreprocessUpdates` writes `blurhash`), which bridges the load gap with a blur — complementary to this FE change.
- `overscanBy=5` is a balance (smoother fast-scroll vs. mounting more items). Pending browser verification (chrome-devtools needs a headless reload on the agent host) to confirm/tune — I'll verify and adjust if needed.

## Verification
- `pnpm lint` — 0 errors. `npx tsc --noEmit` — no errors in changed files. `pnpm build` — compiled successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)