### PR TITLE
fix: persist config across soft navigation (gallery AVIF→preview downgrade on back-nav)

### DIFF
--- a/hooks/use-swr-hydrated.ts
+++ b/hooks/use-swr-hydrated.ts
@@ -1,10 +1,27 @@
+import { useEffect } from 'react'
 import useSWR from 'swr'
+
+// Module-level cache of the last successfully-resolved result per SWR key.
+// On a client-side (soft) navigation the consuming component re-mounts and the
+// value was observed to come back undefined on the first render after the
+// re-mount — which made config-derived UI (e.g. the gallery's variantBaseUrl)
+// fall back to a degraded state (AVIF variants → preview JPGs on returning from
+// the detail page). Feeding the last value as `fallbackData` makes the config
+// available immediately on re-mount, so consumers never lose it across
+// navigation; SWR still revalidates in the background.
+const lastResolved = new Map<string, unknown>()
 
 export const useSwrHydrated = <T = unknown>({ handle, args }: { handle: () => Promise<T>, args: string }) => {
   const { data, error, isLoading, isValidating, mutate } = useSWR(args,
     () => {
       return handle()
-    }, { revalidateOnFocus: false })
+    }, { revalidateOnFocus: false, fallbackData: lastResolved.get(args) as T | undefined })
+
+  useEffect(() => {
+    if (data !== undefined) {
+      lastResolved.set(args, data)
+    }
+  }, [args, data])
 
   return {
     data,


### PR DESCRIPTION
## Problem (devtools-confirmed on live)
Returning from the photo detail page re-mounted the gallery and it **downgraded from AVIF variants to preview JPGs** — and stayed preview. Evidence:
- Fresh `/lotus`: 48 grid imgs **all AVIF** (so the images *have* variants).
- After detail→back: **0 AVIF, 70 preview**, with **0 new AVIF requests and 0 AVIF failures** on the back-nav (only preview requests).

So the gallery never even *attempts* AVIF on re-mount → `variantReady` is false → `variantBaseUrl` is empty. Root cause: `useSwrHydrated('system-config')` returns `undefined` on the first render after a soft-nav re-mount, so `variantBaseUrl` (and other config) is lost. (Rules out onError/`variantFailed` and `avifOk=false`, which would have shown AVIF/webp-variant requests.)

## Fix
Cache the last successfully-resolved result per SWR key at module level and feed it as `fallbackData`, so config is available immediately on re-mount across client navigation (SWR still revalidates in the background). Holistic — also fixes the same re-mount loss for `customTitle` / origin / download config consumers.

## Notes
- This is the targeted root fix for the reported AVIF downgrade. FU-9 (prevent the gallery re-mount entirely via intercepting routes — also removes the redundant re-load + restores scroll) remains a larger optional structural improvement.
- Verify after deploy (devtools): detail→back keeps the grid on `_w.avif`, no downgrade.

## Verification
- `pnpm lint` — 0 errors. `npx tsc --noEmit` — no errors in `use-swr-hydrated.ts`. `pnpm build` — compiled successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)