### PR TITLE
feat(detail): in-place prev/next photo carousel in the detail view

### DIFF
--- a/app/(default)/preview/[...id]/page.tsx
+++ b/app/(default)/preview/[...id]/page.tsx
@@ -2,6 +2,7 @@ import { fetchImageByIdAndAuth } from '~/server/db/query/images'
 import type { PreviewImageHandleProps } from '~/types/props'
 import PreviewImage from '~/components/album/preview-image'
 import { cachedConfigsByKeys, cachedVariantBaseUrl } from '~/server/lib/cache'
+import { getAlbumNeighborWindow } from '~/server/actions/images'
 import type { GalleryDisplayConfig } from '~/types'
 import type { Metadata } from 'next/types'
 
@@ -63,11 +64,18 @@ export default async function PreView({params}: { params: any }) {
 
   const imageData = await getData(id)
 
+  // Server-resolve the album neighbor window so the detail view opens straight
+  // into an in-place prev/next carousel (no extra round-trip). Best-effort.
+  const initialWindow = imageData?.album_value
+    ? await getAlbumNeighborWindow(id, imageData.album_value).catch(() => null)
+    : null
+
   const props: PreviewImageHandleProps = {
     data: imageData,
     args: 'getImages-client-preview',
     id: id,
     configHandle: getConfig,
+    initialWindow,
   }
 
   return (

--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -21,7 +21,12 @@ import { CopyIcon } from '~/components/icons/copy'
 import { RefreshCWIcon } from '~/components/icons/refresh-cw'
 import { cn } from '~/lib/utils'
 import { useSwrHydrated } from '~/hooks/use-swr-hydrated'
-import { useMemo, useState } from 'react'
+import { usePhotoSequence } from '~/hooks/use-photo-sequence'
+import { useBlurImageDataUrl } from '~/hooks/use-blurhash'
+import useEmblaCarousel from 'embla-carousel-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronLeftIcon } from '~/components/icons/chevron-left'
+import { ChevronRightIcon } from '~/components/icons/chevron-right'
 import { ExpandIcon } from '~/components/icons/expand'
 import { useTranslations } from 'next-intl'
 import ProgressiveImage from '~/components/album/progressive-image.tsx'
@@ -63,11 +68,100 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   )
 }
 
+// Off-budget carousel slides (beyond the load radius) render only the decoded
+// blurhash at the photo's aspect ratio — no variant request — so a large album
+// never fans out into dozens of concurrent image loads.
+function PlaceholderSlide({ blurhash, width, height }: { blurhash: string; width?: number; height?: number }) {
+  const dataUrl = useBlurImageDataUrl(blurhash)
+  return (
+    <div
+      aria-hidden
+      className="w-full sm:max-h-[90vh]"
+      style={{
+        aspectRatio: width && height ? `${width} / ${height}` : undefined,
+        backgroundImage: dataUrl ? `url(${dataUrl})` : undefined,
+        backgroundSize: 'contain',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center',
+      }}
+    />
+  )
+}
+
 export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   const router = useRouter()
   const t = useTranslations()
-  const { data: download = false, mutate: setDownload } = useSWR(['masonry/download', props.data?.url ?? ''], null)
+  const { photos, index, current, hasPrev, hasNext, setIndex } = usePhotoSequence({
+    album: props.data?.album_value,
+    initialWindow: props.initialWindow,
+    fallback: props.data,
+  })
+  const { data: download = false, mutate: setDownload } = useSWR(['masonry/download', current?.url ?? ''], null)
   const [lightboxPhoto, setLightboxPhoto] = useState<boolean>(false)
+
+  // Detail-view carousel: the image area is an embla carousel over the windowed
+  // album slice. The metadata panel + zoom always follow `current` (the settled
+  // slide). Drag is disabled while zoomed so the WebGL viewer owns the gesture.
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: false, align: 'center', startIndex: index, watchDrag: !lightboxPhoto })
+  // Only neighbors within this radius render their image (variant); farther
+  // slides stay blurhash placeholders. This *is* the adjacent-prefetch budget —
+  // tighter on mobile to cap memory (see the AVIF double-load fix).
+  const [loadRadius, setLoadRadius] = useState(2)
+  const indexRef = useRef(index)
+  indexRef.current = index
+  const lastSettledRef = useRef(index)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const mq = window.matchMedia('(max-width: 640px)')
+    const apply = () => setLoadRadius(mq.matches ? 1 : 2)
+    apply()
+    mq.addEventListener('change', apply)
+    return () => mq.removeEventListener('change', apply)
+  }, [])
+
+  // The settled slide is the source of truth: sync the index, drop any open zoom,
+  // and shallow-update the URL (history.replaceState — no server re-render) so
+  // every photo is shareable/back-navigable. Ignore no-op settles from reInit
+  // (same index) so paging in more photos / toggling zoom never self-closes.
+  const onSettle = useCallback(() => {
+    if (!emblaApi) return
+    const i = emblaApi.selectedScrollSnap()
+    if (i === lastSettledRef.current) return
+    lastSettledRef.current = i
+    setIndex(i)
+    setLightboxPhoto(false)
+    const photo = photos[i]
+    if (photo && typeof window !== 'undefined') {
+      window.history.replaceState(window.history.state, '', `/preview/${photo.id}`)
+    }
+  }, [emblaApi, photos, setIndex])
+
+  useEffect(() => {
+    if (!emblaApi) return
+    emblaApi.on('settle', onSettle)
+    return () => { emblaApi.off('settle', onSettle) }
+  }, [emblaApi, onSettle])
+
+  // Re-measure + re-center when the window pages in more photos (prepend shifts
+  // the index) or when zoom toggles drag. `index` is read fresh via ref so a
+  // user swipe is never fought by a reInit.
+  useEffect(() => {
+    if (!emblaApi) return
+    lastSettledRef.current = indexRef.current
+    emblaApi.reInit({ loop: false, align: 'center', startIndex: indexRef.current, watchDrag: !lightboxPhoto })
+  }, [emblaApi, photos.length, lightboxPhoto])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onKey = (e: KeyboardEvent) => {
+      if (lightboxPhoto) return
+      if (e.key === 'ArrowLeft') emblaApi?.scrollPrev()
+      else if (e.key === 'ArrowRight') emblaApi?.scrollNext()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [emblaApi, lightboxPhoto])
 
   const exifIconClass = 'text-muted-foreground hover:text-primary transition-colors'
   const badgeIconClass = 'shrink-0 text-primary/60'
@@ -83,28 +177,28 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
 
   // Format date time
   const formattedDateTime = useMemo(() => {
-    if (!props.data?.exif?.dateTime) return null
-    const parsed = dayjs(props.data.exif.dateTime, 'YYYY:MM:DD HH:mm:ss')
-    return parsed.isValid() ? parsed.format('YYYY-MM-DD HH:mm:ss') : props.data.exif.dateTime
-  }, [props.data?.exif?.dateTime])
+    if (!current?.exif?.dateTime) return null
+    const parsed = dayjs(current.exif.dateTime, 'YYYY:MM:DD HH:mm:ss')
+    return parsed.isValid() ? parsed.format('YYYY-MM-DD HH:mm:ss') : current.exif.dateTime
+  }, [current?.exif?.dateTime])
 
   // Calculate file info
   const dimensions = useMemo(() => {
-    if (props.data?.width && props.data?.height) {
-      return `${props.data.width} × ${props.data.height}`
+    if (current?.width && current?.height) {
+      return `${current.width} × ${current.height}`
     }
     return null
-  }, [props.data?.width, props.data?.height])
+  }, [current?.width, current?.height])
 
   const megaPixels = useMemo(() => {
-    if (props.data?.width && props.data?.height) {
-      return `${((props.data.width * props.data.height) / 1_000_000).toFixed(1)} MP`
+    if (current?.width && current?.height) {
+      return `${((current.width * current.height) / 1_000_000).toFixed(1)} MP`
     }
     return null
-  }, [props.data?.width, props.data?.height])
+  }, [current?.width, current?.height])
 
   // Image URL for tone analysis and histogram
-  const imageUrl = props.data?.preview_url || props.data?.url || ''
+  const imageUrl = current?.preview_url || current?.url || ''
 
   const handleClose = () => {
     if (window != undefined) {
@@ -113,8 +207,8 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
         return
       }
     }
-    if (props.data?.album_value) {
-      router.push(`${props.data.album_value}`)
+    if (current?.album_value) {
+      router.push(`${current.album_value}`)
     } else {
       router.push('/')
     }
@@ -124,14 +218,14 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
     setDownload(true)
     try {
       let msg = t('Tips.downloadStart')
-      if (props.data?.album_license != null) {
-        msg += t('Tips.downloadLicense', { license: props.data.album_license })
+      if (current?.album_license != null) {
+        msg += t('Tips.downloadLicense', { license: current.album_license })
       }
 
       toast.warning(msg, { duration: 1500 })
 
       // 获取存储类型
-      const storageType = props.data?.url?.includes('s3') ? 's3' : 'r2'
+      const storageType = current?.url?.includes('s3') ? 's3' : 'r2'
 
       // 读取直接下载配置，决定走二进制 blob 端点还是 presigned URL 端点
       const flagsResponse = await fetch('/api/public/download/config')
@@ -145,7 +239,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
 
       if (directDownload) {
         // 直接下载模式：从 presigned 端点拿到 URL 后由浏览器拉对象存储
-        const presignedResponse = await fetch(`/api/public/download/${props.id}/presigned?storage=${storageType}`)
+        const presignedResponse = await fetch(`/api/public/download/${current?.id}/presigned?storage=${storageType}`)
         if (!presignedResponse.ok) throw new Error('presigned request failed')
         const presignedJson = await presignedResponse.json()
         const data = presignedJson?.data
@@ -156,7 +250,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
         blob = await objectResponse.blob()
       } else {
         // 代理下载模式：服务端返回二进制 blob，文件名从 Content-Disposition 取
-        const binaryResponse = await fetch(`/api/public/download/${props.id}?storage=${storageType}`)
+        const binaryResponse = await fetch(`/api/public/download/${current?.id}?storage=${storageType}`)
         if (!binaryResponse.ok) throw new Error('download request failed')
         const contentDisposition = binaryResponse.headers.get('content-disposition')
         let parsedFilename = 'download'
@@ -185,7 +279,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
     }
   }
 
-  if (!props.data) {
+  if (!current) {
     return (
       <div className="flex items-center justify-center h-full">
         <p className="text-muted-foreground">{t('Tips.loading')}</p>
@@ -196,28 +290,68 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   return (
     <div className="flex flex-col overflow-y-auto scrollbar-hide h-full rounded-none! max-w-none gap-0 p-2">
       <div className="relative h-full flex flex-col space-y-2 sm:grid sm:gap-4 sm:grid-cols-3 w-full">
-        <div className="show-up-motion sm:col-span-2 sm:flex sm:justify-center sm:max-h-[90vh] select-none">
-          {
-            props.data.type === 1 ?
-              <ProgressiveImage
-                imageUrl={props.data.url}
-                previewUrl={props.data.preview_url}
-                alt={props.data.title}
-                height={props.data.height}
-                width={props.data.width}
-                blurhash={props.data.blurhash}
-                imageKey={props.data.image_key}
-                readyMaxWidth={props.data.ready_max_width}
-                variantBaseUrl={configData?.variantBaseUrl ?? ''}
-                showLightbox={lightboxPhoto}
-                onShowLightboxChange={(value)=>setLightboxPhoto(value)}
-              />
-              : <LivePhoto
-                url={props.data.preview_url || props.data.url}
-                videoUrl={props.data.video_url}
-                className="md:h-[90vh] md:max-h-[90vh]"
-              />
-          }
+        <div className="show-up-motion relative sm:col-span-2 sm:flex sm:justify-center sm:max-h-[90vh] select-none">
+          <div className="overflow-hidden w-full" ref={emblaRef}>
+            <div className="flex h-full">
+              {photos.map((photo, i) => {
+                const near = Math.abs(i - index) <= loadRadius
+                const isCurrent = i === index
+                return (
+                  <div
+                    key={photo.id}
+                    className="relative flex min-w-0 shrink-0 grow-0 basis-full items-center justify-center sm:max-h-[90vh]"
+                  >
+                    {near ? (
+                      photo.type === 1 ? (
+                        <ProgressiveImage
+                          key={photo.id}
+                          imageUrl={photo.url}
+                          previewUrl={photo.preview_url}
+                          alt={photo.title}
+                          height={photo.height}
+                          width={photo.width}
+                          blurhash={photo.blurhash}
+                          imageKey={photo.image_key}
+                          readyMaxWidth={photo.ready_max_width}
+                          variantBaseUrl={configData?.variantBaseUrl ?? ''}
+                          showLightbox={isCurrent && lightboxPhoto}
+                          onShowLightboxChange={isCurrent ? ((value) => setLightboxPhoto(value)) : undefined}
+                        />
+                      ) : (
+                        <LivePhoto
+                          url={photo.preview_url || photo.url}
+                          videoUrl={photo.video_url}
+                          className="md:h-[90vh] md:max-h-[90vh]"
+                        />
+                      )
+                    ) : (
+                      <PlaceholderSlide blurhash={photo.blurhash} width={photo.width} height={photo.height} />
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+          {hasPrev && (
+            <button
+              type="button"
+              onClick={() => emblaApi?.scrollPrev()}
+              aria-label="Previous photo"
+              className="absolute left-2 top-1/2 z-30 hidden size-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/30 text-white backdrop-blur transition-opacity hover:bg-black/50 sm:flex"
+            >
+              <ChevronLeftIcon size={22} />
+            </button>
+          )}
+          {hasNext && (
+            <button
+              type="button"
+              onClick={() => emblaApi?.scrollNext()}
+              aria-label="Next photo"
+              className="absolute right-2 top-1/2 z-30 hidden size-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/30 text-white backdrop-blur transition-opacity hover:bg-black/50 sm:flex"
+            >
+              <ChevronRightIcon size={22} />
+            </button>
+          )}
         </div>
         
         {/* Right side panel with all EXIF info */}
@@ -225,7 +359,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
           <div className="flex w-full flex-col space-y-6 pr-4">
             {/* Header with title and close button */}
             <div className="flex items-center justify-between">
-              <div className="flex-1 font-display font-semibold text-lg">{props.data?.title}</div>
+              <div className="flex-1 font-display font-semibold text-lg">{current?.title}</div>
               <AnimatedIconTrigger>
                 {({ iconRef, triggerProps }) => (
                   <button
@@ -249,11 +383,11 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                     className="inline-flex items-center justify-center cursor-pointer"
                     onClick={async () => {
                       try {
-                        const url = props.data?.url
+                        const url = current?.url
                         await navigator.clipboard.writeText(url)
                         let msg = t('Tips.copyImageSuccess')
-                        if (props.data?.album_license != null) {
-                          msg = t('Tips.downloadLicense', { license: props.data?.album_license })
+                        if (current?.album_license != null) {
+                          msg = t('Tips.downloadLicense', { license: current?.album_license })
                         }
                         toast.success(msg, { duration: 1500 })
                       } catch {
@@ -277,7 +411,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                     className="inline-flex items-center justify-center cursor-pointer"
                     onClick={async () => {
                       try {
-                        const url = window.location.origin + '/preview/' + props.id
+                        const url = window.location.origin + '/preview/' + current.id
                         await navigator.clipboard.writeText(url)
                         toast.success(t('Tips.copyShareSuccess'), { duration: 500 })
                       } catch {
@@ -349,40 +483,40 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                 {dimensions && <Row label={t('Exif.dimensions')} value={dimensions} />}
                 {megaPixels && <Row label={t('Exif.pixels')} value={megaPixels} />}
                 <Row label={t('Exif.captureTime')} value={formattedDateTime} />
-                {props.data?.exif?.color_space && (
-                  <Row label={t('Exif.colorSpace')} value={props.data.exif.color_space} />
+                {current?.exif?.color_space && (
+                  <Row label={t('Exif.colorSpace')} value={current.exif.color_space} />
                 )}
               </div>
             </div>
 
             {/* Capture Parameters - Badge style */}
-            {(props.data?.exif?.focal_length || props.data?.exif?.f_number || 
-              props.data?.exif?.exposure_time || props.data?.exif?.iso_speed_rating) && (
+            {(current?.exif?.focal_length || current?.exif?.f_number || 
+              current?.exif?.exposure_time || current?.exif?.iso_speed_rating) && (
               <div>
                 <SectionTitle>{t('Exif.captureParams')}</SectionTitle>
                 <div className="grid grid-cols-2 gap-2">
-                  {props.data?.exif?.focal_length && (
+                  {current?.exif?.focal_length && (
                     <ParamBadge 
                       icon={<CrosshairIcon className={badgeIconClass} size={14} />}
-                      value={props.data.exif.focal_length}
+                      value={current.exif.focal_length}
                     />
                   )}
-                  {props.data?.exif?.f_number && (
+                  {current?.exif?.f_number && (
                     <ParamBadge 
                       icon={<ApertureIcon className={badgeIconClass} size={14} />}
-                      value={props.data.exif.f_number}
+                      value={current.exif.f_number}
                     />
                   )}
-                  {props.data?.exif?.exposure_time && (
+                  {current?.exif?.exposure_time && (
                     <ParamBadge 
                       icon={<TimerIcon className={badgeIconClass} size={14} />}
-                      value={props.data.exif.exposure_time}
+                      value={current.exif.exposure_time}
                     />
                   )}
-                  {props.data?.exif?.iso_speed_rating && (
+                  {current?.exif?.iso_speed_rating && (
                     <ParamBadge 
                       icon={<GaugeIcon className={badgeIconClass} size={14} />}
-                      value={`ISO ${props.data.exif.iso_speed_rating}`}
+                      value={`ISO ${current.exif.iso_speed_rating}`}
                     />
                   )}
                 </div>
@@ -406,49 +540,49 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
             )}
 
             {/* Device Information */}
-            {(props.data?.exif?.make || props.data?.exif?.model || props.data?.exif?.lens_model) && (
+            {(current?.exif?.make || current?.exif?.model || current?.exif?.lens_model) && (
               <div>
                 <SectionTitle>{t('Exif.deviceInfo')}</SectionTitle>
                 <div className="space-y-1.5">
-                  {props.data?.exif?.make && props.data?.exif?.model && (
+                  {current?.exif?.make && current?.exif?.model && (
                     <div className="flex items-center gap-2">
                       <CameraIcon className={badgeIconClass} size={14} />
                       <span className="text-sm text-foreground">
-                        {`${props.data.exif.make} ${props.data.exif.model}`}
+                        {`${current.exif.make} ${current.exif.model}`}
                       </span>
                     </div>
                   )}
-                  {props.data?.exif?.lens_model && (
+                  {current?.exif?.lens_model && (
                     <div className="flex items-center gap-2">
                       <TelescopeIcon className={badgeIconClass} size={14} />
                       <span className="text-sm text-foreground">
-                        {props.data.exif.lens_model}
+                        {current.exif.lens_model}
                       </span>
                     </div>
                   )}
-                  {props.data?.exif?.focal_length && (
-                    <Row label={t('Exif.focalLength')} value={props.data.exif.focal_length} />
+                  {current?.exif?.focal_length && (
+                    <Row label={t('Exif.focalLength')} value={current.exif.focal_length} />
                   )}
                 </div>
               </div>
             )}
 
             {/* Capture Mode */}
-            {(props.data?.exif?.exposure_mode || props.data?.exif?.exposure_program ||
-              props.data?.exif?.white_balance) && (
+            {(current?.exif?.exposure_mode || current?.exif?.exposure_program ||
+              current?.exif?.white_balance) && (
               <div>
                 <SectionTitle>{t('Exif.captureMode')}</SectionTitle>
                 <div className="space-y-1">
-                  {props.data?.exif?.exposure_program && (
-                    <Row label={t('Exif.exposureProgram')} value={props.data.exif.exposure_program} />
+                  {current?.exif?.exposure_program && (
+                    <Row label={t('Exif.exposureProgram')} value={current.exif.exposure_program} />
                   )}
-                  <Row label={t('Exif.exposureMode')} value={props.data?.exif?.exposure_mode} />
-                  <Row label={t('Exif.whiteBalance')} value={props.data?.exif?.white_balance} />
-                  {props.data?.exif?.color_space && (
+                  <Row label={t('Exif.exposureMode')} value={current?.exif?.exposure_mode} />
+                  <Row label={t('Exif.whiteBalance')} value={current?.exif?.white_balance} />
+                  {current?.exif?.color_space && (
                     <div className="flex items-center gap-2">
                       <FlaskIcon className={badgeIconClass} size={14} />
                       <span className="text-sm text-foreground">
-                        {props.data.exif.color_space}
+                        {current.exif.color_space}
                       </span>
                     </div>
                   )}
@@ -457,26 +591,26 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
             )}
 
             {/* Technical Parameters */}
-            {(props.data?.exif?.bits || props.data?.exif?.cfa_pattern) && (
+            {(current?.exif?.bits || current?.exif?.cfa_pattern) && (
               <div>
                 <SectionTitle>{t('Exif.technicalParams')}</SectionTitle>
                 <div className="space-y-1">
-                  {props.data?.exif?.bits && (
-                    <Row label={t('Exif.bitDepth')} value={props.data.exif.bits} />
+                  {current?.exif?.bits && (
+                    <Row label={t('Exif.bitDepth')} value={current.exif.bits} />
                   )}
-                  {props.data?.exif?.cfa_pattern && (
-                    <Row label={t('Exif.cfaPattern')} value={props.data.exif.cfa_pattern} />
+                  {current?.exif?.cfa_pattern && (
+                    <Row label={t('Exif.cfaPattern')} value={current.exif.cfa_pattern} />
                   )}
                 </div>
               </div>
             )}
 
             {/* Labels/Tags */}
-            {props.data?.labels && props.data.labels.length > 0 && (
+            {current?.labels && current.labels.length > 0 && (
               <div>
                 <SectionTitle>{t('Exif.tags')}</SectionTitle>
                 <div className="flex flex-wrap gap-1.5">
-                  {props.data.labels.map((tag: string) => (
+                  {current.labels.map((tag: string) => (
                     <Badge
                       variant="secondary"
                       className="cursor-pointer border-primary/15 bg-primary/10 text-foreground hover:bg-primary/20 transition-colors"
@@ -491,12 +625,12 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
             )}
 
             {/* Description */}
-            {props.data?.detail && (
+            {current?.detail && (
               <div>
                 <div className="flex items-start gap-2">
                   <LanguagesIcon className={badgeIconClass} size={14} />
                   <p className="text-sm text-foreground text-wrap">
-                    {props.data.detail}
+                    {current.detail}
                   </p>
                 </div>
               </div>
@@ -510,7 +644,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                     className="flex items-center space-x-1 text-sm text-muted-foreground transition-colors hover:text-primary"
                     onClick={async () => {
                       try {
-                        const exif = JSON.stringify(props.data?.exif, null, 2)
+                        const exif = JSON.stringify(current?.exif, null, 2)
                         await navigator.clipboard.writeText(exif)
                         toast.success(t('Exif.copySuccess'), { duration: 1500 })
                       } catch {

--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -109,7 +109,15 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   const [loadRadius, setLoadRadius] = useState(2)
   const indexRef = useRef(index)
   indexRef.current = index
+  const photosRef = useRef(photos)
+  photosRef.current = photos
+  const currentIdRef = useRef(current?.id)
+  currentIdRef.current = current?.id
   const lastSettledRef = useRef(index)
+  // Distinguishes our own reInit-driven settles (re-center only) from genuine
+  // user navigation (sync index + drop zoom + write URL), so paging in photos
+  // or toggling zoom never self-closes the viewer or rewrites the URL.
+  const programmaticRef = useRef(false)
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -127,15 +135,21 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   const onSettle = useCallback(() => {
     if (!emblaApi) return
     const i = emblaApi.selectedScrollSnap()
+    // A settle emitted by our own reInit: re-center bookkeeping only.
+    if (programmaticRef.current) {
+      programmaticRef.current = false
+      lastSettledRef.current = i
+      return
+    }
     if (i === lastSettledRef.current) return
     lastSettledRef.current = i
     setIndex(i)
     setLightboxPhoto(false)
-    const photo = photos[i]
+    const photo = photosRef.current[i]
     if (photo && typeof window !== 'undefined') {
       window.history.replaceState(window.history.state, '', `/preview/${photo.id}`)
     }
-  }, [emblaApi, photos, setIndex])
+  }, [emblaApi, setIndex])
 
   useEffect(() => {
     if (!emblaApi) return
@@ -148,8 +162,13 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   // user swipe is never fought by a reInit.
   useEffect(() => {
     if (!emblaApi) return
-    lastSettledRef.current = indexRef.current
-    emblaApi.reInit({ loop: false, align: 'center', startIndex: indexRef.current, watchDrag: !lightboxPhoto })
+    // Re-center on the current photo's *identity*, not a cached index — a
+    // prepend shifts every index, but findIndex keeps the same photo centered.
+    const found = currentIdRef.current ? photosRef.current.findIndex((p) => p.id === currentIdRef.current) : -1
+    const startIndex = found >= 0 ? found : indexRef.current
+    lastSettledRef.current = startIndex
+    programmaticRef.current = true
+    emblaApi.reInit({ loop: false, align: 'center', startIndex, watchDrag: !lightboxPhoto })
   }, [emblaApi, photos.length, lightboxPhoto])
 
   useEffect(() => {

--- a/hooks/use-photo-sequence.ts
+++ b/hooks/use-photo-sequence.ts
@@ -44,6 +44,9 @@ export function usePhotoSequence({
   const [moreBefore, setMoreBefore] = useState(seeded ? initialWindow!.hasPrev : false)
   const [moreAfter, setMoreAfter] = useState(seeded ? initialWindow!.hasNext : false)
   const loadingRef = useRef(false)
+  const mountedRef = useRef(true)
+
+  useEffect(() => () => { mountedRef.current = false }, [])
 
   const extend = useCallback(async (i: number) => {
     if (loadingRef.current || !album || photos.length === 0) return
@@ -55,23 +58,22 @@ export function usePhotoSequence({
     try {
       const anchorId = nearStart ? photos[0].id : photos[photos.length - 1].id
       const w = await getAlbumNeighborWindow(anchorId, album)
-      if (w?.images?.length) {
-        const have = new Set(photos.map((p) => p.id))
-        const fresh = w.images.filter((p) => !have.has(p.id))
-        if (nearStart) {
-          if (fresh.length > 0) {
-            setPhotos((prev) => [...fresh, ...prev])
-            setIndexState((idx) => idx + fresh.length)
-          }
-          setMoreBefore(w.hasPrev)
-        } else {
-          if (fresh.length > 0) setPhotos((prev) => [...prev, ...fresh])
-          setMoreAfter(w.hasNext)
+      // The preview may have been closed while the request was in flight.
+      if (!mountedRef.current) return
+      const have = new Set(photos.map((p) => p.id))
+      const fresh = w?.images?.filter((p) => !have.has(p.id)) ?? []
+      if (nearStart) {
+        if (fresh.length > 0) {
+          setPhotos((prev) => [...fresh, ...prev])
+          setIndexState((idx) => idx + fresh.length)
         }
+        // No *new* photos this direction (empty window or a fully-overlapping
+        // one) → treat the edge as exhausted, otherwise the extend effect keeps
+        // re-firing the same overlapping fetch in a tight loop.
+        setMoreBefore(fresh.length > 0 ? Boolean(w?.hasPrev) : false)
       } else {
-        // No images came back for this edge → nothing more that direction.
-        if (nearStart) setMoreBefore(false)
-        else setMoreAfter(false)
+        if (fresh.length > 0) setPhotos((prev) => [...prev, ...fresh])
+        setMoreAfter(fresh.length > 0 ? Boolean(w?.hasNext) : false)
       }
     } catch {
       // Best-effort: keep the current window; the user can still browse it.

--- a/hooks/use-photo-sequence.ts
+++ b/hooks/use-photo-sequence.ts
@@ -1,0 +1,99 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getAlbumNeighborWindow } from '~/server/actions/images'
+import type { AlbumNeighborWindow, ImageType } from '~/types'
+
+// Refetch the next window when the current index gets within this many slides of
+// a loaded edge, so swiping never stalls at the boundary waiting for data.
+const EDGE_THRESHOLD = 3
+
+export interface PhotoSequence {
+  photos: ImageType[]
+  index: number
+  current: ImageType | undefined
+  /** A previous photo exists (loaded or beyond the loaded window). */
+  hasPrev: boolean
+  /** A next photo exists (loaded or beyond the loaded window). */
+  hasNext: boolean
+  /** Sync the index from the carousel's settled slide. */
+  setIndex: (i: number) => void
+}
+
+/**
+ * Drives the detail-view photo carousel: holds a windowed slice of the album's
+ * ordered photos (seeded from the server-resolved `initialWindow`), tracks the
+ * current index, and transparently extends the window by calling
+ * `getAlbumNeighborWindow` when the index approaches a loaded edge — so large
+ * albums page in without ever loading the whole list. Falls back to a
+ * single-photo sequence when there is no window (e.g. a deep-link to a hidden
+ * image, where currentIndex is -1).
+ */
+export function usePhotoSequence({
+  album,
+  initialWindow,
+  fallback,
+}: {
+  album: string | undefined
+  initialWindow: AlbumNeighborWindow | null | undefined
+  fallback: ImageType
+}): PhotoSequence {
+  const seeded = (initialWindow?.images?.length ?? 0) > 0 && (initialWindow?.currentIndex ?? -1) >= 0
+  const [photos, setPhotos] = useState<ImageType[]>(seeded ? initialWindow!.images : [fallback])
+  const [index, setIndexState] = useState(seeded ? initialWindow!.currentIndex : 0)
+  const [moreBefore, setMoreBefore] = useState(seeded ? initialWindow!.hasPrev : false)
+  const [moreAfter, setMoreAfter] = useState(seeded ? initialWindow!.hasNext : false)
+  const loadingRef = useRef(false)
+
+  const extend = useCallback(async (i: number) => {
+    if (loadingRef.current || !album || photos.length === 0) return
+    const nearStart = i <= EDGE_THRESHOLD && moreBefore
+    const nearEnd = i >= photos.length - 1 - EDGE_THRESHOLD && moreAfter
+    if (!nearStart && !nearEnd) return
+
+    loadingRef.current = true
+    try {
+      const anchorId = nearStart ? photos[0].id : photos[photos.length - 1].id
+      const w = await getAlbumNeighborWindow(anchorId, album)
+      if (w?.images?.length) {
+        const have = new Set(photos.map((p) => p.id))
+        const fresh = w.images.filter((p) => !have.has(p.id))
+        if (nearStart) {
+          if (fresh.length > 0) {
+            setPhotos((prev) => [...fresh, ...prev])
+            setIndexState((idx) => idx + fresh.length)
+          }
+          setMoreBefore(w.hasPrev)
+        } else {
+          if (fresh.length > 0) setPhotos((prev) => [...prev, ...fresh])
+          setMoreAfter(w.hasNext)
+        }
+      } else {
+        // No images came back for this edge → nothing more that direction.
+        if (nearStart) setMoreBefore(false)
+        else setMoreAfter(false)
+      }
+    } catch {
+      // Best-effort: keep the current window; the user can still browse it.
+    } finally {
+      loadingRef.current = false
+    }
+  }, [album, photos, moreBefore, moreAfter])
+
+  useEffect(() => {
+    void extend(index)
+  }, [index, extend])
+
+  const setIndex = useCallback((i: number) => {
+    setIndexState((prev) => (i === prev || i < 0 ? prev : i))
+  }, [])
+
+  return {
+    photos,
+    index,
+    current: photos[index] ?? fallback,
+    hasPrev: index > 0 || moreBefore,
+    hasNext: index < photos.length - 1 || moreAfter,
+    setIndex,
+  }
+}

--- a/types/props.ts
+++ b/types/props.ts
@@ -1,6 +1,6 @@
 // 业务专用类型
 
-import { AlbumType, GalleryDisplayConfig, ImageType } from '~/types/index'
+import { AlbumNeighborWindow, AlbumType, GalleryDisplayConfig, ImageType } from '~/types/index'
 
 export type AlbumDataProps = {
   data: AlbumType[]
@@ -38,6 +38,10 @@ export type PreviewImageHandleProps = {
   args: string
   id: string
   configHandle?: () => Promise<GalleryDisplayConfig>
+  // Server-resolved neighbor window centered on `data`, so the detail view can
+  // render an in-place prev/next carousel over the album without an extra
+  // round-trip on open. Best-effort — falls back to a single-photo sequence.
+  initialWindow?: AlbumNeighborWindow | null
 }
 
 export type ProgressiveImageProps = {


### PR DESCRIPTION
## What

Turn the photo detail view into a carousel over the album, so you can move between photos in place (swipe / arrow keys / on-screen buttons) instead of returning to the grid and reopening each one — the album→photo browsing flow afilmory does well. This is phase 1 of that work.

## Changes

- **`usePhotoSequence` hook + server-resolved neighbor window.** The preview route server-resolves a window of neighbors centered on the opened photo (`getAlbumNeighborWindow`) and passes it as `initialWindow`. The hook holds that windowed slice, tracks the current index, and transparently extends the window (refetching when within a few slides of a loaded edge) so large albums page in without ever loading the whole list. Falls back to a single-photo sequence when there is no window.
- **Detail view is now an embla carousel** over the windowed slice. The metadata panel, histogram, share link and download all follow the settled slide instead of a fixed photo.
- **Shallow URL updates.** Settling on a slide updates the URL via `history.replaceState` (no server re-render), so every photo stays shareable and back-navigable.
- **Bounded image loading.** Only slides within the load radius (±2 desktop / ±1 mobile) render their AVIF variant; farther slides stay decoded-blurhash placeholders, so a large album never fans out into dozens of concurrent image loads. This is also the adjacent-prefetch budget — the slide you land on is always already loaded.
- **Single high-res viewer.** The WebGL zoom viewer stays one on-demand instance bound to the current photo (keyed per id, drag disabled while zoomed), preserving the earlier zoom-lifecycle behavior.
- Desktop prev/next buttons + ArrowLeft/ArrowRight navigation.

## Notes

- Phase 1 of a multi-PR effort; later phases add the shared-element open/close transition and mobile gestures (swipe-to-dismiss, thumbnail strip).
- `tsc --noEmit` and `eslint` pass for the changed files (remaining repo-wide warnings are pre-existing and unrelated).
- Cannot run the dev server here (needs a DB); verification is type/lint plus post-deploy checks. Worth stress-testing on deploy: rapid swiping through many photos, opening zoom on several different photos in a row, and repeated open/close, to confirm WebGL contexts created == destroyed and no leak.