### PR TITLE
fix(gallery): raise default page size 8 → 24 (FU-11)

### DIFF
--- a/app/admin/settings/preferences/page.tsx
+++ b/app/admin/settings/preferences/page.tsx
@@ -31,7 +31,7 @@ export default function Preferences() {
   const [umamiHost, setUmamiHost] = useState('')
   const [maxUploadFiles, setMaxUploadFiles] = useState('5')
   const [customIndexOriginEnable, setCustomIndexOriginEnable] = useState(false)
-  const [adminImagesPerPage, setAdminImagesPerPage] = useState('8')
+  const [adminImagesPerPage, setAdminImagesPerPage] = useState('24')
   const [defaultTheme, setDefaultTheme] = useState<'light' | 'dark' | 'system'>('light')
   const t = useTranslations()
 

--- a/server/db/query/images.ts
+++ b/server/db/query/images.ts
@@ -41,8 +41,8 @@ export async function fetchServerImagesListByAlbum(
   }
   // 如果没有提供 pageSize，从配置中获取
   if (!pageSize) {
-    const configPageSize = await fetchConfigValue('admin_images_per_page', '8')
-    pageSize = parseInt(configPageSize, 10) || 8
+    const configPageSize = await fetchConfigValue('admin_images_per_page', String(DEFAULT_SIZE))
+    pageSize = parseInt(configPageSize, 10) || DEFAULT_SIZE
   }
   
   if (album && album !== '') {

--- a/server/lib/config-transform.ts
+++ b/server/lib/config-transform.ts
@@ -74,7 +74,7 @@ export function toCustomInfo(configs: Config[]): CustomInfo {
     umamiAnalytics: str(configs, 'umami_analytics'),
     maxUploadFiles: int(configs, 'max_upload_files', 5),
     customIndexOriginEnable: bool(configs, 'custom_index_origin_enable'),
-    adminImagesPerPage: int(configs, 'admin_images_per_page', 8),
+    adminImagesPerPage: int(configs, 'admin_images_per_page', 24),
     defaultTheme: normalizeDefaultTheme(valueOf(configs, 'default_theme')),
   }
 }
@@ -120,7 +120,7 @@ export function toVariantStorageInfo(configs: Config[]): VariantStorageInfo {
 
 export function toAdminConfig(configs: Config[]): AdminConfig {
   return {
-    adminImagesPerPage: int(configs, 'admin_images_per_page', 8),
+    adminImagesPerPage: int(configs, 'admin_images_per_page', 24),
   }
 }
 


### PR DESCRIPTION
## Why

Fast scroll waits at the bottom for the next page API. Two compounding causes — the FE prefetch trigger (FU-10 #500, Design) **and** the page size.

The **default/album gallery** resolves its page size from `admin_images_per_page`, whose fallback default was **8**, while the **tag/other** client galleries already use `DEFAULT_SIZE = 24`. Small 8-image pages = many short round-trips → a page is exhausted before the next arrives → bottom-wait.

## What

Unify the default to `DEFAULT_SIZE` (24):
- `server/db/query/images.ts` — the album/default query fallback now references `DEFAULT_SIZE` instead of a hardcoded `8` (no more magic number, stays in sync).
- `server/lib/config-transform.ts` — both `admin_images_per_page` config-read defaults `8 → 24`.
- `app/admin/settings/preferences/page.tsx` — settings form initial state `'8' → '24'`.

Fewer, larger pages reduce round-trips and **feed FU-10's chain-on-load** so it reaches its content-based cap (~1.5 viewports) in fewer API calls. AVIF variants keep each page light, so a larger first page is cheap. masonic still virtualizes rendering, so only visible items mount regardless of page length.

## Notes
- **This changes the *fallback* default only.** Instances that already persisted `admin_images_per_page` (e.g. at 8) are unaffected until they change it in admin settings — so for an existing deployment, bumping the value in **admin → preferences** takes effect immediately without a deploy.
- Complementary to and independent of FU-10 #500 (FE prefetch) — no conflict.

## Test plan
- [ ] Fresh/unset instance serves 24/page on album/default gallery
- [ ] Existing instance: bump `admin_images_per_page` in settings → takes effect
- [ ] Combined with FU-10: fast scroll no longer waits at bottom (verified in devtools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
