### PR TITLE
ci(build-main): add manual workflow_dispatch trigger for main

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual deploy of the current main: build and push the `:latest` image on
+  # demand (defaults to the main branch) without having to cut a `v*` tag.
+  workflow_dispatch:
 
 jobs:
   build:
@@ -12,9 +15,6 @@ jobs:
     steps:
       - name: Checkout PicImpact
         uses: actions/checkout@v4
-      - name: Get Version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## What

Adds a manual trigger to the **Latest** image workflow (`build-main.yaml`) so the current `main` can be built and pushed to Docker Hub on demand, without cutting a `v*` tag.

- Add `workflow_dispatch:` alongside the existing `push: tags: ['v*']` trigger. From the Actions tab you can now run it manually (defaults to the `main` branch) → builds the multi-arch image and pushes `picimpact:latest`. The server then pulls `:latest`.
- Drop the `Get Version` step: build-main hardcodes the `picimpact:latest` tag and never referenced its `VERSION` output, so it was dead code — and under a manual (non-tag) run `${GITHUB_REF#refs/tags/}` would resolve to a branch ref, which is misleading. Removing it keeps the manual run clean.

## Scope / not changed

- The image tag stays `:latest` (the deployable tag this workflow already produces).
- The versioned release workflow (`build-release.yaml`, `v*` tags → `picimpact:<version>`) is **untouched**.
- No server-side deploy logic added — this only builds + pushes the image (existing buildx → Docker Hub), as scoped.

## Verify

After merge: GitHub → Actions → "Latest Docker Multi-arch Image CI & CD" → Run workflow (branch `main`) → confirms a fresh `picimpact:latest` is built and pushed.