### PR TITLE
fix(detail): mount the zoom viewer when opened via the fullscreen (⛶) button

### DIFF
--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -181,7 +181,8 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
   // limit — on top of the ±loadRadius unmount that already bounds them.
   const VIEWER_LRU_CAP = 3
   const [zoomLru, setZoomLru] = useState<string[]>([])
-  const bumpZoomLru = useCallback((id: string) => {
+  const bumpZoomLru = useCallback((id: string | undefined) => {
+    if (!id) return
     setZoomLru((prev) => [id, ...prev.filter((x) => x !== id)].slice(0, VIEWER_LRU_CAP))
   }, [])
   // Exit transition: fade the detail view out, then navigate (deferred-nav), so
@@ -441,7 +442,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                           imageKey={photo.image_key}
                           readyMaxWidth={photo.ready_max_width}
                           variantBaseUrl={configData?.variantBaseUrl ?? ''}
-                          keepViewerMounted={zoomLru.includes(photo.id)}
+                          keepViewerMounted={zoomLru.includes(photo.id) || (isCurrent && lightboxPhoto)}
                           showLightbox={isCurrent && lightboxPhoto}
                           onShowLightboxChange={isCurrent ? ((value) => { setLightboxPhoto(value); if (value) bumpZoomLru(photo.id) }) : undefined}
                         />
@@ -604,6 +605,9 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                     className="inline-flex items-center justify-center cursor-pointer"
                     onClick={() => {
                       setLightboxPhoto(true)
+                      // Mirror the image-click path: register the viewer in the LRU so
+                      // the mount-gate (keepViewerMounted) actually mounts it.
+                      bumpZoomLru(current?.id)
                     }}
                     {...mergeAnimatedTriggerProps({}, triggerProps)}
                   >


### PR DESCRIPTION
## Symptom

Clicking the **fullscreen (⛶) button** on a photo opened a blank zoom area — "can't load zoom." Happens on every device; it is **not** a WebGL/GPU issue — the viewer simply was never mounted.

## Root cause

The ⛶ button's `onClick` only set `lightboxPhoto = true`. It did **not** add the photo to the zoomed-viewer LRU, unlike the image-click path:

```
// image click (had the bump):
onShowLightboxChange = (value) => { setLightboxPhoto(value); if (value) bumpZoomLru(photo.id) }
// ⛶ button (missing the bump):
onClick = () => { setLightboxPhoto(true) }   // ← no bumpZoomLru
```

With the LRU mount-gate added earlier (`keepViewerMounted={zoomLru.includes(photo.id)}` → `progressive-image` gates the viewer on `hasOpenedFullScreen && keepViewerMounted !== false`), a photo opened via ⛶ was never in the LRU, so `keepViewerMounted` was `false` → `false !== false` → the WebGL viewer `<div>` never rendered → blank. The two zoom-open paths were asymmetric; the mount-gate was added without updating the ⛶ path.

## Fix (both, complementary)

- **A** — the ⛶ button now also calls `bumpZoomLru(current?.id)`, mirroring the image-click path. `bumpZoomLru` now ignores a falsy id defensively.
- **B** — the mount-gate also keeps the currently-open photo mounted regardless of which path opened it:
  `keepViewerMounted={zoomLru.includes(photo.id) || (isCurrent && lightboxPhoto)}`.
  This root-fixes the whole class (any route that sets `lightboxPhoto`) and does **not** relax the LRU's ≤3 cap — the current photo should always be mounted; the rest stay LRU-bound.

`tsc` + `eslint` clean. The viewer-lifecycle / GL-context LRU behavior is otherwise unchanged. (Verification needs a real GPU browser — the fullscreen WebGL viewer can't be exercised headless; the fix is that the viewer `<div>` now mounts on the ⛶ path, which is environment-independent.)