### PR TITLE
fix(detail): keep current photo in sync on switch (drop stuck-prone programmaticRef)

### DIFF
--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -203,10 +203,6 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   const currentIdRef = useRef(current?.id)
   currentIdRef.current = current?.id
   const lastSettledRef = useRef(index)
-  // Distinguishes our own reInit-driven settles (re-center only) from genuine
-  // user navigation (sync index + drop zoom + write URL), so paging in photos
-  // or toggling zoom never self-closes the viewer or rewrites the URL.
-  const programmaticRef = useRef(false)
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -224,12 +220,11 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   const onSettle = useCallback(() => {
     if (!emblaApi) return
     const i = emblaApi.selectedScrollSnap()
-    // A settle emitted by our own reInit: re-center bookkeeping only.
-    if (programmaticRef.current) {
-      programmaticRef.current = false
-      lastSettledRef.current = i
-      return
-    }
+    // A reInit settles at the index we just stored in lastSettledRef (the current
+    // photo), so it lands here as a no-op. Only a genuine user settle to a new
+    // slide gets past this to sync index / drop zoom / write the URL. (We rely on
+    // lastSettledRef, NOT a "programmatic" flag — a flag could stick if a reInit
+    // emitted no settle and then swallow the user's next real navigation.)
     if (i === lastSettledRef.current) return
     lastSettledRef.current = i
     setIndex(i)
@@ -256,7 +251,6 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
     const found = currentIdRef.current ? photosRef.current.findIndex((p) => p.id === currentIdRef.current) : -1
     const startIndex = found >= 0 ? found : indexRef.current
     lastSettledRef.current = startIndex
-    programmaticRef.current = true
     emblaApi.reInit({ loop: false, align: 'center', startIndex, watchDrag: !lightboxPhoto })
   }, [emblaApi, photos.length, lightboxPhoto])
 


### PR DESCRIPTION
## Symptom

After opening a photo (or after zooming / paging the window), switching to another photo left the detail panel, histogram, zoom target, share link and URL **one photo behind** the visible slide — and the keyboard/arrows felt dead (the slide scrolled but the detail didn't update). Reproduced: 1 ArrowRight moves the slide but not the URL/`current`; a 2nd updates the URL but still lagging one behind.

This is the cause of the post-deploy reports (switch/zoom "can't load", subsequent thumbnails "don't show", keyboard "fails"). Image loading itself is fine — variants return 200; the detail just pointed at the wrong photo (one that may not be in the rendered window yet).

## Root cause

`programmaticRef` was set `true` before every embla `reInit`, relying on the assumption that **reInit always emits a `settle`** to consume and clear it. When a reInit emitted no settle (e.g. `startIndex` unchanged), the flag stayed `true` and **swallowed the user's next real settle**, so that switch's `setIndex` / `replaceState` never ran → `current` desynced from the slide. Triggered by anything that reInits (zoom toggle = `lightboxPhoto` change, or window paging = `photos.length` change) followed by a switch.

## Fix

Remove the flag entirely. The reInit effect already stores its `startIndex` in `lastSettledRef` *before* calling reInit, so the reInit's own settle lands as a no-op via the existing `i === lastSettledRef.current` check (still no zoom self-close, no spurious URL rewrite) — but now there's no flag that can stick. Every genuine user settle always syncs index / drops zoom / writes the URL.

Net `-11/+5`. No change to variant rendering, the GL-context LRU, or the zoom path.

## Verification

`tsc` clean. Logic-level fix (removes the stuck-flag class of bug). Needs a post-deploy re-trace on **both** the full-page `/preview` and the grid→modal overlay path. Note: keyboard arrows already reach the handler inside the Radix Dialog (window-level keydown isn't blocked by the focus trap), so bug-3 ("keyboard fails") is the same desync (`current` frozen), not a focus-trap issue — worth confirming on a real device after deploy.