### PR TITLE
fix(a11y): use role="list" for the masonry container (FU-17)

### DIFF
--- a/components/gallery/virtual-masonry.tsx
+++ b/components/gallery/virtual-masonry.tsx
@@ -29,6 +29,13 @@ interface VirtualMasonryProps<T extends VirtualMasonryItem> {
   maxColumnCount?: number
   className?: string
   overscanBy?: number
+  // ARIA role for the masonry container. masonic derives the item role from it
+  // ("list" → "listitem", "grid" → "gridcell"). Defaults to "list": a photo
+  // gallery is a list of links, and "grid" was invalid here because masonic
+  // nests gridcells directly under the grid with no intervening "row"
+  // (tripping aria-required-children / aria-required-parent). "list"/"listitem"
+  // is a valid parent/child pair with no row requirement.
+  role?: 'list' | 'grid'
 }
 
 function VirtualMasonryInner<T extends VirtualMasonryItem>({
@@ -43,11 +50,13 @@ function VirtualMasonryInner<T extends VirtualMasonryItem>({
   // scrolling doesn't outrun item mount + image load/decode (which left blank
   // cells, especially for slower-decoding AVIF).
   overscanBy = 5,
+  role = 'list',
 }: Readonly<VirtualMasonryProps<T>>) {
   return (
     <Masonry
       items={items}
       render={render}
+      role={role}
       columnGutter={columnGutter}
       columnWidth={columnWidth}
       columnCount={columnCount}


### PR DESCRIPTION
## Why

Mobile Lighthouse accessibility audit (score **90**) flagged two failures, both on the masonry container:

- **`aria-required-children`** — an element with `role="grid"` must contain `row` children.
- **`aria-required-parent`** — a `gridcell` must be contained by a `row`.

The container renders with masonic's default `role="grid"`, and masonic nests its `gridcell` items **directly under the grid with no intervening `row`** — so both contracts are violated.

## What

A photo gallery is semantically a **list of links**, not a data grid. Switch the container to `role="list"`; masonic derives the matching item role (`"list"` → `"listitem"`, per its `itemRole` logic), yielding a valid `list → listitem` parent/child pair with **no `row` requirement**.

Exposed as an optional `role` prop on `VirtualMasonry` (default `"list"`), so both consumers (default masonry + simple feed) get the fix automatically.

**Purely an ARIA attribute change** — layout, virtualization, item rendering, and keyboard behaviour are unchanged.

## Verification

- `pnpm exec tsc --noEmit` — clean (masonic's types accept `role`).
- `pnpm lint` — clean.
- Post-deploy: re-run mobile Lighthouse → confirm `aria-required-children` / `aria-required-parent` pass and accessibility rises from 90.

Found during the pre-release FE benchmark. The other Lighthouse item (`errors-in-console` → `net::ERR_CONNECTION_REFUSED`) was traced to the umami analytics script config (not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
