### PR TITLE
fix(viewer): keep zoom viewer mounted + CSS-toggle (restore context reuse/state, follow-up to #509)

### DIFF
--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -34,6 +34,11 @@ export default function ProgressiveImage(
   const [highResImageUrl, setHighResImageUrl] = useState<string | null>(null)
   const [highResImageLoaded, setHighResImageLoaded] = useState(false)
   const [showFullScreenViewer, setShowFullScreenViewer] = useState(Boolean(props.showLightbox))
+  // Latches true on the first full-screen open and stays true so the WebGL
+  // viewer remains mounted across subsequent open/close (toggled only via CSS
+  // visibility) — preserving its context + zoom/pan state. Lazily gates the
+  // first mount so the engine isn't built until the user actually zooms.
+  const [hasOpenedFullScreen, setHasOpenedFullScreen] = useState(Boolean(props.showLightbox))
   const [webGLAvailable] = useState(() => isWebGLSupported())
   const avifOk = useAvifSupport()
 
@@ -68,6 +73,7 @@ export default function ProgressiveImage(
   useEffect(() => {
     if (props.showLightbox) {
       setShowFullScreenViewer(true)
+      setHasOpenedFullScreen(true)
       if (!highResImageUrl && !isLoading) {
         loadHighResolutionImage()
       }
@@ -86,6 +92,7 @@ export default function ProgressiveImage(
   // Open the full-screen viewer, loading the high-res image on demand.
   const openFullScreen = () => {
     setShowFullScreenViewer(true)
+    setHasOpenedFullScreen(true)
     props.onShowLightboxChange?.(true)
     if (!highResImageUrl && !isLoading) {
       loadHighResolutionImage()
@@ -191,18 +198,24 @@ export default function ProgressiveImage(
               }}
             />
           </Activity>
-          {/* Conditionally MOUNT the full-screen viewer rather than toggling an
-              <Activity> hidden/visible. <Activity> preserves the <canvas> DOM and
-              component state but runs the child's effect cleanup on hide — which
-              fires the WebGL engine's destroy()/loseContext(). Because the same
-              canvas is reused and `isInitialized` state is preserved, re-opening
-              never rebuilds the engine and lands on a permanently-lost context →
-              blank image + crash on the 2nd open. Mount/unmount gives every open a
-              fresh canvas + context (and destroy() on a discarded canvas stays
-              correct), fixing the crash while keeping the FU-13 leak fix intact. */}
-          {showFullScreenViewer && (
+          {/* Keep the full-screen viewer MOUNTED once it has been opened, and
+              toggle it with CSS visibility rather than <Activity> or conditional
+              mount/unmount. <Activity> runs the child's effect cleanup on hide
+              (firing the WebGL engine's destroy()/loseContext() on every close →
+              the 2nd-open crash); conditional unmount rebuilds the engine on every
+              open (losing zoom/pan state + paying the re-creation cost). Staying
+              mounted keeps one engine + WebGL context alive across open/close, so
+              zoom/pan state is preserved and the context is reused — and destroy()
+              only runs when ProgressiveImage itself unmounts (leaving the detail
+              page), which keeps the FU-13 leak fix. `visibility:hidden` (not
+              display:none) keeps the canvas sized so re-showing doesn't reset the
+              view, and pointer-events are disabled while hidden so the invisible
+              overlay never blocks the page. Mounted lazily on first open so the
+              engine isn't built until the user actually zooms. */}
+          {hasOpenedFullScreen && (
             webGLAvailable ? <div
               className="fixed inset-0 z-[100] bg-background/95 flex items-center justify-center"
+              style={{ visibility: showFullScreenViewer ? 'visible' : 'hidden', pointerEvents: showFullScreenViewer ? 'auto' : 'none' }}
               onClick={(e) => {
                 // 点击背景关闭
                 if (e.target === e.currentTarget) {
@@ -256,6 +269,7 @@ export default function ProgressiveImage(
               </div>
             </div> : <div
               className="fixed inset-0 z-[100] bg-background/95 flex items-center justify-center overflow-auto"
+              style={{ visibility: showFullScreenViewer ? 'visible' : 'hidden', pointerEvents: showFullScreenViewer ? 'auto' : 'none' }}
               onClick={(e) => {
                 if (e.target === e.currentTarget) {
                   handleCloseViewer()


### PR DESCRIPTION
## Context

Follow-up to **#509** (already merged). @Zheaoli  pointed out that #509's approach (conditionally mount/unmount the full-screen viewer) fixed the 2nd-open crash but **regressed UX**: every open rebuilt the WebGL engine (re-creation cost) and **lost the zoom/pan state**. The original design deliberately kept one engine + context alive across open/close within the modal — preserving zoom/pan and avoiding rebuilds.

## Root cause (recap)

The viewer was toggled with `<Activity>`, which runs the child's effect cleanup on hide → fired FU-13's `destroy()`/`loseContext()` on **every close** → the 2nd open landed on a permanently-lost context → crash. The destroy was bound to the wrong lifecycle (zoom-close instead of detail-unmount).

## Fix C

Keep the viewer **mounted** once opened and toggle it with **CSS `visibility`** instead of `<Activity>` / conditional unmount:

- Staying mounted → the effect cleanup never runs on close → **one engine + WebGL context stays alive across open/close** → context reused, **zoom/pan state preserved**, zero rebuild cost (restores original UX).
- `destroy()`/`loseContext()` now runs **only when ProgressiveImage unmounts** (leaving the detail page), via the WebGLImageViewer's own unmount cleanup → **FU-13 leak fix fully preserved** (one context created+released per detail visit, `created==lost`).
- `visibility:hidden` (not `display:none`) keeps the canvas **sized**, so re-showing doesn't drive the engine through a 0×0 resize that would reset zoom (the engine's `getFitToScreenScale` clamps to 1 on a 0×0 canvas; `visibility` avoids that path). `pointer-events:none` while hidden so the invisible overlay never blocks the page.
- `hasOpenedFullScreen` latches on first open → engine still built **lazily** (not before the user zooms).

The WebGL engine and FU-13's `destroy()`/`loseContext()` are **unchanged**.

## Verification (post-deploy, devtools)

Modal-internal **open→close→open→close ≥3 rounds**:
- same context throughout (`isContextLost()` stays false, **no new context created**)
- **zoom/pan state preserved** across open/close
- zero throw, image renders every time

Leaving the detail page → `destroy()` runs (`created==lost`, no leak). Will run the harness after deploy; to be independently confirmed via the `isContextLost()` + scale-preservation hook.

Supersedes #509's approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
