### PR TITLE
fix(webgl-viewer): make engine destroy() idempotent

### DIFF
--- a/components/album/webgl-viewer/WebGLImageViewerEngine.ts
+++ b/components/album/webgl-viewer/WebGLImageViewerEngine.ts
@@ -71,6 +71,12 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
   private lastTouchY = 0
 
   private isAnimating = false
+  // Guards `destroy()` against re-entry. The viewer can be torn down via more
+  // than one path (React unmount on slide-out, and the LRU cap unmounting a
+  // backgrounded zoom viewer), and StrictMode can double-invoke cleanup, so
+  // destroy() must be safe to call repeatedly without acting on already-freed
+  // GL objects.
+  private isDestroyed = false
   private animationStartTime = 0
   private animationDuration = 300
   private startScale = 1
@@ -962,6 +968,12 @@ export class WebGLImageViewerEngine extends ImageViewerEngineBase {
   }
 
   public destroy() {
+    // Idempotent: a second call (double teardown path / StrictMode) is a no-op
+    // rather than re-deleting freed GL objects or re-terminating the worker.
+    if (this.isDestroyed) {
+      return
+    }
+    this.isDestroyed = true
     // Halt the animation loop so no queued frame renders against the GL
     // objects deleted below.
     this.isAnimating = false


### PR DESCRIPTION
## Why

`WebGLImageViewerEngine.destroy()` can be reached more than once:
- React cleanup when a slide unmounts on slide-out;
- the upcoming detail-viewer **LRU cap** unmounting a backgrounded zoom viewer (a second teardown trigger);
- StrictMode double-invoking effect cleanup.

Today the body is only *incidentally* safe to repeat — it leans on WebGL `deleteTexture` / `deleteProgram` / `loseContext()` being spec no-ops on already-freed or context-lost objects, and on the nullable resources (buffers, worker, RAF, ResizeObserver) being `if`/`?.`-guarded. It doesn't throw, but the safety is implicit.

## What

Add an explicit `isDestroyed` re-entry guard at the top of `destroy()`: a second call returns immediately instead of acting on freed GL state. This makes the double-teardown path bulletproof rather than dependent on lenient WebGL semantics, ahead of the LRU work that adds the second teardown trigger.

## Scope / risk

- One boolean field + an early return. No behaviour change for the normal single-destroy path (which already runs exactly once today).
- Complements the LRU's mount-gate approach: the mount-gate keeps the React wrapper state (`isInitialized`) clean by going through a full unmount→remount; this guard keeps the engine itself safe under any repeated `destroy()`.
- No type/API changes; type-checks clean.