### PR TITLE
fix(gallery): hydrate variantBaseUrl from server to stop preview double-load (mobile crash regression)

### DIFF
--- a/app/(default)/page.tsx
+++ b/app/(default)/page.tsx
@@ -33,7 +33,10 @@ export default async function Home() {
     args: 'getImages-client',
     album: '/',
     totalHandle: getImagesPageTotal,
-    configHandle: getDisplayConfig
+    configHandle: getDisplayConfig,
+    // Server-resolved so the gallery serves AVIF on the first render (no
+    // preview double-load while the client config SWR is still pending).
+    variantBaseUrl,
   }
 
   return (

--- a/app/(default)/tag/[...tag]/page.tsx
+++ b/app/(default)/tag/[...tag]/page.tsx
@@ -1,6 +1,7 @@
 import type { ImageHandleProps } from '~/types/props'
 import { fetchClientImagesListByTag, fetchClientImagesPageTotalByTag } from '~/server/db/query/images'
 import { getDisplayConfig } from '~/server/actions/images'
+import { getVariantBaseUrl } from '~/server/lib/variant-storage'
 import TagGallery from '~/components/album/tag-gallery'
 
 import 'react-photo-album/masonry.css'
@@ -19,12 +20,17 @@ export default async function Label({params}: { params: any }) {
     return await fetchClientImagesPageTotalByTag(tag)
   }
 
+  // Server-resolved so the tag gallery serves AVIF on the first render (no
+  // preview double-load while the client config SWR is still pending).
+  const variantBaseUrl = await getVariantBaseUrl().catch(() => '')
+
   const props: ImageHandleProps = {
     handle: getData,
     args: 'getImages-client-tag',
     album: `${decodeURIComponent(tag)}`,
     totalHandle: getPageTotal,
     configHandle: getDisplayConfig,
+    variantBaseUrl,
   }
 
   return (

--- a/app/(theme)/[...album]/page.tsx
+++ b/app/(theme)/[...album]/page.tsx
@@ -31,7 +31,10 @@ export default async function Page({
     args: 'getImages-client',
     album: `/${album}`,
     totalHandle: getImagesPageTotal,
-    configHandle: getAlbumDisplayConfig
+    configHandle: getAlbumDisplayConfig,
+    // Server-resolved so the gallery serves AVIF on the first render (no
+    // preview double-load while the client config SWR is still pending).
+    variantBaseUrl,
   }
 
   if (!data) {

--- a/components/album/tag-gallery.tsx
+++ b/components/album/tag-gallery.tsx
@@ -45,7 +45,10 @@ export default function TagGallery(props : Readonly<ImageHandleProps>) {
     handle: props.configHandle ?? (async () => emptyConfig),
     args: 'system-config',
   })
-  const variantBaseUrl = configData?.variantBaseUrl ?? ''
+  // Prefer the live config, but fall back to the server-passed base on the first
+  // render (before the config SWR resolves) so tag photos serve AVIF immediately
+  // instead of double-loading preview thumbnails.
+  const variantBaseUrl = configData?.variantBaseUrl ?? props.variantBaseUrl ?? ''
   const dataList = data?.flat() ?? []
   const t = useTranslations()
   const router = useRouter()
@@ -67,7 +70,10 @@ export default function TagGallery(props : Readonly<ImageHandleProps>) {
             }}
             photos={
               dataList?.map((item: ImageType) => ({
-                src: item.preview_url || item.url,
+                // Layout `src` only — the actual image is rendered by BlurImage
+                // via the variant ladder. Never reference the full-resolution
+                // original here (⑤: the tag grid must not load multi-MB originals).
+                src: item.preview_url || '',
                 alt: item.detail,
                 ...item,
                 variantBaseUrl,

--- a/components/layout/theme/default/default-gallery.tsx
+++ b/components/layout/theme/default/default-gallery.tsx
@@ -116,7 +116,10 @@ export default function DefaultGallery(props : Readonly<ImageHandleProps>) {
     handle: props.configHandle ?? (async () => emptyConfig),
     args: 'system-config',
   })
-  const variantBaseUrl = configData?.variantBaseUrl ?? ''
+  // Prefer the live config, but fall back to the server-passed base on the first
+  // render (before the config SWR resolves) so the grid serves AVIF immediately
+  // instead of double-loading preview thumbnails.
+  const variantBaseUrl = configData?.variantBaseUrl ?? props.variantBaseUrl ?? ''
 
   // Memoize dataList to avoid unnecessary recalculations
   const dataList = useMemo(() => data?.flat() ?? [], [data])

--- a/components/layout/theme/polaroid/polaroid-gallery.tsx
+++ b/components/layout/theme/polaroid/polaroid-gallery.tsx
@@ -173,7 +173,10 @@ export default function PolaroidGallery(props: Readonly<ImageHandleProps>) {
   })
 
   const customTitle = configData?.customTitle
-  const variantBaseUrl = configData?.variantBaseUrl ?? ''
+  // Prefer the live config, but fall back to the server-passed base on the first
+  // render (before the config SWR resolves) so cards serve AVIF immediately
+  // instead of double-loading preview thumbnails.
+  const variantBaseUrl = configData?.variantBaseUrl ?? props.variantBaseUrl ?? ''
 
   const { data } = useSWRInfinite((index) => {
     return [`client-${props.args}-${index}-${props.album}`, index]

--- a/components/layout/theme/simple/simple-gallery.tsx
+++ b/components/layout/theme/simple/simple-gallery.tsx
@@ -58,7 +58,10 @@ export default function SimpleGallery(props: Readonly<ImageHandleProps>) {
     () => configData?.customIndexOriginEnable === true,
     [configData]
   )
-  const variantBaseUrl = configData?.variantBaseUrl ?? ''
+  // Prefer the live config, but fall back to the server-passed base on the first
+  // render (before the config SWR resolves) so the feed serves AVIF immediately
+  // instead of double-loading preview thumbnails.
+  const variantBaseUrl = configData?.variantBaseUrl ?? props.variantBaseUrl ?? ''
   // masonic render adapter (single column vertical feed). Memoized on the
   // config flags so masonic keeps a stable render-component identity.
   const SimpleRender = useMemo(() => {

--- a/types/props.ts
+++ b/types/props.ts
@@ -24,6 +24,13 @@ export type ImageHandleProps = {
   album: string
   totalHandle: (album: string, camera?: string, lens?: string) => Promise<number>
   configHandle?: () => Promise<GalleryDisplayConfig>
+  // Variant CDN base resolved on the server (the same value `configHandle` will
+  // return). Passed so the gallery has it on the very first client render,
+  // before the client-side config SWR resolves — otherwise the grid briefly
+  // sees an empty base, falls back to requesting `preview_url` thumbnails, then
+  // swaps to AVIF once config arrives (a wasteful double-load that spiked mobile
+  // memory). With this, the first render already serves AVIF variants.
+  variantBaseUrl?: string
 }
 
 export type PreviewImageHandleProps = {


### PR DESCRIPTION
## The regression

The album was loading **many previously-optimized-away webp/original requests**, OOM-crashing mobile in a reload loop (a regression of problem ③).

**Root cause** (devtools + code, confirmed independently by all three of us): on a cold load the galleries read `variantBaseUrl` from the client config SWR (`useSwrHydrated('system-config')`), which is **empty on the first render**. With an empty base, `hasReadyVariants(...)` is false → every above-the-fold grid item renders its `preview_url` thumbnail (firing ~24 preview webp/jpg requests on `/dog`), then swaps to AVIF once config resolves (item `key` flips `preview→variant`, remounting). That transient preview double-load spiked memory → mobile OOM.

devtools: stable **40 AVIF + 24 preview** on `/dog` (one-time double-load, not an infinite loop on desktop; mobile OOMs on the memory spike). **Not #507** — that PR only touches the detail viewer.

## The fix

The route pages already resolve `variantBaseUrl` on the server (added for the FU-15 preload hint). Thread it into the galleries as a prop so the base is present on the **first** client render:

```ts
const variantBaseUrl = configData?.variantBaseUrl ?? props.variantBaseUrl ?? ''
```

Server prop and client SWR resolve the **same** value (same `variant_storage` config), so when the SWR settles the base doesn't change → no key flip, no remount, **no double-load**. First render already serves AVIF.

## Scope (all 4 live gallery surfaces + their pages)

- `default` / `simple` / `polaroid` — home (`app/(default)/page.tsx`) + album (`app/(theme)/[...album]/page.tsx`)
- `tag-gallery` (react-photo-album) — `app/(default)/tag/[...tag]/page.tsx`. BlurImage already uses the shared variant ladder; it just needed the base on first render. Also dropped the `|| item.url` fallback in the tag layout `src` so the tag grid never references the original (⑤).
- `types/props.ts` — added `variantBaseUrl?: string` to `ImageHandleProps`.
- `template-gallery` is **dead code** (no route renders it) → intentionally untouched.

Genuinely variant-less images (`ready_max_width === 0`) still fall back to `preview_url` when the base is known — that path is preserved (Review constraint #6).

## Verification

- `pnpm exec tsc --noEmit` — 0 new errors; `pnpm lint` — 0 errors.
- Post-deploy: devtools hard-reload `/lotus` · `/dog` · `/tag/*` → **0 preview/original requests** (AVIF only) + mobile no longer crashes + LCP not regressed. Impl to curl-verify the same.

Release-blocker fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
