### PR TITLE
fix(detail): portal the fullscreen zoom viewer to body (escape the modal dialog transform)

### DIFF
--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -2,6 +2,7 @@
 
 import type { ProgressiveImageProps } from '~/types/props.ts'
 import { useEffect, useState, useRef, Activity } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslations } from 'next-intl'
 import { MotionImage } from '~/components/album/motion-image'
 import { useBlurImageDataUrl } from '~/hooks/use-blurhash'
@@ -237,7 +238,17 @@ export default function ProgressiveImage(
               view, and pointer-events are disabled while hidden so the invisible
               overlay never blocks the page. Mounted lazily on first open so the
               engine isn't built until the user actually zooms. */}
-          {hasOpenedFullScreen && props.keepViewerMounted !== false && (
+          {/* Portal the fullscreen viewer to <body>. In the @modal route the
+              detail lives inside Radix DialogContent, which is `position:fixed`
+              with `translate(-50%,-50%)` — a transformed ancestor becomes the
+              containing block for `position:fixed` descendants, so the viewer's
+              `inset-0` would map to the dialog box (shifted/clipped → blank)
+              instead of the viewport. Portaling to body escapes that transform so
+              the viewer covers the real viewport. (The full-page route has no such
+              ancestor, which is why it worked there.) The modal already sets
+              `onInteractOutside=preventDefault` + `modal={false}`, so viewer
+              interaction outside DialogContent doesn't dismiss the dialog. */}
+          {hasOpenedFullScreen && props.keepViewerMounted !== false && typeof document !== 'undefined' && createPortal((
             webGLAvailable ? <div
               className="fixed inset-0 z-[100] bg-background/95 flex items-center justify-center"
               style={{ visibility: showFullScreenViewer ? 'visible' : 'hidden', pointerEvents: showFullScreenViewer ? 'auto' : 'none' }}
@@ -332,7 +343,7 @@ export default function ProgressiveImage(
                 alt={props.alt || 'image'}
               />
             </div>
-          )}
+          ), document.body)}
         </>
       ) : null}
 


### PR DESCRIPTION
## Symptom

Grid → modal → open photo zoom = **blank/white**, but the direct `/preview/{id}` (full-page) URL zooms fine. Environment-independent (full-page renders on the same GPU). Distinct from the LRU mount-gate fix.

## Root cause

In the `@modal` route the detail view renders inside Radix **DialogContent**, whose base styles are `position:fixed; top:50%; left:50%; translate-x-[-50%] translate-y-[-50%]` (+ `zoom-in/out-95` animations). Per CSS, a **transformed ancestor becomes the containing block for `position:fixed` descendants** — so the WebGL fullscreen viewer (`fixed inset-0 z-[100]`, rendered inside DialogContent) had its `inset-0` resolved against the dialog's translated/clipped box instead of the viewport → off-screen/clipped → blank. The full-page route has no DialogContent ancestor, so it worked there.

## Fix

Render the viewer via `createPortal(viewer, document.body)` so it escapes the transformed ancestor and covers the real viewport.

- React tree unchanged — only the DOM parent moves to `body`. The **#510 lifecycle** (mount on `hasOpenedFullScreen`, `visibility` toggle, `destroy` on unmount) and the GL-context LRU are untouched.
- SSR guard: `typeof document !== 'undefined'` (viewer is client-only + only after `hasOpenedFullScreen`).
- Dismiss interaction: `modal.tsx` already sets `onInteractOutside={(e)=>e.preventDefault()}` + `modal={false}`, so interacting with the portaled viewer (now DOM-outside DialogContent) does **not** dismiss the dialog.
- z-index: viewer `z-[100]` > dialog `z-50`; both at body level → viewer on top.

`tsc` + `eslint` clean. Headless can't exercise the modal WebGL viewer (no GPU + soft-nav intercept), so post-deploy verification: devtools confirms the viewer's `boundingClientRect` is the full viewport (0,0,vw,vh) rather than the dialog box, and Manjusaka confirms zoom renders in the modal on his device.