### PR TITLE
fix(webgl-viewer): release engine on unmount to stop WebGL context leak (FU-13)

### DIFF
--- a/components/album/webgl-viewer/WebGLImageViewer.tsx
+++ b/components/album/webgl-viewer/WebGLImageViewer.tsx
@@ -147,6 +147,16 @@ export const WebGLImageViewer = ({
   })
   useEffect(() => {
     setUpWebGLEngine()
+    // Release the WebGL engine on unmount. Without this, every mount (each
+    // album → detail → zoom cycle) leaks a full WebGL context, its textures /
+    // buffers / program, the texture Web Worker, and ~9 canvas/window event
+    // listeners — browsers cap live WebGL contexts (~16) and silently drop the
+    // oldest once exceeded, so repeated cycles degrade sharply. destroy()
+    // already tears all of that down; it just was never being called.
+    return () => {
+      viewerRef.current?.destroy()
+      viewerRef.current = null
+    }
   }, [])
 
   const handleOutlineToggle = useCallback(

--- a/components/album/webgl-viewer/WebGLImageViewerEngine.ts
+++ b/components/album/webgl-viewer/WebGLImageViewerEngine.ts
@@ -97,6 +97,7 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
   private currentQuality: 'high' | 'medium' | 'low' | 'unknown' = 'unknown'
   private isLoadingTexture = true
   private worker: Worker | null = null
+  private workerObjectUrl: string | null = null
   private textureWorkerInitialized = false
 
   private positionBuffer: WebGLBuffer | null = null
@@ -326,7 +327,10 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
   }
 
   private initWorker() {
-    this.worker = new Worker(URL.createObjectURL(new Blob([TextureWorkerSource])), {
+    // Keep the blob object URL so it can be revoked on destroy; created inline
+    // it would leak one URL mapping per engine instance.
+    this.workerObjectUrl = URL.createObjectURL(new Blob([TextureWorkerSource]))
+    this.worker = new Worker(this.workerObjectUrl, {
       name: 'texture-worker',
     })
 
@@ -958,6 +962,9 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
   }
 
   public destroy() {
+    // Halt the animation loop so no queued frame renders against the GL
+    // objects deleted below.
+    this.isAnimating = false
     window.removeEventListener('resize', this.boundResizeCanvas)
     this.canvas.removeEventListener('mousedown', this.boundHandleMouseDown)
     this.canvas.removeEventListener('mousemove', this.boundHandleMouseMove)
@@ -987,6 +994,12 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
     if (this.program) {
       this.gl.deleteProgram(this.program)
     }
+
+    // Force the WebGL context to be released immediately instead of waiting for
+    // lazy GC. Browsers cap live contexts (~16); under rapid mount/unmount
+    // cycles GC can't reclaim them fast enough, so without this the limit is
+    // still reached even when destroy() runs on every unmount.
+    this.gl.getExtension('WEBGL_lose_context')?.loseContext()
     if (this.resizeObserver) {
       this.resizeObserver.disconnect()
     }
@@ -997,6 +1010,11 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
     }
 
     this.worker?.terminate()
+    this.worker = null
+    if (this.workerObjectUrl) {
+      URL.revokeObjectURL(this.workerObjectUrl)
+      this.workerObjectUrl = null
+    }
   }
 
   private updateDebugInfo() {


### PR DESCRIPTION
## Why

The zoom panel lags entering from detail, and **degrades dramatically after repeated album → detail → zoom cycles** — the classic monotonic-degradation-across-cycles signature of a resource leak.

**Root cause** (found by code-read, cross-verified via devtools + review): `components/album/webgl-viewer/WebGLImageViewer.tsx` created a `WebGLImageViewerEngine` in a mount effect with **no cleanup return**, so `engine.destroy()` was never called on unmount. Each cycle leaked a full WebGL context + textures/buffers/program + the texture Web Worker + ~9 canvas/window listeners. Browsers cap live WebGL contexts (~16) and silently drop the oldest once exceeded → sharp degradation + `context lost`.

**Design's devtools verification**: detail/viewer canvas count 2 → 0 on back-nav → the component **does** unmount, so a mount-effect cleanup is sufficient — **FU-13 alone fixes it, no FU-9 (no-remount) needed** for this leak.

## What

All in the viewer teardown path:
1. **WebGLImageViewer effect cleanup** → `viewerRef.current?.destroy(); viewerRef.current = null`. The `= null` also defuses the double-destroy from `ProgressiveImage`'s own cleanup (child cleanup runs first → destroys + nulls → parent's `?.destroy()` no-ops).
2. **`destroy()` now calls `getExtension('WEBGL_lose_context')?.loseContext()`** — forces *immediate* context release instead of lazy GC, which can't keep up under rapid cycles and would still hit the ~16 cap even with destroy running. (Independently flagged by both Design and Review — `destroy()` deleted resources but never released the context.)
3. **`destroy()` sets `isAnimating = false`** so no queued animation frame renders against the just-deleted GL objects (the main `animate()` loop has no stored rAF id; it's gated by `isAnimating`, so this is the correct stop).
4. **Worker blob object URL** is stored and `revokeObjectURL`'d on destroy (was created inline at `initWorker` and leaked one URL mapping per engine).

## Test plan
- [ ] Repeat album → detail → zoom → back several times; confirm JS heap no longer grows monotonically, live WebGL context count stays bounded, and no `context lost` warnings.
- [ ] Single open/close still renders + zooms correctly (no premature teardown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
