### PR TITLE
feat(gallery): album neighbor-window query for detail prev/next

### DIFF
--- a/server/actions/images.ts
+++ b/server/actions/images.ts
@@ -1,6 +1,8 @@
 'use server'
 
 import { fetchConfigValue } from '~/server/db/query/configs'
+import { fetchAlbumNeighborWindow } from '~/server/db/query/images'
+import { fetchDailyNeighborWindow } from '~/server/db/query/daily'
 import { checkAndRefreshDailyImages } from '~/server/db/operate/daily'
 import {
   cachedClientImagesListByAlbum,
@@ -11,7 +13,7 @@ import {
   cachedDailyImagesPageTotal,
   cachedVariantBaseUrl,
 } from '~/server/lib/cache'
-import type { GalleryDisplayConfig, ImageType } from '~/types'
+import type { AlbumNeighborWindow, GalleryDisplayConfig, ImageType } from '~/types'
 
 export async function getImagesData(pageNum: number, album: string, camera?: string, lens?: string): Promise<ImageType[]> {
   if (album === '/') {
@@ -21,6 +23,30 @@ export async function getImagesData(pageNum: number, album: string, camera?: str
     }
   }
   return cachedClientImagesListByAlbum(pageNum, album, camera, lens)
+}
+
+/**
+ * Server action behind the photo detail page's prev/next navigation. Returns a
+ * bounded window of the current gallery context's ordered images centered on
+ * `imageId`. Mirrors `getImagesData`'s context resolution: `album === '/'` with
+ * the daily view enabled walks the daily feed, otherwise the main-page feed;
+ * any other value walks that concrete album. Used by both detail render paths
+ * (intercepted modal + full page / deep link).
+ */
+export async function getAlbumNeighborWindow(
+  imageId: string,
+  album: string,
+  radius: number = 10,
+  camera?: string,
+  lens?: string
+): Promise<AlbumNeighborWindow> {
+  if (album === '/') {
+    const isDailyEnabled = await cachedConfigValue('daily_enabled', 'false')
+    if (isDailyEnabled === 'true') {
+      return fetchDailyNeighborWindow(imageId, radius, camera, lens)
+    }
+  }
+  return fetchAlbumNeighborWindow(imageId, album, radius, camera, lens)
 }
 
 export async function getImagesPageTotal(album: string, camera?: string, lens?: string): Promise<number> {

--- a/server/db/query/daily.ts
+++ b/server/db/query/daily.ts
@@ -4,7 +4,7 @@
 
 import { Prisma } from '@prisma/client'
 import { db } from '~/server/lib/db'
-import type { ImageType } from '~/types'
+import type { AlbumNeighborWindow, ImageType } from '~/types'
 
 const DEFAULT_SIZE = 24
 
@@ -35,6 +35,62 @@ export async function fetchDailyImagesList(
     ORDER BY image.daily_sort
     LIMIT ${DEFAULT_SIZE} OFFSET ${(pageNum - 1) * DEFAULT_SIZE}
   `
+}
+
+/**
+ * Fetch a window of the daily feed's ordered images centered on `imageId`, for
+ * prev/next navigation on the photo detail page when the home feed is in daily
+ * mode. Mirrors `fetchDailyImagesList`'s `ORDER BY image.daily_sort` so the
+ * sequence matches the daily grid. Bounded single round-trip; uncached, like
+ * `fetchAlbumNeighborWindow`.
+ */
+export async function fetchDailyNeighborWindow(
+  imageId: string,
+  radius: number = 10,
+  camera?: string,
+  lens?: string
+): Promise<AlbumNeighborWindow> {
+  if (!imageId) {
+    return { images: [], currentIndex: -1, total: 0, hasPrev: false, hasNext: false }
+  }
+  const safeRadius = Math.max(0, Math.min(50, Number.isFinite(radius) ? Math.floor(radius) : 10))
+
+  const rows: any[] = await db.$queryRaw`
+    WITH ranked AS (
+      SELECT
+          image.*,
+          ROW_NUMBER() OVER (ORDER BY image.daily_sort) AS rn,
+          COUNT(*) OVER () AS total
+      FROM
+          "public"."daily_images" AS image
+      WHERE
+          1 = 1
+      ${camera ? Prisma.sql`AND COALESCE(image.exif->>'model', 'Unknown') = ${camera}` : Prisma.empty}
+      ${lens ? Prisma.sql`AND COALESCE(image.exif->>'lens_model', 'Unknown') = ${lens}` : Prisma.empty}
+    ),
+    target AS (
+      SELECT rn AS target_rn FROM ranked WHERE id = ${imageId}
+    )
+    SELECT ranked.*
+    FROM ranked, target
+    WHERE ranked.rn BETWEEN target.target_rn - ${safeRadius} AND target.target_rn + ${safeRadius}
+    ORDER BY ranked.rn
+  `
+
+  if (!rows || rows.length === 0) {
+    return { images: [], currentIndex: -1, total: 0, hasPrev: false, hasNext: false }
+  }
+  const total = Number(rows[0].total)
+  const firstRn = Number(rows[0].rn)
+  const lastRn = Number(rows[rows.length - 1].rn)
+  const images = rows.map(({ rn, total: _total, ...image }) => image) as ImageType[]
+  return {
+    images,
+    currentIndex: images.findIndex((img) => img.id === imageId),
+    total,
+    hasPrev: firstRn > 1,
+    hasNext: lastRn < total,
+  }
 }
 
 /**

--- a/server/db/query/images.ts
+++ b/server/db/query/images.ts
@@ -4,7 +4,7 @@
 
 import { Prisma } from '@prisma/client'
 import { db } from '~/server/lib/db'
-import type { ImageType } from '~/types'
+import type { AlbumNeighborWindow, ImageType } from '~/types'
 import { fetchConfigValue } from './configs'
 import { buildExifFilters, buildPagination, buildShowFilter, calcPageTotal } from './helpers'
 
@@ -279,6 +279,135 @@ export async function fetchClientImagesPageTotalByAlbum(
     ) AS unique_images;
   `
   return calcPageTotal(pageTotal[0].total, DEFAULT_SIZE)
+}
+
+/**
+ * Shape the raw window rows into an `AlbumNeighborWindow`, stripping the
+ * window-function helper columns (`rn`, `total`) the SQL carries.
+ */
+function shapeNeighborWindow(rows: any[], imageId: string): AlbumNeighborWindow {
+  if (!rows || rows.length === 0) {
+    return { images: [], currentIndex: -1, total: 0, hasPrev: false, hasNext: false }
+  }
+  const total = Number(rows[0].total)
+  const firstRn = Number(rows[0].rn)
+  const lastRn = Number(rows[rows.length - 1].rn)
+  const images = rows.map(({ rn, total: _total, ...image }) => image) as ImageType[]
+  return {
+    images,
+    currentIndex: images.findIndex((img) => img.id === imageId),
+    total,
+    hasPrev: firstRn > 1,
+    hasNext: lastRn < total,
+  }
+}
+
+/**
+ * Fetch a window of a gallery context's ordered images centered on `imageId`,
+ * for prev/next navigation on the photo detail page. Both detail render paths
+ * (intercepted modal + full page / deep link) use this single server contract
+ * so navigation stays consistent across filtered / direct / shared views.
+ *
+ * `album === '/'` is the home (main-page) feed; any other value is a concrete
+ * album. The ordering mirrors `fetchClientImagesListByAlbum` exactly — same
+ * `image.sort DESC, ...` / per-album `image_sorting` — so the navigation
+ * sequence matches the grid. (The home/daily feed is handled by the
+ * `getAlbumNeighborWindow` action, which mirrors `getImagesData`'s daily check.)
+ *
+ * One bounded round-trip: a window function ranks the context, then only rows
+ * within `radius` of the target are returned. Deliberately uncached, matching
+ * the uncached `fetchImageByIdAndAuth` the detail page already runs (a per-image
+ * cache key would add high cardinality for little gain).
+ *
+ * NOTE on `random_show` albums: navigation uses the album's DETERMINISTIC order.
+ * A server-side window cannot reproduce the per-request `Math.random()` shuffle
+ * the grid applies, so the order is best-effort (stable + navigable, but not
+ * matching a shuffled grid). Per product decision we do not seed/stabilise it.
+ */
+export async function fetchAlbumNeighborWindow(
+  imageId: string,
+  album: string,
+  radius: number = 10,
+  camera?: string,
+  lens?: string
+): Promise<AlbumNeighborWindow> {
+  if (!imageId || !album) {
+    return { images: [], currentIndex: -1, total: 0, hasPrev: false, hasNext: false }
+  }
+  const safeRadius = Math.max(0, Math.min(50, Number.isFinite(radius) ? Math.floor(radius) : 10))
+
+  // Home (main-page) feed: no album join, gated by show_on_mainpage. Mirrors
+  // the `album === '/'` branch of fetchClientImagesListByAlbum.
+  if (album === '/') {
+    const homeRows: any[] = await db.$queryRaw`
+      WITH ranked AS (
+        SELECT
+            image.*,
+            ROW_NUMBER() OVER (ORDER BY image.sort DESC, image.created_at DESC, image.updated_at DESC) AS rn,
+            COUNT(*) OVER () AS total
+        FROM
+            "public"."images" AS image
+        WHERE
+            image.del = 0
+        AND image.show = 0
+        AND image.show_on_mainpage = 0
+        ${buildExifFilters(camera, lens)}
+      ),
+      target AS (
+        SELECT rn AS target_rn FROM ranked WHERE id = ${imageId}
+      )
+      SELECT ranked.*
+      FROM ranked, target
+      WHERE ranked.rn BETWEEN target.target_rn - ${safeRadius} AND target.target_rn + ${safeRadius}
+      ORDER BY ranked.rn
+    `
+    return shapeNeighborWindow(homeRows, imageId)
+  }
+
+  const albumData = await db.albums.findFirst({
+    where: {
+      album_value: album
+    }
+  })
+  let orderBy = Prisma.sql(['image.sort DESC, image.created_at DESC, image.updated_at DESC'])
+  if (albumData && albumData.image_sorting && ALBUM_IMAGE_SORTING_ORDER[albumData.image_sorting]) {
+    orderBy = Prisma.sql([`image.sort DESC, ${ALBUM_IMAGE_SORTING_ORDER[albumData.image_sorting]}`])
+  }
+
+  const rows: any[] = await db.$queryRaw`
+    WITH ranked AS (
+      SELECT
+          image.*,
+          albums.name AS album_name,
+          albums.id AS album_value,
+          albums.license AS album_license,
+          albums.image_sorting AS album_image_sorting,
+          ROW_NUMBER() OVER (ORDER BY ${orderBy}) AS rn,
+          COUNT(*) OVER () AS total
+      FROM
+          "public"."images" AS image
+      INNER JOIN "public"."images_albums_relation" AS relation
+          ON image.id = relation."imageId"
+      INNER JOIN "public"."albums" AS albums
+          ON relation.album_value = albums.album_value
+      WHERE
+          image.del = 0
+      AND albums.del = 0
+      AND image.show = 0
+      AND albums.show = 0
+      AND albums.album_value = ${album}
+      ${buildExifFilters(camera, lens)}
+    ),
+    target AS (
+      SELECT rn AS target_rn FROM ranked WHERE id = ${imageId}
+    )
+    SELECT ranked.*
+    FROM ranked, target
+    WHERE ranked.rn BETWEEN target.target_rn - ${safeRadius} AND target.target_rn + ${safeRadius}
+    ORDER BY ranked.rn
+  `
+
+  return shapeNeighborWindow(rows, imageId)
 }
 
 /**

--- a/types/index.ts
+++ b/types/index.ts
@@ -63,6 +63,23 @@ export type ImageType = {
 }
 
 /**
+ * A bounded slice of a gallery context's ordered images centered on one target
+ * image, powering prev/next navigation in the photo detail view.
+ */
+export type AlbumNeighborWindow = {
+  /** Up to (2 * radius + 1) images, in gallery order, centered on the target. */
+  images: ImageType[];
+  /** 0-based index of the target image within `images`; -1 if not found. */
+  currentIndex: number;
+  /** Total images in the context (after the same show/del/exif filters). */
+  total: number;
+  /** Whether an image exists before the first returned image. */
+  hasPrev: boolean;
+  /** Whether an image exists after the last returned image. */
+  hasNext: boolean;
+}
+
+/**
  * @deprecated Use the dedicated config-shape types below (`CustomInfo`, `S3Info`,
  * `R2Info`, `OpenListInfo`, `AdminConfig`, `DailyConfig`). This raw row shape is
  * still consumed by the storage client builders (`getClient`, `getR2Client`) and


### PR DESCRIPTION
## What

Adds the server data path for **prev/next navigation in the photo detail view**. It is the backend half of the album → photo detail switching work; the front-end carousel/transition layer consumes this contract separately.

Both detail render paths — the intercepted modal (over the grid) and the full page / deep link — call a single server action, `getAlbumNeighborWindow`, so the navigation sequence stays consistent across filtered, direct, and shared views (no SWR-cache key/pagination matching to get wrong).

## API

```ts
getAlbumNeighborWindow(imageId, album, radius = 10, camera?, lens?): Promise<AlbumNeighborWindow>
```

```ts
type AlbumNeighborWindow = {
  images: ImageType[]      // up to 2*radius+1 images, in gallery order, centered on the target
  currentIndex: number     // 0-based index of the target within images; -1 if not found
  total: number            // total images in the context (same show/del/exif filters)
  hasPrev: boolean         // an image exists before the first returned image
  hasNext: boolean         // an image exists after the last returned image
}
```

Context resolution mirrors `getImagesData`:
- `album === '/'` with the daily view enabled → daily feed window (`fetchDailyNeighborWindow`, ordered by `daily_sort`);
- `album === '/'` otherwise → main-page feed window;
- any other value → that concrete album's window.

## How

Each window is **one bounded round-trip**: a `ROW_NUMBER()` window function ranks the context using the exact same ordering as `fetchClientImagesListByAlbum` (`image.sort DESC, image.created_at DESC, image.updated_at DESC`, or the per-album `image_sorting` mode), then only rows within `radius` of the target are returned. `currentIndex` / `total` / `hasPrev` / `hasNext` let the client render edges and request the next window as the user nears one. `radius` defaults to 10, clamped to 0..50.

## Notes

- **Uncached by design**, matching the uncached `fetchImageByIdAndAuth` the detail page already runs. A per-image cache key would add high cardinality for little gain, and it keeps this read off the gallery tag's invalidation surface.
- **`random_show` albums** are navigated in their deterministic order. A server-side window cannot reproduce the per-request shuffle the grid applies, so ordering there is best-effort and intentionally not stabilised (per product decision).
- No schema changes; no change to existing queries or the auth/render model. New code only.