### PR TITLE
feat(detail): shared-element FLIP transition from grid into the detail view

### DIFF
--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -30,6 +30,7 @@ import { ChevronRightIcon } from '~/components/icons/chevron-right'
 import { ExpandIcon } from '~/components/icons/expand'
 import { useTranslations } from 'next-intl'
 import ProgressiveImage from '~/components/album/progressive-image.tsx'
+import TransitionOverlay from '~/components/album/transition-overlay'
 import ToneAnalysis from '~/components/album/tone-analysis'
 import HistogramChart from '~/components/album/histogram-chart'
 import { Separator } from '~/components/ui/separator'
@@ -308,6 +309,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
 
   return (
     <div className="flex flex-col overflow-y-auto scrollbar-hide h-full rounded-none! max-w-none gap-0 p-2">
+      <TransitionOverlay />
       <div className="relative h-full flex flex-col space-y-2 sm:grid sm:gap-4 sm:grid-cols-3 w-full">
         <div className="show-up-motion relative sm:col-span-2 sm:flex sm:justify-center sm:max-h-[90vh] select-none">
           <div className="overflow-hidden w-full" ref={emblaRef}>
@@ -318,6 +320,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                 return (
                   <div
                     key={photo.id}
+                    data-flip-target={isCurrent ? '' : undefined}
                     className="relative flex min-w-0 shrink-0 grow-0 basis-full items-center justify-center sm:max-h-[90vh]"
                   >
                     {near ? (

--- a/components/album/transition-overlay.tsx
+++ b/components/album/transition-overlay.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { motion } from 'motion/react'
+import { useTransitionStore } from '~/stores/transition-store'
+
+interface Box { top: number; left: number; width: number; height: number }
+
+// The object-contain box of an image with the given aspect inside a container —
+// the same letterbox math the detail <img className="object-contain"> applies,
+// so the flight lands exactly where the real image will sit.
+function containedBox(container: Box, aspect: number): Box {
+  if (aspect <= 0 || container.width <= 0 || container.height <= 0) return container
+  const containerAspect = container.width / container.height
+  let width: number
+  let height: number
+  if (containerAspect > aspect) {
+    height = container.height
+    width = height * aspect
+  } else {
+    width = container.width
+    height = width / aspect
+  }
+  return {
+    width,
+    height,
+    left: container.left + (container.width - width) / 2,
+    top: container.top + (container.height - height) / 2,
+  }
+}
+
+/**
+ * Shared-element (FLIP) transition from a grid thumbnail into the detail view.
+ * Reads the source rect captured at click time, measures where the detail image
+ * will land ([data-flip-target]), then flies the cached thumbnail pixels from
+ * one to the other and cross-fades into the real detail image. Because the grid
+ * cell and the contained detail image share the photo's aspect ratio, this is a
+ * clean uniform scale — no stretch, no crop discontinuity. Renders nothing (and
+ * the detail just opens instantly) when there is no source or no target.
+ */
+export default function TransitionOverlay() {
+  const source = useTransitionStore((s) => s.source)
+  const clear = useTransitionStore((s) => s.clear)
+  const [mounted, setMounted] = useState(false)
+  const [flight, setFlight] = useState<null | { target: Box; dx: number; dy: number; scale: number; src: string }>(null)
+  const [phase, setPhase] = useState<'flying' | 'fading'>('flying')
+  const rafRef = useRef<number | null>(null)
+  const startedForRef = useRef<string | null>(null)
+
+  useEffect(() => { setMounted(true) }, [])
+
+  useEffect(() => {
+    if (!source) {
+      // The render guard below (`!source`) already hides the overlay; just reset
+      // the once-per-source latch so a future source animates again.
+      startedForRef.current = null
+      return
+    }
+    if (startedForRef.current === source.id) return
+
+    let frames = 0
+    const measure = () => {
+      const targetEl = document.querySelector<HTMLElement>('[data-flip-target]')
+      if (targetEl) {
+        const r = targetEl.getBoundingClientRect()
+        if (r.width > 0 && r.height > 0) {
+          const target = containedBox({ top: r.top, left: r.left, width: r.width, height: r.height }, source.aspect)
+          startedForRef.current = source.id
+          setFlight({
+            target,
+            dx: source.rect.left - target.left,
+            dy: source.rect.top - target.top,
+            scale: target.width > 0 ? source.rect.width / target.width : 1,
+            src: source.src,
+          })
+          setPhase('flying')
+          return
+        }
+      }
+      frames += 1
+      if (frames > 30) {
+        // Target never laid out (~0.5s) — give up and open without the flight.
+        clear()
+        return
+      }
+      rafRef.current = requestAnimationFrame(measure)
+    }
+    rafRef.current = requestAnimationFrame(measure)
+    return () => { if (rafRef.current) cancelAnimationFrame(rafRef.current) }
+  }, [source, clear])
+
+  if (!mounted || !source || !flight) return null
+
+  const { target, dx, dy, scale, src } = flight
+
+  return createPortal(
+    <motion.div
+      aria-hidden
+      className="pointer-events-none fixed z-[120] overflow-hidden rounded-sm"
+      style={{ top: target.top, left: target.left, width: target.width, height: target.height, transformOrigin: '0 0' }}
+      initial={{ x: dx, y: dy, scale, opacity: 1 }}
+      animate={phase === 'fading'
+        ? { x: 0, y: 0, scale: 1, opacity: 0 }
+        : { x: 0, y: 0, scale: 1, opacity: 1 }}
+      transition={phase === 'fading'
+        ? { duration: 0.18, ease: 'easeOut' }
+        : { duration: 0.34, ease: [0.22, 1, 0.36, 1] }}
+      onAnimationComplete={() => {
+        if (phase === 'flying') setPhase('fading')
+        else clear()
+      }}
+    >
+      {/* Deliberately a plain <img>, not next/image: this flies the exact src the
+          grid already decoded/cached, so it must not go through a loader or refetch. */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={src} alt="" className="h-full w-full object-cover" draggable={false} />
+    </motion.div>,
+    document.body,
+  )
+}

--- a/components/gallery/masonry-photo-item.tsx
+++ b/components/gallery/masonry-photo-item.tsx
@@ -7,16 +7,20 @@ import type { ImageType } from '~/types'
 import { Aperture, Timer, Focus, Disc3 } from 'lucide-react'
 import { useBlurImageDataUrl, DEFAULT_HASH } from '~/hooks/use-blurhash'
 import { Skeleton } from '~/components/ui/skeleton'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { hasReadyVariants, makeVariantLoader } from '~/lib/image/loader'
 import { useAvifSupport } from '~/hooks/use-avif-support'
 import { DEFAULT_GRID_SIZES } from '~/lib/image/grid-image-sizes'
+import { useTransitionStore } from '~/stores/transition-store'
 
 export default function MasonryPhotoItem({ photo, width, variantBaseUrl = '', priority = false }: { photo: ImageType, width?: number, variantBaseUrl?: string, priority?: boolean }) {
   const router = useRouter()
   const dataURL = useBlurImageDataUrl(photo.blurhash)
   const avifOk = useAvifSupport()
   const [isLoading, setIsLoading] = useState(true)
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const imgRef = useRef<HTMLImageElement>(null)
+  const setTransitionSource = useTransitionStore((s) => s.setSource)
   // If a (supposedly ready) variant fails to load, fall back down the ladder
   // rather than retrying the variant forever.
   const [variantFailed, setVariantFailed] = useState(false)
@@ -58,17 +62,39 @@ export default function MasonryPhotoItem({ photo, width, variantBaseUrl = '', pr
     ? { width, height: Math.round(width / aspectRatio) }
     : { aspectRatio }
 
+  // Capture the thumbnail's screen rect + the exact pixels it is currently
+  // showing, so the detail view can fly this element from here into place
+  // (shared-element FLIP). Best-effort: if anything is missing the detail view
+  // just opens without the transition.
+  const openDetail = () => {
+    const el = wrapperRef.current
+    if (el) {
+      const r = el.getBoundingClientRect()
+      const src = imgRef.current?.currentSrc || imgRef.current?.src || dataURL
+      if (r.width > 0 && r.height > 0 && src) {
+        setTransitionSource({
+          id: photo.id,
+          rect: { top: r.top, left: r.left, width: r.width, height: r.height },
+          src,
+          aspect: aspectRatio,
+        })
+      }
+    }
+    router.push(`/preview/${photo.id}`)
+  }
+
   return (
     <div
+      ref={wrapperRef}
       role="link"
       tabIndex={0}
       className="group relative cursor-pointer overflow-hidden rounded-sm [will-change:auto] hover:[will-change:transform]"
       style={sizeStyle}
-      onClick={() => router.push(`/preview/${photo.id}`)}
+      onClick={openDetail}
       onKeyDown={(e: React.KeyboardEvent) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
-          router.push(`/preview/${photo.id}`)
+          openDetail()
         }
       }}
     >
@@ -87,6 +113,7 @@ export default function MasonryPhotoItem({ photo, width, variantBaseUrl = '', pr
       {imageProps ? (
         <Image
           {...imageProps}
+          ref={imgRef}
           key={variantReady ? 'variant' : 'preview'}
           className={cn(
             'object-cover transition-transform duration-500 group-hover:scale-105',

--- a/stores/transition-store.ts
+++ b/stores/transition-store.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+
+// Source thumbnail captured at click time, used to drive the shared-element
+// (FLIP) transition from the grid into the detail view. Purely ephemeral
+// client state — never persisted or SSR-hydrated — so unlike the other stores
+// it uses a plain global `create` store instead of the vanilla+provider pattern
+// (which exists to hydrate persisted state and brings no benefit here).
+export interface TransitionSource {
+  /** The clicked photo's id (the photo the detail view opens on). */
+  id: string
+  /** Viewport rect of the thumbnail image at click time. */
+  rect: { top: number; left: number; width: number; height: number }
+  /** The exact (already-decoded/cached) src the grid was showing, so the flying
+   *  element shows real pixels with no extra request or flash. */
+  src: string
+  /** photo.width / photo.height — the grid cell is rendered at this aspect, and
+   *  so is the detail's contained image, so the FLIP is a clean uniform scale. */
+  aspect: number
+}
+
+interface TransitionState {
+  source: TransitionSource | null
+  setSource: (source: TransitionSource) => void
+  clear: () => void
+}
+
+export const useTransitionStore = create<TransitionState>((set) => ({
+  source: null,
+  setSource: (source) => set({ source }),
+  clear: () => set({ source: null }),
+}))


### PR DESCRIPTION
## What

Opening a photo now **flies the thumbnail into place** instead of hard-cutting to the detail view — the shared-element open transition afilmory has. Phase 2 of the detail-view work.

> Stacked on #516 (Phase 1 carousel). Base is `feat/detail-carousel-phase1`; review/merge that first. The diff here is only the transition.

## How

- On click, the grid captures the thumbnail's viewport rect **and the exact pixels it's already showing** (`img.currentSrc`) into a small transient zustand store (`stores/transition-store.ts`), then navigates.
- `TransitionOverlay` (mounted in the detail view, portaled to `body`) measures where the detail image will land (`[data-flip-target]` on the current slide), then flies the cached thumbnail from the source rect to that target and cross-fades into the real detail image.
- Because the grid cell and the contained detail image are **both rendered at the photo's aspect ratio**, the flight is a clean uniform scale — no stretch, no crop discontinuity, and the flying element shows real cached pixels (no extra request, no flash).

## Safety / guardrails

- **No new WebGL context path** (the Phase 2/3 hard constraint): the overlay is a plain `<img>`. The single keyed WebGL viewer from #516 is untouched.
- Fully **additive and best-effort**: if the source rect or the landing target isn't available (deep-link, no thumbnail, slow layout → ~0.5s rAF timeout), the detail just opens instantly exactly as before. No behavior change on those paths.
- `tsc --noEmit` + `eslint` clean for changed files (one advisory warning: the standard portal `mounted` guard).

## Notes

- Scoped to the **open** transition. The **close**/exit transition is grouped with Phase 3 (mobile swipe-down dismiss shares the same exit machinery).
- Can't run dev locally (needs DB) — verification is type/lint + post-deploy visual. The math is robust by construction and the cross-fade tolerates small misalignment, but the feel (durations/easing) is worth an eyeball on deploy.