### PR TITLE
fix(viewer): load the original in the zoom panel, not the 2560 variant

### DIFF
--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -11,9 +11,9 @@ import { isWebGLSupported } from '~/lib/utils/webgl'
 import { hasReadyVariants, makeVariantLoader } from '~/lib/image/loader'
 import { useAvifSupport } from '~/hooks/use-avif-support'
 
-// Width requested for the detail high-res view; the loader clamps it to the
-// largest generated tier (variants go up to 2560), so we never pull the
-// multi-MB original for in-page viewing.
+// Width requested for the variant FALLBACK used only when a photo has no
+// original URL; the loader clamps it to the largest generated tier (2560). The
+// zoom viewer normally loads the original (see highResSource below).
 const DETAIL_HIGH_RES_WIDTH = 2560
 
 /**
@@ -37,16 +37,23 @@ export default function ProgressiveImage(
   const [webGLAvailable] = useState(() => isWebGLSupported())
   const avifOk = useAvifSupport()
 
-  // High-res source for the viewer: the largest generated variant (≤2560) when
-  // available, else the original. Deliberately NOT the multi-MB original.
-  const highResSource = hasReadyVariants(props.imageKey, props.readyMaxWidth ?? 0, props.variantBaseUrl)
+  // High-res source for the full-screen zoom viewer: the ORIGINAL, full-
+  // resolution image. The zoom panel is where the user explicitly pixel-peeps,
+  // so it must show native detail — the largest variant (≤2560) looks soft once
+  // magnified past that width. This is loaded lazily, gated to the lightbox
+  // actually opening (see below), so the multi-MB original is only fetched when
+  // the user opts into zooming; the inline detail view keeps showing the
+  // lightweight preview/variant and never pulls the original. Falls back to the
+  // largest variant only if no original URL is available.
+  const variantHighResSource = hasReadyVariants(props.imageKey, props.readyMaxWidth ?? 0, props.variantBaseUrl)
     ? makeVariantLoader({
         base: props.variantBaseUrl as string,
         imageKey: props.imageKey as string,
         readyMaxWidth: props.readyMaxWidth as number,
         format: avifOk ? 'avif' : 'webp',
       })({ src: props.imageKey as string, width: DETAIL_HIGH_RES_WIDTH })
-    : props.imageUrl
+    : ''
+  const highResSource = props.imageUrl || variantHighResSource
 
   const webglViewerRef = useRef<WebGLImageViewerRef | null>(null)
   useEffect(() => {


### PR DESCRIPTION
## Why

The zoom panel looked soft when magnified — it loads a lower-resolution image, not the original.

**Confirmed root cause** (code + devtools): `progressive-image.tsx` set the viewer's `highResSource` to the largest **variant** (≤2560) when variants are ready, only falling back to the original otherwise. FU-7 did this to avoid the multi-MB original. devtools on `/dog` showed the zoom fetching `_2560.avif`, never `dog/DSC_*.jpg`. So deep zoom past 2560px shows no native detail.

## What

Switch the zoom viewer's high-res source to the **original** (`props.imageUrl`); keep the variant only as a fallback when a photo has no original URL.

- The existing **lightbox-open gate** is unchanged — the original is fetched lazily, only when the user actively opens full-screen zoom.
- The grid and inline detail view keep serving the lightweight variant/preview, so **⑤ (no heavy images in the feed)** is unaffected — only an explicit zoom pays the original's cost.
- This deliberately reverts FU-7's "viewer uses variant" choice: the zoom panel is where native detail matters.

The original bucket returns 200 / has CORS / needs no presign, so the XHR-blob path is unblocked.

## Verification

- `pnpm exec tsc --noEmit` — no new errors; `pnpm lint` — 0 errors.
- Post-deploy: devtools confirm the zoom fetches `…/DSC_*.jpg` (original) and deep zoom shows native detail.

Issue #2 from the same report (top-left indicator) is being investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
