### PR TITLE
perf(lcp): eager-load + server preload first gallery image (FU-15)

### DIFF
--- a/app/(default)/page.tsx
+++ b/app/(default)/page.tsx
@@ -1,10 +1,14 @@
 import type { ImageHandleProps } from '~/types/props'
+import type { ImageType } from '~/types'
 import { getImagesData, getImagesPageTotal, getDisplayConfig, initDailyIfNeeded } from '~/server/actions/images'
+import { getVariantBaseUrl } from '~/server/lib/variant-storage'
 import SimpleGallery from '~/components/layout/theme/simple/simple-gallery.tsx'
 import { fetchConfigsByKeys } from '~/server/db/query/configs'
 import { toCustomInfo } from '~/server/lib/config-transform'
 import DefaultGallery from '~/components/layout/theme/default/default-gallery.tsx'
 import PolaroidGallery from '~/components/layout/theme/polaroid/polaroid-gallery.tsx'
+import GalleryPreloadHints from '~/components/gallery/gallery-preload-hints'
+import { gridSizesForTheme } from '~/lib/image/grid-image-sizes'
 
 export default async function Home() {
   await initDailyIfNeeded()
@@ -17,6 +21,13 @@ export default async function Home() {
 
   const currentStyle = await getStyleConfig()
 
+  // Server-side data for the LCP preload hint: the first gallery image and the
+  // variant CDN base. Best-effort — a failure here must never break the page.
+  const [firstPage, variantBaseUrl] = await Promise.all([
+    getImagesData(1, '/').catch(() => [] as ImageType[]),
+    getVariantBaseUrl().catch(() => ''),
+  ])
+
   const props: ImageHandleProps = {
     handle: getImagesData,
     args: 'getImages-client',
@@ -27,6 +38,11 @@ export default async function Home() {
 
   return (
     <>
+      <GalleryPreloadHints
+        image={firstPage[0]}
+        variantBaseUrl={variantBaseUrl}
+        sizes={gridSizesForTheme(currentStyle)}
+      />
       {currentStyle
         && currentStyle === '1' ? <SimpleGallery {...props} />
         : currentStyle === '2' ? <PolaroidGallery {...props} />

--- a/app/(theme)/[...album]/page.tsx
+++ b/app/(theme)/[...album]/page.tsx
@@ -1,11 +1,14 @@
 import { getImagesData, getImagesPageTotal, getAlbumDisplayConfig } from '~/server/actions/images'
+import { getVariantBaseUrl } from '~/server/lib/variant-storage'
 import type { ImageHandleProps } from '~/types/props'
 import DefaultGallery from '~/components/layout/theme/default/default-gallery'
 import { fetchAlbumByRouter } from '~/server/db/query/albums'
 import 'react-photo-album/masonry.css'
-import type { AlbumType } from '~/types'
+import type { AlbumType, ImageType } from '~/types'
 import SimpleGallery from '~/components/layout/theme/simple/simple-gallery'
 import PolaroidGallery from '~/components/layout/theme/polaroid/polaroid-gallery'
+import GalleryPreloadHints from '~/components/gallery/gallery-preload-hints'
+import { gridSizesForTheme } from '~/lib/image/grid-image-sizes'
 
 export default async function Page({
   params
@@ -15,6 +18,13 @@ export default async function Page({
   const { album } = await params
 
   const data: AlbumType = await fetchAlbumByRouter(`/${album}`)
+
+  // Server-side data for the LCP preload hint: the album's first image and the
+  // variant CDN base. Best-effort — a failure here must never break the page.
+  const [firstPage, variantBaseUrl] = await Promise.all([
+    getImagesData(1, `/${album}`).catch(() => [] as ImageType[]),
+    getVariantBaseUrl().catch(() => ''),
+  ])
 
   const props: ImageHandleProps = {
     handle: getImagesData,
@@ -30,6 +40,11 @@ export default async function Page({
 
   return (
     <>
+      <GalleryPreloadHints
+        image={firstPage[0]}
+        variantBaseUrl={variantBaseUrl}
+        sizes={gridSizesForTheme(data.theme)}
+      />
       {data.theme === '1' ? <SimpleGallery {...props} />
         : data.theme === '2' ? <PolaroidGallery {...props} />
         : <DefaultGallery {...props} />

--- a/components/gallery/gallery-preload-hints.tsx
+++ b/components/gallery/gallery-preload-hints.tsx
@@ -1,0 +1,91 @@
+import { preload, preconnect } from 'react-dom'
+import type { ImageType } from '~/types'
+import { hasReadyVariants } from '~/lib/image/loader'
+import { VARIANT_TIER_WIDTHS, buildVariantKey } from '~/lib/image/variant-tiers'
+
+// Smallest entry of next.config `images.deviceSizes` — the base width
+// next/image multiplies by the smallest `vw` ratio in `sizes` to decide which
+// srcset candidates to emit. Keep in sync with next.config.
+const SMALLEST_DEVICE_SIZE = 640
+
+/**
+ * Server-rendered resource hints for the gallery's LCP image.
+ *
+ * The gallery itself is a client component loaded with `ssr: false`, so its
+ * first image (the LCP element) is not present in the initial HTML — the
+ * browser's preload scanner can't discover it and the image only starts
+ * downloading after hydration + dynamic import (~2.7s of pure "load delay" was
+ * measured this way). This server component emits, into the initial `<head>`:
+ *
+ *  - `preconnect` to the variant CDN origin, so the TLS/TCP handshake overlaps
+ *    with JS download.
+ *  - a responsive `preload` (`as=image`, `fetchpriority=high`) for the first
+ *    image's AVIF variants. The `imagesrcset` is generated from the SAME shared
+ *    tier ladder (`VARIANT_TIER_WIDTHS` + `buildVariantKey`) that next/image's
+ *    custom loader uses, and `imagesizes` is the SAME string the rendered
+ *    `<img>` uses — so the preload scanner and next/image select the identical
+ *    candidate (single download, no waste). Tiers are clamped to
+ *    `ready_max_width` because, unlike the loader, this manual preload is not
+ *    clamped and must not point at an ungenerated (404) variant.
+ *
+ * AVIF only: `type="image/avif"` lets non-AVIF browsers (<5%) skip the hint
+ * entirely (so they incur no waste and just fall back to the normal lazy load).
+ *
+ * Renders nothing.
+ */
+export default function GalleryPreloadHints({
+  image,
+  variantBaseUrl,
+  sizes,
+}: {
+  image: ImageType | undefined
+  variantBaseUrl: string
+  sizes: string
+}) {
+  if (!variantBaseUrl) {
+    return null
+  }
+
+  // Warm the connection to the variant CDN regardless of the first image (helps
+  // every below-the-fold image too).
+  try {
+    preconnect(new URL(variantBaseUrl).origin)
+  } catch {
+    // variantBaseUrl wasn't an absolute URL — skip preconnect.
+  }
+
+  if (!image || !hasReadyVariants(image.image_key, image.ready_max_width, variantBaseUrl)) {
+    return null
+  }
+
+  const base = variantBaseUrl.replace(/\/+$/, '')
+
+  // Replicate next/image's `getWidths` candidate selection so the preload
+  // scanner and next/image evaluate the SAME srcset against the SAME `sizes` and
+  // pick the identical entry (single download). For a `sizes` with vw units,
+  // next/image keeps the tiers `>= deviceSizes[0] * (smallestVw / 100)`. Then
+  // clamp to `ready_max_width` (the manual preload, unlike the loader, isn't
+  // clamped and must not point at an ungenerated → 404 variant).
+  const vwValues = [...sizes.matchAll(/(\d{1,3})vw/g)].map((m) => Number(m[1]))
+  const smallestRatio = vwValues.length > 0 ? Math.min(...vwValues) / 100 : 0
+  const threshold = SMALLEST_DEVICE_SIZE * smallestRatio
+  const tiers = VARIANT_TIER_WIDTHS.filter(
+    (width) => width >= threshold && width <= image.ready_max_width,
+  )
+  if (tiers.length === 0) {
+    return null
+  }
+
+  const url = (width: number) => `${base}/${buildVariantKey(image.image_key, width, 'avif')}`
+  const imageSrcSet = tiers.map((width) => `${url(width)} ${width}w`).join(', ')
+
+  preload(url(tiers[0]), {
+    as: 'image',
+    fetchPriority: 'high',
+    type: 'image/avif',
+    imageSrcSet,
+    imageSizes: sizes,
+  })
+
+  return null
+}

--- a/components/gallery/masonry-photo-item.tsx
+++ b/components/gallery/masonry-photo-item.tsx
@@ -10,8 +10,9 @@ import { Skeleton } from '~/components/ui/skeleton'
 import { useState } from 'react'
 import { hasReadyVariants, makeVariantLoader } from '~/lib/image/loader'
 import { useAvifSupport } from '~/hooks/use-avif-support'
+import { DEFAULT_GRID_SIZES } from '~/lib/image/grid-image-sizes'
 
-export default function MasonryPhotoItem({ photo, width, variantBaseUrl = '' }: { photo: ImageType, width?: number, variantBaseUrl?: string }) {
+export default function MasonryPhotoItem({ photo, width, variantBaseUrl = '', priority = false }: { photo: ImageType, width?: number, variantBaseUrl?: string, priority?: boolean }) {
   const router = useRouter()
   const dataURL = useBlurImageDataUrl(photo.blurhash)
   const avifOk = useAvifSupport()
@@ -93,8 +94,12 @@ export default function MasonryPhotoItem({ photo, width, variantBaseUrl = '' }: 
           )}
           alt={photo.detail || photo.title || ''}
           fill
-          sizes="(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw"
-          loading="lazy"
+          sizes={DEFAULT_GRID_SIZES}
+          // First above-the-fold items load eagerly with high fetch priority so the
+          // LCP image is discovered immediately instead of waiting on the lazy
+          // IntersectionObserver at low priority (the variant is a tiny AVIF — the
+          // cost was discovery delay, not bytes). Later items stay lazy.
+          {...(priority ? { priority: true } : { loading: 'lazy' as const })}
           placeholder={hasRealBlurhash ? 'blur' : 'empty'}
           blurDataURL={dataURL}
           onLoad={() => setIsLoading(false)}

--- a/components/gallery/simple/gallery-image.tsx
+++ b/components/gallery/simple/gallery-image.tsx
@@ -10,15 +10,18 @@ import { useState } from 'react'
 import { Badge } from '~/components/ui/badge.tsx'
 import { hasReadyVariants, makeVariantLoader } from '~/lib/image/loader'
 import { useAvifSupport } from '~/hooks/use-avif-support'
+import { SIMPLE_GRID_SIZES } from '~/lib/image/grid-image-sizes'
 
 export default function GalleryImage({
   photo,
   customIndexOriginEnable,
   variantBaseUrl = '',
+  priority = false,
 }: {
   photo: ImageType
   customIndexOriginEnable: boolean
   variantBaseUrl?: string
+  priority?: boolean
 }) {
   const router = useRouter()
   const avifOk = useAvifSupport()
@@ -89,8 +92,8 @@ export default function GalleryImage({
             alt={photo.title}
             width={photo.width}
             height={photo.height}
-            sizes="(min-width: 768px) 75vw, 100vw"
-            loading="lazy"
+            sizes={SIMPLE_GRID_SIZES}
+            {...(priority ? { priority: true } : { loading: 'lazy' as const })}
             loader={makeVariantLoader({
               base: variantBaseUrl,
               imageKey: photo.image_key,
@@ -114,7 +117,7 @@ export default function GalleryImage({
             alt={photo.title}
             width={photo.width}
             height={photo.height}
-            loading="lazy"
+            {...(priority ? { priority: true } : { loading: 'lazy' as const })}
             unoptimized={useUnoptimized}
             placeholder={hasRealBlurhash ? 'blur' : 'empty'}
             blurDataURL={dataURL}

--- a/components/layout/theme/default/default-gallery.tsx
+++ b/components/layout/theme/default/default-gallery.tsx
@@ -13,6 +13,12 @@ import InfiniteScroll from '~/components/ui/origin/infinite-scroll.tsx'
 import FloatingFilterBall from '~/components/album/floating-filter-ball.tsx'
 import { Skeleton } from '~/components/ui/skeleton'
 
+// How many leading items load eagerly (priority) rather than lazily. Sized to
+// the widest column count (xl = 5) so the first visible row is always eager,
+// which lets the LCP image start downloading immediately. Variants are tiny
+// AVIFs (~5KB), so a few eager fetches cost almost nothing.
+const LCP_EAGER_COUNT = 5
+
 // Responsive column count matching the previous Tailwind breakpoints
 // (columns-2 / sm:columns-3 / lg:columns-4 / xl:columns-5).
 function useResponsiveColumnCount(): number {
@@ -123,8 +129,11 @@ export default function DefaultGallery(props : Readonly<ImageHandleProps>) {
   // shared photo item sized to that column. Memoized on `variantBaseUrl` so
   // masonic keeps a stable render-component identity (avoids remounting items).
   const RenderItem = useMemo(() => {
-    return function RenderItem({ data, width }: { index: number, data: ImageType, width: number }) {
-      return <MasonryPhotoItem photo={data} width={width} variantBaseUrl={variantBaseUrl} />
+    return function RenderItem({ index, data, width }: { index: number, data: ImageType, width: number }) {
+      // Eager-load the first row(s) so the LCP image is fetched at high priority
+      // instead of waiting on the lazy IntersectionObserver. Covers up to the
+      // widest column count (5) so the first visible row is always eager.
+      return <MasonryPhotoItem photo={data} width={width} variantBaseUrl={variantBaseUrl} priority={index < LCP_EAGER_COUNT} />
     }
   }, [variantBaseUrl])
 

--- a/components/layout/theme/polaroid/polaroid-gallery.tsx
+++ b/components/layout/theme/polaroid/polaroid-gallery.tsx
@@ -12,6 +12,7 @@ import { useBlurImageDataUrl } from '~/hooks/use-blurhash'
 import { cn } from '~/lib/utils'
 import { hasReadyVariants, makeVariantLoader } from '~/lib/image/loader'
 import { useAvifSupport } from '~/hooks/use-avif-support'
+import { POLAROID_GRID_SIZES } from '~/lib/image/grid-image-sizes'
 
 /**
  * 拍立得照片卡片组件
@@ -23,12 +24,14 @@ const PolaroidCard = memo(function PolaroidCard({
   onMouseDown,
   zIndex,
   variantBaseUrl = '',
+  priority = false,
 }: {
   item: ImageType
   style: React.CSSProperties
   onMouseDown: (id: string) => void
   zIndex: number
   variantBaseUrl?: string
+  priority?: boolean
 }) {
   const [isLoading, setIsLoading] = useState(true)
   const blurDataUrl = useBlurImageDataUrl(item.blurhash)
@@ -131,8 +134,8 @@ const PolaroidCard = memo(function PolaroidCard({
               }
               setIsLoading(false)
             }}
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-            priority={false}
+            sizes={POLAROID_GRID_SIZES}
+            priority={priority}
           />
         ) : (
           <div
@@ -222,7 +225,7 @@ export default function PolaroidGallery(props: Readonly<ImageHandleProps>) {
       <p className="absolute top-1/2 mx-auto max-w-sm -translate-y-3/4 text-center text-2xl font-black text-muted-foreground md:text-4xl">
         {customTitle || '瓦达西可不可爱'}
       </p>
-      {dataList?.map((item: ImageType) => (
+      {dataList?.map((item: ImageType, index: number) => (
         <PolaroidCard
           key={item.id}
           item={item}
@@ -230,6 +233,7 @@ export default function PolaroidGallery(props: Readonly<ImageHandleProps>) {
           zIndex={cardZIndices[item.id] || 1}
           onMouseDown={handleCardClick}
           variantBaseUrl={variantBaseUrl}
+          priority={index < 3}
         />
       ))}
     </DraggableCardContainer>

--- a/components/layout/theme/simple/simple-gallery.tsx
+++ b/components/layout/theme/simple/simple-gallery.tsx
@@ -62,8 +62,10 @@ export default function SimpleGallery(props: Readonly<ImageHandleProps>) {
   // masonic render adapter (single column vertical feed). Memoized on the
   // config flags so masonic keeps a stable render-component identity.
   const SimpleRender = useMemo(() => {
-    return function SimpleRender({ data }: { index: number, data: ImageType, width: number }) {
-      return <GalleryImage photo={data} customIndexOriginEnable={customIndexOriginEnable} variantBaseUrl={variantBaseUrl} />
+    return function SimpleRender({ index, data }: { index: number, data: ImageType, width: number }) {
+      // Single-column feed: only the first image is above the fold, so eager-load
+      // the first two to cover the LCP element without wasting bandwidth.
+      return <GalleryImage photo={data} customIndexOriginEnable={customIndexOriginEnable} variantBaseUrl={variantBaseUrl} priority={index < 2} />
     }
   }, [customIndexOriginEnable, variantBaseUrl])
   const t = useTranslations()

--- a/lib/image/grid-image-sizes.ts
+++ b/lib/image/grid-image-sizes.ts
@@ -1,0 +1,35 @@
+/**
+ * Single source of truth for each theme's grid `<img sizes>` attribute.
+ *
+ * The server-rendered LCP preload hint (`components/gallery/gallery-preload-hints`)
+ * MUST emit an `imagesizes` byte-identical to the `sizes` of the rendered grid
+ * `<img>`. Otherwise the preload scanner and next/image run their candidate
+ * selection against different `sizes` and may pick different srcset widths,
+ * causing a wasted double download. Importing the same constant in both places
+ * makes that drift impossible.
+ */
+
+// Default masonry theme (components/gallery/masonry-photo-item.tsx).
+export const DEFAULT_GRID_SIZES = '(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw'
+
+// Simple single-column feed theme (components/gallery/simple/gallery-image.tsx).
+export const SIMPLE_GRID_SIZES = '(min-width: 768px) 75vw, 100vw'
+
+// Polaroid draggable-cards theme (components/layout/theme/polaroid/polaroid-gallery.tsx).
+export const POLAROID_GRID_SIZES = '(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
+
+/**
+ * Resolve the grid `<img sizes>` for a theme selector value (`custom_index_style`
+ * on the home page, or an album's `theme` field): '1' = simple, '2' = polaroid,
+ * anything else = default. Used by the server preload hint to match the theme
+ * that will actually render.
+ */
+export function gridSizesForTheme(theme: string | undefined): string {
+  if (theme === '1') {
+    return SIMPLE_GRID_SIZES
+  }
+  if (theme === '2') {
+    return POLAROID_GRID_SIZES
+  }
+  return DEFAULT_GRID_SIZES
+}


### PR DESCRIPTION
## Why

Benchmark of `photos.manjusaka.me` (`/lotus`, desktop trace) found **LCP 4.69s (POOR)** with a **~2.77s "Load delay"** — even though the AVIF variant of the LCP image downloads in **~89µs** (CLS already 0.01, good). All three LCPDiscovery checks failed:

- `fetchpriority=high` not applied
- LCP resource uses `loading=lazy`
- **not discoverable in the initial document**

Root cause: the gallery is a client component loaded with `dynamic(ssr: false)`, so the first image (the LCP element) isn't in the initial HTML. The preload scanner can't find it, and it only starts downloading after hydration + the dynamic import resolves (~3.5s). The cost is **discovery delay, not bytes**.

## What

Two FE fixes targeting the discovery delay (TTFB is handled separately in FU-16):

1. **Eager first row** — pass `priority` to the first above-the-fold grid items (default masonry: first 5, simple feed: first 2, polaroid: first 3) so next/image uses `eager` + `fetchpriority=high` instead of lazy + low priority. Fixes checks ① and ②.

2. **Server-rendered resource hints** (`components/gallery/gallery-preload-hints.tsx`) — a Server Component rendered by the home/album pages that emits, into the **initial `<head>`**:
   - `preconnect` to the variant CDN origin
   - a responsive `<link rel="preload" as="image" fetchpriority="high" type="image/avif">` for the first image

   Fixes check ③ (discoverable in initial document).

### No double download (the part Review/Impl flagged)

- `imagesrcset` is generated from the **same shared tier ladder** (`VARIANT_TIER_WIDTHS` + `buildVariantKey`) the next/image loader uses.
- The candidate widths **replicate next/image's `getWidths`** selection (`width >= deviceSizes[0] * smallestVw/100`), so the preload scanner and next/image evaluate the **same srcset** against the **same `sizes`** and pick the identical entry.
- `imagesizes` is **byte-identical** to the rendered `<img sizes>` via a new single-source module `lib/image/grid-image-sizes.ts` (imported by both the grid items and the hint — drift-impossible).
- Tiers are **clamped to `ready_max_width`** so we never preload an ungenerated (404) variant.
- **AVIF-only** with `type="image/avif"` → non-AVIF clients (<5%) skip the hint entirely (no waste).

The pages now fetch the first image server-side (best-effort with `.catch` — a failure never breaks the page) to feed the hint.

## Verification

- `pnpm exec tsc --noEmit` — no new errors (only pre-existing unrelated ones).
- `pnpm lint` — 0 errors.
- Post-deploy I'll verify via chrome-devtools: LCP drop on `/lotus`, the preload `<link>` present in initial HTML, and the first image is a **single** download (no 404, no double-fetch) across default/simple/polaroid themes.

Part of the pre-release optimization round. FU-16 (TTFB caching) is a parallel PR by Impl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)