### PR TITLE
perf(cache): short TTL for gallery image listings

### DIFF
--- a/server/lib/cache.ts
+++ b/server/lib/cache.ts
@@ -28,38 +28,52 @@ export const CACHE_TAG = {
 
 /**
  * On-demand `revalidateTag` is the primary freshness mechanism. This TTL is a
- * safety net so a missed invalidation self-heals, and it also bounds the lag
- * for the preprocess ticker's background `variants_ready` updates (which run
- * outside request scope and therefore cannot call `revalidateTag`).
+ * safety net so a missed invalidation self-heals. Albums and public config only
+ * change via admin writes (which call `revalidateTag` synchronously in request
+ * scope), so a long safety-net TTL is fine for them.
  */
 const REVALIDATE_SECONDS = 3600
+
+/**
+ * Image listings (the `gallery` tag) have an extra freshness source the others
+ * don't: the preprocess ticker flips `variants_ready` in the BACKGROUND, so it
+ * runs outside request scope and cannot call `revalidateTag` (Next throws
+ * "Invariant: static generation store missing" with no work store). That update
+ * is therefore only picked up when the cache entry expires, so the gallery TTL
+ * doubles as the upper bound on how long a freshly-processed image can keep
+ * showing its placeholder. Keep it short to bound that lag (≤60s) while still
+ * absorbing the bulk of repeat reads — page-1 first paint stays a cache hit for
+ * most requests within each window. Admin writes still bust this tag instantly
+ * via `revalidateGalleryCache`; this only governs the background-ticker gap.
+ */
+const GALLERY_REVALIDATE_SECONDS = 60
 
 export const cachedClientImagesListByAlbum = unstable_cache(
   (pageNum: number, album: string, camera?: string, lens?: string) =>
     fetchClientImagesListByAlbum(pageNum, album, camera, lens),
   ['public-client-images-list'],
-  { tags: [CACHE_TAG.gallery], revalidate: REVALIDATE_SECONDS },
+  { tags: [CACHE_TAG.gallery], revalidate: GALLERY_REVALIDATE_SECONDS },
 )
 
 export const cachedClientImagesPageTotalByAlbum = unstable_cache(
   (album: string, camera?: string, lens?: string) =>
     fetchClientImagesPageTotalByAlbum(album, camera, lens),
   ['public-client-images-total'],
-  { tags: [CACHE_TAG.gallery], revalidate: REVALIDATE_SECONDS },
+  { tags: [CACHE_TAG.gallery], revalidate: GALLERY_REVALIDATE_SECONDS },
 )
 
 export const cachedDailyImagesList = unstable_cache(
   (pageNum: number, camera?: string, lens?: string) =>
     fetchDailyImagesList(pageNum, camera, lens),
   ['public-daily-images-list'],
-  { tags: [CACHE_TAG.gallery], revalidate: REVALIDATE_SECONDS },
+  { tags: [CACHE_TAG.gallery], revalidate: GALLERY_REVALIDATE_SECONDS },
 )
 
 export const cachedDailyImagesPageTotal = unstable_cache(
   (camera?: string, lens?: string) =>
     fetchDailyImagesPageTotal(camera, lens),
   ['public-daily-images-total'],
-  { tags: [CACHE_TAG.gallery], revalidate: REVALIDATE_SECONDS },
+  { tags: [CACHE_TAG.gallery], revalidate: GALLERY_REVALIDATE_SECONDS },
 )
 
 export const cachedAlbumsShow = unstable_cache(


### PR DESCRIPTION
## Background

The public gallery image-list caches (the `gallery` tag in `server/lib/cache.ts`) are the only cached reads whose freshness depends on a background source. The preprocess ticker flips `variants_ready` **outside request scope**, so it cannot call `revalidateTag` — Next throws `Invariant: static generation store missing` when there is no work store. As a result, that update was only picked up when the 1h safety-net TTL expired, so a freshly-processed image could keep showing its placeholder for up to an hour after its variants were actually ready.

## Change

Give the four `gallery`-tagged wrappers their own **60s** TTL, while leaving the `albums` and `config` caches at 1h.

- `albums` / `config` only change via admin writes, which bust their tags synchronously in request scope — so a long safety-net TTL remains fine for them.
- Admin writes still invalidate the `gallery` tag **instantly** via `revalidateGalleryCache` (image create / update / delete / show-hide / sort). The short TTL only bounds the background-ticker gap, now ≤60s instead of ≤1h.
- A 60s window still absorbs the bulk of repeat reads, so page-1 first paint stays a cache hit for most requests (it is hit during server render via the FU-15 preload hint).

## Why option ① (short TTL) over the alternatives

- **Uncaching the image-list** would also work, but it is not TTFB-free: the server-side preload hint calls `getImagesData(1, album)` during page render, so the image-list cache helps first paint — dropping it adds a DB query there.
- **A request-scoped revalidate route fetched by the ticker** would make updates instant but adds a route plus internal auth — heavier than warranted for a ≤60s bound.

Short TTL is one line per wrapper, keeps the page-1 first-paint cache hit, and bounds staleness to ≤60s.

## Scope / risk

- Single file, comment + one new constant applied to four wrappers. No behavior change for `albums`/`config`, no change to the auth/render model.
- No new TypeScript errors introduced in the touched file.