### PR TITLE
feat(detail): bottom thumbnail strip + fade-out close transition

### DIFF
--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { GalleryDisplayConfig } from '~/types'
+import type { GalleryDisplayConfig, ImageType } from '~/types'
 import type { PreviewImageHandleProps } from '~/types/props'
 import LivePhoto from '~/components/album/live-photo'
 import { toast } from 'sonner'
@@ -86,6 +86,57 @@ function PlaceholderSlide({ blurhash, width, height }: { blurhash: string; width
         backgroundPosition: 'center',
       }}
     />
+  )
+}
+
+// Decoded-blurhash fallback for a strip thumbnail with no preview url.
+function ThumbBlur({ blurhash }: { blurhash: string }) {
+  const url = useBlurImageDataUrl(blurhash)
+  return <div className="h-full w-full bg-cover bg-center" style={{ backgroundImage: url ? `url(${url})` : undefined }} />
+}
+
+// Bottom thumbnail strip — a horizontally scrollable row over the album window,
+// the active photo ringed and auto-centered. Clicking jumps the carousel there.
+// Plain <img>/blurhash only (no WebGL), and it reuses the same windowed `photos`
+// the carousel already holds, so it adds no fetches.
+function ThumbnailStrip({ photos, activeIndex, onSelect }: { photos: ImageType[]; activeIndex: number; onSelect: (i: number) => void }) {
+  const ref = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const el = ref.current?.querySelector<HTMLElement>('[data-active="true"]')
+    el?.scrollIntoView({ inline: 'center', block: 'nearest', behavior: 'smooth' })
+  }, [activeIndex])
+  return (
+    <div className="pointer-events-none absolute inset-x-0 bottom-2 z-20 flex justify-center px-2">
+      <div
+        ref={ref}
+        className="pointer-events-auto flex max-w-full gap-1.5 overflow-x-auto rounded-xl bg-background/60 p-1.5 backdrop-blur-md scrollbar-hide"
+      >
+        {photos.map((p, i) => {
+          const active = i === activeIndex
+          return (
+            <button
+              key={p.id}
+              type="button"
+              data-active={active}
+              aria-current={active}
+              aria-label={`View photo ${i + 1}`}
+              onClick={() => onSelect(i)}
+              className={cn(
+                'relative size-12 shrink-0 overflow-hidden rounded-md transition-all',
+                active ? 'opacity-100 ring-2 ring-primary' : 'opacity-50 hover:opacity-90',
+              )}
+            >
+              {p.preview_url ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={p.preview_url} alt="" loading="lazy" draggable={false} className="h-full w-full object-cover" />
+              ) : (
+                <ThumbBlur blurhash={p.blurhash} />
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
   )
 }
 
@@ -374,8 +425,15 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
               <ChevronRightIcon size={22} />
             </button>
           )}
+          {photos.length > 1 && !lightboxPhoto && (
+            <ThumbnailStrip
+              photos={photos}
+              activeIndex={index}
+              onSelect={(i) => emblaApi?.scrollTo(i)}
+            />
+          )}
         </div>
-        
+
         {/* Right side panel with all EXIF info */}
         <ScrollArea className="sm:max-h-[90vh]">
           <div className="flex w-full flex-col space-y-6 pr-4">

--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -31,6 +31,7 @@ import { ExpandIcon } from '~/components/icons/expand'
 import { useTranslations } from 'next-intl'
 import ProgressiveImage from '~/components/album/progressive-image.tsx'
 import TransitionOverlay from '~/components/album/transition-overlay'
+import { motion } from 'motion/react'
 import ToneAnalysis from '~/components/album/tone-analysis'
 import HistogramChart from '~/components/album/histogram-chart'
 import { Separator } from '~/components/ui/separator'
@@ -150,6 +151,9 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   })
   const { data: download = false, mutate: setDownload } = useSWR(['masonry/download', current?.url ?? ''], null)
   const [lightboxPhoto, setLightboxPhoto] = useState<boolean>(false)
+  // Exit transition: fade the detail view out, then navigate (deferred-nav), so
+  // closing isn't a hard cut back to the grid.
+  const [closing, setClosing] = useState(false)
 
   // Detail-view carousel: the image area is an embla carousel over the windowed
   // album slice. The metadata panel + zoom always follow `current` (the settled
@@ -271,7 +275,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   // Image URL for tone analysis and histogram
   const imageUrl = current?.preview_url || current?.url || ''
 
-  const handleClose = () => {
+  const navigateAway = () => {
     if (window != undefined) {
       if (window.history.length > 1) {
         router.back()
@@ -283,6 +287,12 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
     } else {
       router.push('/')
     }
+  }
+
+  // Trigger the exit fade; the actual navigation runs when it completes.
+  const handleClose = () => {
+    if (closing) return
+    setClosing(true)
   }
 
   const handleDownload = async () => {
@@ -359,7 +369,12 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   }
 
   return (
-    <div className="flex flex-col overflow-y-auto scrollbar-hide h-full rounded-none! max-w-none gap-0 p-2">
+    <motion.div
+      className="flex flex-col overflow-y-auto scrollbar-hide h-full rounded-none! max-w-none gap-0 p-2"
+      animate={{ opacity: closing ? 0 : 1 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+      onAnimationComplete={() => { if (closing) navigateAway() }}
+    >
       <TransitionOverlay />
       <div className="relative h-full flex flex-col space-y-2 sm:grid sm:gap-4 sm:grid-cols-3 w-full">
         <div className="show-up-motion relative sm:col-span-2 sm:flex sm:justify-center sm:max-h-[90vh] select-none">
@@ -742,6 +757,6 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
           </div>
         </ScrollArea>
       </div>
-    </div>
+    </motion.div>
   )
 }


### PR DESCRIPTION
## What

Phase 3 of the detail-view work. Two pieces here; the third (mobile swipe-down dismiss) is split out — see Notes.

> Stacked on #517 → #516. Base is `feat/detail-transition-phase2`; merge order #516 → #517 → this.

### Bottom thumbnail strip
A horizontally scrollable strip of the album window sits at the bottom of the detail view: the active photo is ringed and auto-scrolled to center, clicking a thumbnail jumps the carousel to it (via embla `scrollTo`, sharing the same settle → index/URL sync). Hidden for single-photo views and while the zoom viewer is open. Reuses the windowed `photos` the carousel already holds and renders only plain `<img>`/blurhash — no extra fetches, no WebGL.

### Fade-out close transition
Closing now fades the detail view out over 0.2s and then navigates (deferred-nav), instead of a hard cut back to the grid. Opacity-only (no transform, so it can't create a containing block for the fixed zoom viewer), and the fade only *defers* the unmount — once it navigates, the modal unmounts and `ProgressiveImage`'s destroy/loseContext fires normally, so the viewer teardown is never stalled (per the Phase-2 review note).

## Safety

- No new WebGL context path — strip is plain `<img>`/blurhash, close is opacity-only. The single keyed viewer from #516 is untouched.
- `tsc --noEmit` + `eslint` clean for the changed file (one advisory: the function-type param name).

## Notes — mobile swipe-down dismiss deferred (deliberately)

The third Phase-3 item, mobile swipe-down-to-dismiss, is **not** in this PR. It shares the touch surface with embla's horizontal drag, so a naive implementation risks regressing the approved carousel swipe, and the gesture feel/coordination genuinely can't be verified without a touch device (I can't run dev here). Rather than ship it blind and risk the carousel, I'm raising it for a decision — happy to implement it as the immediate next step with the understanding that it needs on-device tuning, or pair it with whoever can test on a phone.