### PR TITLE
fix(upload): preserve original filename for downloads

### DIFF
--- a/components/admin/upload/livephoto-file-upload.tsx
+++ b/components/admin/upload/livephoto-file-upload.tsx
@@ -52,6 +52,7 @@ export default function LivephotoFileUpload() {
   const [exif, setExif] = useState({} as ExifType)
   const [title, setTitle] = useState('')
   const [url, setUrl] = useState('')
+  const [imageName, setImageName] = useState('')
   const [previewUrl, setPreviewUrl] = useState('')
   const [videoUrl, setVideoUrl] = useState('')
   const [loading, setLoading] = useState(false)
@@ -124,6 +125,7 @@ export default function LivephotoFileUpload() {
         album: album,
         url: url,
         title: title,
+        image_name: imageName,
         preview_url: previewUrl,
         blurhash: hash,
         video_url: videoUrl,
@@ -167,6 +169,8 @@ export default function LivephotoFileUpload() {
     await loadExif(processedFile)
     setHash(await encodeBrowserThumbHash(processedFile))
     setUrl(res?.data?.url)
+    // Preserve the original uploaded filename for the download default name.
+    setImageName(processedFile.name)
   }
 
   async function onRequestVideoUpload(file: File) {
@@ -181,6 +185,7 @@ export default function LivephotoFileUpload() {
   async function onBeforeUpload(type: number) {
     if (type === 1) {
       setTitle('')
+      setImageName('')
       setPreviewUrl('')
       setVideoUrl('')
       setImageLabels([])
@@ -192,6 +197,7 @@ export default function LivephotoFileUpload() {
     setExif({} as ExifType)
     setHash('')
     setUrl('')
+    setImageName('')
     setTitle('')
     setDetail('')
     setWidth(0)

--- a/components/admin/upload/multiple-file-upload.tsx
+++ b/components/admin/upload/multiple-file-upload.tsx
@@ -78,6 +78,11 @@ export default function MultipleFileUpload() {
             album: album,
             url: url,
             title: '',
+            // Preserve the original uploaded filename so downloads default to it
+            // instead of the randomized storage key. `file` here is the
+            // (post-HEIC-conversion) uploaded file, so its name matches the
+            // stored bytes (e.g. `foo.jpg` for a converted `foo.heic`).
+            image_name: file.name,
             preview_url: previewUrl,
             blurhash: hash,
             exif: exifObj,

--- a/hono/images.ts
+++ b/hono/images.ts
@@ -39,6 +39,14 @@ app.post('/', async (c) => {
     if (body?.exif?.dateTime && !dayjs(body?.exif?.dateTime, 'YYYY:MM:DD HH:mm:ss', true).isValid()) {
       body.exif.dateTime = ''
     }
+    // Reduce the preserved original filename to a bare basename (defense in
+    // depth — `File.name` from the client is already a basename, but strip any
+    // path separators so it stays safe as the download Content-Disposition
+    // value). Empty/whitespace falls back to null → download derives the name
+    // from the URL, i.e. the prior behaviour.
+    if (typeof body.image_name === 'string') {
+      body.image_name = body.image_name.split(/[\\/]/).pop()?.trim() || null
+    }
     // New images are stored with variants_ready=false; the background
     // preprocess ticker (see instrumentation.ts) picks them up asynchronously
     // and generates variants via a tracked /admin/tasks run — no inline work


### PR DESCRIPTION
## Problem

After upload the original filename was discarded: the storage key is generated as `{cuid}.{ext}` (randomized so same-named files don't collide), `image_name` was left null, and the multi-image uploader never sent it. So a downloaded file got the random ID as its name instead of the original.

## Fix

Persist the original (post-HEIC-conversion) filename in the existing `image_name` column on upload. The download route's `deriveFilename` already prefers `image_name` (RFC 5987 `filename*=UTF-8''…`), so **no download-route or migration change is needed** — only the upload payload.

- `multiple-file-upload` / `livephoto-file-upload`: include `image_name` (the uploaded file's name) in the insert payload; `simple-file-upload` already did.
- `hono/images` POST: reduce `image_name` to a bare basename (defense-in-depth) before insert; empty/whitespace falls back to the URL-derived name (prior behaviour).
- The storage key stays randomized, so same-named files in a batch don't overwrite each other; the original name is used only for display and the download default.

## Test plan
- [ ] Upload several images (incl. a batch with duplicate names + one non-ASCII name) → DB `image_name` is the original; storage keys stay unique.
- [ ] Download each → default filename is the original (non-ASCII not garbled, via RFC 5987).
- [ ] Upload a HEIC → stored as `foo.jpg`, and `image_name` is `foo.jpg` (post-conversion, matching the bytes), not `foo.heic`.
- [ ] Image with empty/no name → falls back to the URL-derived name (unchanged behaviour).

Note: these upload components carry pre-existing loose typing (e.g. `res?.data?.url` passed where a `string` is expected, one stale `@ts-expect-error`); this change introduces no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
