### PR TITLE
fix(cache): make on-demand tag invalidation immediate (new albums weren't showing in real time)

### DIFF
--- a/server/lib/cache.ts
+++ b/server/lib/cache.ts
@@ -111,16 +111,46 @@ export const cachedVariantBaseUrl = unstable_cache(
 )
 
 /**
+ * Immediately, hard-expire a public cache tag on an admin write.
+ *
+ * We pass `{ expire: 0 }`, NOT the `'max'` profile, on purpose. The two forms
+ * are NOT equivalent — this is the difference between "the new album shows up
+ * now" and "...in up to an hour":
+ *
+ *  - `revalidateTag(tag, 'max')` is stale-while-revalidate. Next resolves the
+ *    `'max'` cacheLife to `{ expire: 31536000 }` (one year) and tells the cache
+ *    handler to expire the tag a YEAR from now — `file-system-cache` computes
+ *    `expired = now + expire * 1000`. `areTagsExpired` only treats an entry as
+ *    expired once `expiredAt <= now`, so the tag is merely marked *stale*, never
+ *    hard-expired. A hot entry (e.g. the home page album nav) keeps being served
+ *    and is only refreshed by its own `unstable_cache` TTL — for albums/config
+ *    that's `REVALIDATE_SECONDS` (1h). That is why a newly created album did not
+ *    appear on the home page in real time.
+ *  - `{ expire: 0 }` sets `expired = now` → immediate hard expiration → the next
+ *    read misses and refetches. This is what on-demand invalidation needs.
+ *
+ * (`updateTag` is also immediate, but it throws outside a Server Action; our
+ * writes run inside the Hono route handler at `app/api/[[...route]]/route.ts`,
+ * so it is not usable here. The single-argument `revalidateTag(tag)` is also
+ * immediate but is deprecated and logs a warning on every call.)
+ *
+ * MUST be called from a request scope (Server Action or Route Handler) — never
+ * during render.
+ */
+function expireTag(tag: string) {
+  revalidateTag(tag, { expire: 0 })
+}
+
+/**
  * Invalidate cached image listings. Call from any write that changes what the
  * gallery shows: image create / update / delete / show-hide / sort.
  *
- * MUST be called from a request scope (Server Action or Route Handler) — never
- * during render. The daily materialized-view refresh deliberately does NOT call
- * this, because it can run during page render via `initDailyIfNeeded`; daily
- * freshness is covered by the TTL instead.
+ * The daily materialized-view refresh deliberately does NOT call this, because
+ * it can run during page render via `initDailyIfNeeded`; daily freshness is
+ * covered by the TTL instead.
  */
 export function revalidateGalleryCache() {
-  revalidateTag(CACHE_TAG.gallery, 'max')
+  expireTag(CACHE_TAG.gallery)
 }
 
 /**
@@ -128,8 +158,8 @@ export function revalidateGalleryCache() {
  * busts gallery listings, since album changes affect which images are shown.
  */
 export function revalidateAlbumsCache() {
-  revalidateTag(CACHE_TAG.albums, 'max')
-  revalidateTag(CACHE_TAG.gallery, 'max')
+  expireTag(CACHE_TAG.albums)
+  expireTag(CACHE_TAG.gallery)
 }
 
 /**
@@ -137,8 +167,8 @@ export function revalidateAlbumsCache() {
  * gallery listings, since some settings change them (page size, daily toggle).
  */
 export function revalidateConfigCache() {
-  revalidateTag(CACHE_TAG.config, 'max')
-  revalidateTag(CACHE_TAG.gallery, 'max')
+  expireTag(CACHE_TAG.config)
+  expireTag(CACHE_TAG.gallery)
 }
 
 /**
@@ -146,7 +176,7 @@ export function revalidateConfigCache() {
  * bypass the per-entity mutation paths above (e.g. backup restore).
  */
 export function revalidateAllPublicCaches() {
-  revalidateTag(CACHE_TAG.gallery, 'max')
-  revalidateTag(CACHE_TAG.albums, 'max')
-  revalidateTag(CACHE_TAG.config, 'max')
+  expireTag(CACHE_TAG.gallery)
+  expireTag(CACHE_TAG.albums)
+  expireTag(CACHE_TAG.config)
 }


### PR DESCRIPTION
## Symptom

Creating a new album did not update the public home page in real time — the new album only appeared after up to an hour.

## Root cause

The on-demand invalidation helpers in `server/lib/cache.ts` called `revalidateTag(tag, 'max')`. In Next 16 the two-argument form with a cacheLife profile is **stale-while-revalidate, not immediate**:

1. `'max'` resolves to the cacheLife `{ stale: 300, revalidate: 30d, expire: 365d }` (`config-shared.js`).
2. On flush, Next derives `durations = { expire: 31536000 }` and passes it to the cache handler (`revalidation-utils.js`). Its own comment: *"If profile is not found and not 'max', durations will be undefined which will trigger immediate expiration."*
3. The file-system cache handler stores `expired = now + expire * 1000` — i.e. **one year in the future** (`file-system-cache.js`). Only `revalidateTag(tag)` with no profile stores `expired = now`.
4. `areTagsExpired` treats an entry as expired only once `expiredAt <= now`, so the tag is merely marked *stale*, never hard-expired.

The home page album nav (`cachedAlbumsShow`, tag `albums`) is a hot entry, so it kept being served and was refreshed only by its own `unstable_cache` TTL — 1h for albums/config. Hence "not real-time". This also matches the observation that a *new image* sometimes appeared sooner (a cold/evicted entry refetches fresh) while the *new album* stayed stale (hot nav entry, only marked stale).

This affects all three public cache groups (`gallery` / `albums` / `config`); the `albums`/`config` 1h TTL just made it most visible there. `gallery` already has the 60s TTL from #513, which masked it for images.

## Fix

Route all invalidation through a single `expireTag` helper that passes `{ expire: 0 }`:

- `{ expire: 0 }` → handler stores `expired = now` → **immediate hard expiration** → next read refetches.
- Type-correct (`CacheLifeConfig = { expire?: number }`), and **no deprecation warning** (unlike the single-arg form).
- `updateTag` would also be immediate but throws outside a Server Action; our writes run inside the Hono route handler (`app/api/[[...route]]/route.ts`), so it is not usable here.

## Scope / risk

- Single file. Behaviour change is strictly *more* correct: tags now hard-expire on admin writes instead of being marked stale with a one-year window.
- No change to TTLs, render mode, or the auth model. No new TypeScript errors in the touched file.

## Note on a shared cacheHandler

This fix is required **regardless** of cache backend. A shared/persistent cacheHandler (for multi-instance propagation) would still receive the one-year duration under `'max'` and not expire immediately, so dropping `'max'` is a prerequisite. Whether a shared cacheHandler is additionally needed depends on whether the deployment runs multiple instances — tracked separately.