### PR TITLE
fix(preprocess): handle oversized panoramas + slow original fetch

### DIFF
--- a/server/lib/image-variants.ts
+++ b/server/lib/image-variants.ts
@@ -29,11 +29,33 @@ export {
 export type { VariantFormat }
 
 /**
- * Decompression-bomb guard for sharp. 100 MP comfortably covers high-end
- * camera output (e.g. 100MP medium format) while rejecting pathological
- * inputs crafted to exhaust memory.
+ * Default decompression-bomb guard for sharp, in pixels. sharp's own default is
+ * ~268MP; an earlier revision tightened this to 100MP, which turned out to
+ * reject large stitched panoramas (well above 100MP). The default is raised to
+ * comfortably cover multi-row panoramas while still rejecting pathological
+ * gigapixel inputs crafted to exhaust memory, and is overridable via the
+ * `IMAGE_MAX_INPUT_PIXELS` env var for outliers.
+ *
+ * Memory note: variants only need a <=2560px decode and `resize` downsamples,
+ * and JPEG benefits from libvips shrink-on-load (decode memory tracks the
+ * output, not the input) — so a high limit is memory-safe for the common JPEG
+ * case. Very large non-JPEG sources (e.g. a 300MP PNG) still decode in full
+ * (~1.2GB raw), so the guard stays a bounded number rather than disabled
+ * (`false`).
  */
-const MAX_INPUT_PIXELS = 100_000_000
+const DEFAULT_MAX_INPUT_PIXELS = 500_000_000
+
+function resolveMaxInputPixels(raw: string | undefined): number {
+  if (raw) {
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.floor(parsed)
+    }
+  }
+  return DEFAULT_MAX_INPUT_PIXELS
+}
+
+const MAX_INPUT_PIXELS = resolveMaxInputPixels(process.env.IMAGE_MAX_INPUT_PIXELS)
 
 /** Edge length used when sampling the image down to compute its thumbhash. */
 const THUMBHASH_MAX_EDGE = 100

--- a/server/tasks/image-preprocess.ts
+++ b/server/tasks/image-preprocess.ts
@@ -16,7 +16,10 @@ import type { ResolvedVariantStorage } from '~/server/lib/variant-storage'
 import type { AdminTaskIssue, AdminTaskStage } from '~/types/admin-tasks'
 import { ADMIN_TASK_KEY_PREPROCESS_IMAGES } from '~/types/admin-tasks'
 
-const FETCH_TIMEOUT_MS = 30_000
+// Originals can be 20MB+ and live behind slow object storage; 30s timed out on
+// the largest files during backfill. 60s gives slow large-original fetches more
+// headroom while still bounding a stuck request.
+const FETCH_TIMEOUT_MS = 60_000
 
 export type PreprocessImage = {
   id: string


### PR DESCRIPTION
## Why

Backfill (1091 images) surfaced **9 failures**, of which **5 are real bugs** (Manjusaka: ignore the 4 genuine 404s):

| count | stage | code | cause |
|---|---|---|---|
| 4 | process-batch | `variant_generation_failed` "Input image exceeds pixel limit" | the 100MP sharp guard rejected large stitched panoramas |
| 1 | fetch | `timeout` | a large original exceeded the 30s fetch budget |
| 4 | fetch | `404` | originals genuinely deleted — **expected, ignored** |

## What

- **Raise the input-pixel guard default 100MP → 500MP**, overridable via `IMAGE_MAX_INPUT_PIXELS`. sharp's own default is ~268MP; an earlier revision had tightened it to 100MP, which turned out too strict for panoramas. The guard stays a **bounded number, not `false`** — JPEG shrink-on-load keeps the common case memory-safe (variants only need a ≤2560px decode), while very large non-JPEG sources still decode in full.
- **Bump original-fetch timeout 30s → 60s** so slow large-original downloads from object storage don't abort early.

## Re-run / verification

No single-image mechanism needed: failed images keep `variants_ready=false`, and a **default-scope backfill re-run** (`WHERE variants_ready=false`) reprocesses exactly these images. After deploy + re-run, the 4 panoramas generate variants; the 4 404s remain expected failures.

Env-parsing logic validated against undefined/empty/invalid/negative/zero/scientific-notation/float inputs (all fall back to the bounded default or floor correctly).

## Test plan
- [ ] Deploy
- [ ] Re-run backfill (default scope) → confirm the 4 oversized panoramas now produce variants (to be spot-checked in devtools)
- [ ] Confirm 404s remain the only residual failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
