### PR TITLE
fix(detail): portal fullscreen viewer to body so modal zoom isn't blank

### DIFF
--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -2,6 +2,7 @@
 
 import type { ProgressiveImageProps } from '~/types/props.ts'
 import { useEffect, useState, useRef, Activity } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslations } from 'next-intl'
 import { MotionImage } from '~/components/album/motion-image'
 import { useBlurImageDataUrl } from '~/hooks/use-blurhash'
@@ -237,7 +238,14 @@ export default function ProgressiveImage(
               view, and pointer-events are disabled while hidden so the invisible
               overlay never blocks the page. Mounted lazily on first open so the
               engine isn't built until the user actually zooms. */}
-          {hasOpenedFullScreen && props.keepViewerMounted !== false && (
+          {/* Portal the fullscreen overlay to <body> so its `fixed inset-0`
+              positioning is relative to the viewport. When the detail page is
+              opened as the intercepted-route modal, an ancestor (Radix
+              DialogContent) carries a `translate(-50%,-50%)` transform, which
+              would otherwise become the containing block for `position: fixed`
+              and trap the viewer inside the dialog box → blank fullscreen. The
+              guard keeps it inert during SSR. */}
+          {hasOpenedFullScreen && props.keepViewerMounted !== false && typeof document !== 'undefined' && createPortal(
             webGLAvailable ? <div
               className="fixed inset-0 z-[100] bg-background/95 flex items-center justify-center"
               style={{ visibility: showFullScreenViewer ? 'visible' : 'hidden', pointerEvents: showFullScreenViewer ? 'auto' : 'none' }}
@@ -331,7 +339,8 @@ export default function ProgressiveImage(
                 src={highResImageUrl}
                 alt={props.alt || 'image'}
               />
-            </div>
+            </div>,
+            document.body
           )}
         </>
       ) : null}


### PR DESCRIPTION
## Symptom

Opening a photo's fullscreen zoom from the **intercepted-route modal** (album grid → detail) shows a **blank** screen. The same photo opened via a **direct `/preview/<id>` link works** fine.

## Root cause

The fullscreen overlay (`components/album/progressive-image.tsx`) uses `position: fixed; inset: 0`. In the modal, it is a descendant of Radix `DialogContent`, whose class includes `translate-x-[-50%] translate-y-[-50%]` (plus a `zoom-in-95` open animation). A transformed ancestor establishes the **containing block** for `position: fixed` descendants, so the viewer was positioned relative to the dialog box rather than the viewport → it never covered the screen → blank.

The full-page `/preview/<id>` route has no transformed ancestor, which is exactly why that path worked.

(GPU-independent — the viewer mounts; it's just mispositioned/clipped. The earlier "View fullscreen toolbar button" mount-gate fix, #528, is a separate issue on a different path.)

## Fix

Render the overlay through `createPortal(..., document.body)` so its `fixed` positioning is always relative to the viewport, independent of any transformed ancestor. Guarded with `typeof document !== 'undefined'` for SSR.

- The overlay stays in the React tree (portals preserve it), so the keep-mounted lifecycle + WebGL viewer teardown from the LRU work are unchanged.
- The modal wrapper already prevents interact-outside dismissal (`onInteractOutside` → `preventDefault`), so portaling the viewer out of `DialogContent` doesn't let zoom gestures close the dialog.
- `z-[100]` keeps the viewer above the dialog `z-50` (both at body level after portal).

## Verify

After deploy: album grid → open a photo (modal) → click the photo / "View fullscreen" → the zoomable image should now fill the viewport (previously blank). Direct `/preview/<id>` should remain unaffected. Devtools: the overlay's `boundingClientRect` should be `0,0,vw,vh`, not trapped in the dialog box.

(Headless note: the intercepted-route modal can't be reproduced in headless — synthetic clicks fall through to the full-page route — so the modal-path verification needs a real browser / Manjusaka.)