### PR TITLE
ci: manual build+push of the latest main image (workflow_dispatch)

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual deploy: build and push `:latest` from the chosen branch (default main)
+  # without cutting a tag, so the current main can be redeployed on demand.
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## What

Adds a `workflow_dispatch` trigger to `build-main.yaml` so the multi-arch `:latest` image can be built and pushed **manually** from the chosen branch (default main), without cutting a `v*` tag first. Scope per request: just manually build+push a main image (same buildx → Docker Hub flow; no server-deploy step added).

```yaml
on:
  push:
    tags:
      - 'v*'
  workflow_dispatch:
```

## Notes

- This workflow pushes a hardcoded `:latest` tag and does **not** consume the `Get Version` step's output, so a manual (non-tag) run needs no version handling — the deprecated `${GITHUB_REF#refs/tags/}` would resolve to a branch ref on dispatch, but it's unused here, so `:latest` is simply built from the selected branch's code. (Left the unused step as-is to keep this change minimal; can remove separately if desired.)
- The existing `v*` tag trigger is unchanged.
- Not touching `build-release.yaml` (the versioned image): a manual run there *would* need a version input since its tag does use `Get Version`. Out of scope unless wanted.