### PR TITLE
fix(detail): mount WebGL viewer when opening fullscreen from the toolbar

### DIFF
--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -441,7 +441,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                           imageKey={photo.image_key}
                           readyMaxWidth={photo.ready_max_width}
                           variantBaseUrl={configData?.variantBaseUrl ?? ''}
-                          keepViewerMounted={zoomLru.includes(photo.id)}
+                          keepViewerMounted={zoomLru.includes(photo.id) || (isCurrent && lightboxPhoto)}
                           showLightbox={isCurrent && lightboxPhoto}
                           onShowLightboxChange={isCurrent ? ((value) => { setLightboxPhoto(value); if (value) bumpZoomLru(photo.id) }) : undefined}
                         />
@@ -604,6 +604,10 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                     className="inline-flex items-center justify-center cursor-pointer"
                     onClick={() => {
                       setLightboxPhoto(true)
+                      // Keep this photo's WebGL viewer mounted (same as the
+                      // in-image zoom path) so the LRU mount-gate doesn't leave
+                      // it unmounted -> blank fullscreen.
+                      if (current?.id) bumpZoomLru(current.id)
                     }}
                     {...mergeAnimatedTriggerProps({}, triggerProps)}
                   >


### PR DESCRIPTION
## Symptom

Opening a photo's fullscreen zoom from the **"View fullscreen" toolbar button** (the ⛶ icon) shows a **blank** view — the WebGL viewer never appears.

## Root cause

The detail-viewer LRU cap gates the WebGL viewer mount on:

```tsx
keepViewerMounted={zoomLru.includes(photo.id)}
```

The toolbar fullscreen button only did `setLightboxPhoto(true)` — it never added the photo to `zoomLru`. So for any photo not already zoomed via the in-image path, `keepViewerMounted` stayed `false`, the ProgressiveImage mount-gate `hasOpenedFullScreen && keepViewerMounted !== false` evaluated to `false`, and the viewer's container **never mounted** → blank fullscreen. The in-image zoom path worked only because its `onShowLightboxChange` handler bumps the LRU.

(Confirmed by devtools: clicking the toolbar button produced **no viewer canvas at all** — not a WebGL/context failure, the element simply wasn't rendered. Clicking the image body, which bumps the LRU, did mount the viewer.)

## Fix (two complementary changes)

1. **Bump the LRU from the toolbar button** too, mirroring the in-image `onShowLightboxChange` path (guarded with `current?.id` against an undefined fallback id).
2. **Mount-gate keeps the current photo's viewer mounted while its lightbox is open**: `keepViewerMounted={zoomLru.includes(photo.id) || (isCurrent && lightboxPhoto)}`. This makes any path that opens the lightbox mount the viewer, independent of LRU membership.

The LRU still caps **background/closed** zoomed viewers, so the ≤3 live-WebGL-context bound from the LRU work is preserved (the currently-open photo should always be mounted anyway).

## Verify

After deploy: open a photo → click the ⛶ "View fullscreen" button → the zoomable WebGL image should appear (previously blank). Also confirm switching/closing/re-opening still respects the ≤3 context cap.