### PR TITLE
fix(viewer): mount/unmount zoom viewer instead of Activity hide/show (2nd-open crash)

### DIFF
--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -191,8 +191,17 @@ export default function ProgressiveImage(
               }}
             />
           </Activity>
-          <Activity mode={showFullScreenViewer ? 'visible' : 'hidden'}>
-            {webGLAvailable ? <div
+          {/* Conditionally MOUNT the full-screen viewer rather than toggling an
+              <Activity> hidden/visible. <Activity> preserves the <canvas> DOM and
+              component state but runs the child's effect cleanup on hide — which
+              fires the WebGL engine's destroy()/loseContext(). Because the same
+              canvas is reused and `isInitialized` state is preserved, re-opening
+              never rebuilds the engine and lands on a permanently-lost context →
+              blank image + crash on the 2nd open. Mount/unmount gives every open a
+              fresh canvas + context (and destroy() on a discarded canvas stays
+              correct), fixing the crash while keeping the FU-13 leak fix intact. */}
+          {showFullScreenViewer && (
+            webGLAvailable ? <div
               className="fixed inset-0 z-[100] bg-background/95 flex items-center justify-center"
               onClick={(e) => {
                 // 点击背景关闭
@@ -283,8 +292,8 @@ export default function ProgressiveImage(
                 src={highResImageUrl}
                 alt={props.alt || 'image'}
               />
-            </div>}
-          </Activity>
+            </div>
+          )}
         </>
       ) : null}
 


### PR DESCRIPTION
## The bug

@Zheaoli : on the image detail page, **the second time** you click into the WebGL zoom, the whole page crashes and the image won't display.

## Root cause (devtools-reproduced + code, confirmed by Design + Impl)

The full-screen viewer was wrapped in `<Activity mode={showFullScreenViewer ? 'visible' : 'hidden'}>`. React `<Activity>` **preserves the child DOM (the same `<canvas>`) and state**, but **runs the child's effect cleanup on hide and re-runs effects on show**. So:

1. **Open #1** → engine built on canvas C, context α ✓
2. **Close** → Activity hidden → WebGLImageViewer effect cleanup → FU-13 `destroy()` → `loseContext()` **permanently loses α** + nulls the engine ref; **canvas C is preserved** by Activity.
3. **Open #2** → Activity re-runs the effect → `setUpWebGLEngine()`, but `isInitialized` state was preserved (`true`) → `if (isInitialized) return` **skips rebuilding** → null engine on a dead-context canvas → `createProgram()` returns null → `attachShader(null, …)` throws → **blank image + full-page crash**.

devtools evidence: open#1 context alive → close `lost=1` → open#2 **no new context created**, `ctxAlive=false`.

This is a **regression from FU-13 (#503)** — its 10-cycle test only exercised album→detail→zoom→navigate-away (true unmount, fresh canvas next time), not detail-page open→close→**reopen** (Activity hide/show reusing the same canvas).

## Fix

Conditionally **mount/unmount** the viewer (`{showFullScreenViewer && ( … )}`) instead of toggling `<Activity>`:
- Every open = a fresh `WebGLImageViewer` → fresh `<canvas>` → fresh context → fresh `isInitialized` → engine builds normally.
- Every close = a real unmount → FU-13 `destroy()`/`loseContext()` runs on a canvas that's being discarded — correct, and the leak fix is **fully preserved** (each open/close still creates + releases exactly one context).
- Trade-off: zoom/pan resets on each open — expected for a lightbox.

No engine change; FU-13's `loseContext()` is untouched (correct under the mount/unmount model).

## Verification

- `pnpm exec tsc --noEmit` — no new errors; `pnpm lint` — 0 errors.
- **Post-deploy** (devtools): detail → zoom open→close→open→close several times → no crash, image renders each time, each open creates a NEW live context (`ctxAlive=true`). Will re-run the reproduction harness after deploy.

Release-blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)