### PR TITLE
fix(histogram): sqrt y-axis so a clipping spike doesn't flatten the chart

### DIFF
--- a/components/album/histogram-chart.tsx
+++ b/components/album/histogram-chart.tsx
@@ -73,7 +73,7 @@ const drawHistogram = (canvas: HTMLCanvasElement, histogram: CompressedHistogram
   // 清空画布
   ctx.clearRect(0, 0, width, height)
 
-  // 找到最大值用于归一化
+  // 跨 4 个通道取全局最大值用于归一化。
   const maxVal = Math.max(...histogram.luminance, ...histogram.red, ...histogram.green, ...histogram.blue)
 
   if (maxVal === 0) return
@@ -115,7 +115,11 @@ const drawHistogram = (canvas: HTMLCanvasElement, histogram: CompressedHistogram
     const barWidth = chartWidth / data.length
 
     for (const [i, datum] of data.entries()) {
-      const barHeight = (datum / maxVal) * chartHeight
+      // sqrt 纵轴而不是线性：低调照片（纯黑背景）会在最暗 bin 堆一个巨大的 clipping
+      // 尖峰，线性归一化会把其余真实分布全压成看不见的平线（看着像空直方图）。sqrt
+      // 压缩动态范围——尖峰仍顶到顶、中间调重新可见，且保留「阴影占大头」的低调特征
+      //（log 会把中间调抬太高、反而像正常曝光）。datum ≤ maxVal 恒成立，无需 clamp。
+      const barHeight = (Math.sqrt(datum) / Math.sqrt(maxVal)) * chartHeight
       const x = padding + i * barWidth
       const y = height - padding - barHeight
 


### PR DESCRIPTION
## Bug

@Zheaoli reported a specific image's histogram rendering incorrectly: \`/preview/cmb2hqbvl0013ig1y4qnp0f6h\` — a figure shot on a pure-black background (the page's own tone analysis: low-key, shadows 82%, highlights 2%). The histogram renders as a flat, near-empty dark box.

## Root cause (devtools-confirmed — not CORS, not the image source)

The histogram canvas renders fine (no \`SecurityError\`, the preview loads). The problem is the linear normalization in \`drawHistogram\`: \`barHeight = (datum / maxVal) * chartHeight\`. A low-key image piles a huge clipping spike into the darkest bin — measured here: bin 0 = 43185, the next real bins ≈ 335 (~130x). Linearly, that spike becomes \`maxVal\` and every other bar scales to ~1% height and disappears. The histogram is computed correctly; the display is flattened by the spike.

## Fix

Scale bar heights by \`sqrt(count)\` instead of linearly (max stays the absolute max, kept global across the 4 channels):

\`\`\`ts
const barHeight = (Math.sqrt(datum) / Math.sqrt(maxVal)) * chartHeight
\`\`\`

- The clipping spike still reaches full height (a low-key shot should show a big shadow spike).
- The rest of the distribution becomes visible again, while the shadow-weighted low-key character is preserved — \`log\` would over-lift the midtones and make a low-key shot look normally exposed.
- \`count <= max\` always, so bars never exceed the canvas: no clamp needed, no data dropped (avoids the clamp + few-bins edge cases of a percentile approach).

## Verification (simulated the exact render logic on the reported image)

- linear: 1 of 127 non-zero bins renders a visible bar (flat/empty).
- sqrt: 75 of 127 render; the shadow spike stays full-height; the tallest midtone lifts from ~1% to ~9%.

\`pnpm exec tsc --noEmit\` clean; \`pnpm lint\` clean. Post-deploy I'll devtools-confirm the rendered histogram on this image plus a normal and a high-key image (no regression).

(Supersedes the earlier percentile approach in this PR per review — sqrt avoids the clamp + edge cases and preserves tonal character.)