### PR TITLE
fix(detail): stabilize image-area height to stop the per-switch layout jump (CLS)

### DIFF
--- a/components/album/preview-image.tsx
+++ b/components/album/preview-image.tsx
@@ -431,8 +431,12 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
     >
       <TransitionOverlay />
       <div className="relative h-full flex flex-col space-y-2 sm:grid sm:gap-4 sm:grid-cols-3 w-full">
-        <div className="show-up-motion relative sm:col-span-2 sm:flex sm:justify-center sm:max-h-[90vh] select-none">
-          <div className="overflow-hidden w-full" ref={emblaRef}>
+        {/* Fixed 90vh height on desktop (not max-h) so the image area never
+            resizes to each photo's aspect ratio — different aspects letterbox
+            within a constant box instead of changing the row height on every
+            switch (that height jump was the remaining "flicker"). CLS≈0. */}
+        <div className="show-up-motion relative sm:col-span-2 sm:flex sm:justify-center sm:h-[90vh] select-none">
+          <div className="overflow-hidden w-full sm:h-full" ref={emblaRef}>
             <div className="flex h-full">
               {photos.map((photo, i) => {
                 const near = Math.abs(i - index) <= loadRadius
@@ -441,7 +445,7 @@ export default function PreviewImage(props: Readonly<PreviewImageHandleProps>) {
                   <div
                     key={photo.id}
                     data-flip-target={isCurrent ? '' : undefined}
-                    className="relative flex min-w-0 shrink-0 grow-0 basis-full items-center justify-center sm:max-h-[90vh]"
+                    className="relative flex min-w-0 shrink-0 grow-0 basis-full items-center justify-center sm:h-full"
                   >
                     {near ? (
                       photo.type === 1 ? (


### PR DESCRIPTION
## Symptom

After the histogram/zoom flicker fixes deployed, the detail view still visibly "flickered" / jumped on switch and load (Manjusaka, real device). Profiling pinned the residual cause: **image-area CLS ~0.06** — the whole modal reflows on each switch.

## Cause

The image area used `sm:max-h-[90vh]` (a *max*), so it sized to each photo's contained height. Switching between photos of different aspect ratios changed the row height every time → the modal jumped/reflowed.

## Fix

Make the image area a **fixed `sm:h-[90vh]`** box on desktop; the carousel viewport and slides fill it (`sm:h-full`), and the image keeps `object-contain` centered. Different aspect ratios now **letterbox within a constant-height box** instead of resizing it → height no longer changes on switch → CLS ≈ 0, no jump.

- Mobile unchanged (no `sm:` height → still sizes to content).
- Accepted trade-off (agreed with the team): landscape photos get more top/bottom letterboxing within the fixed box — that's the cost of a stable height.
- No change to the carousel logic, zoom viewer, or data.

## Verification

`tsc` clean. Can't measure CLS headless on the modal path reliably; post-deploy: re-profile to confirm CLS → ~0 and Manjusaka confirms the switch/load jump is gone. Known secondary (deferred): the `MotionImage` 1s fade-in could be shortened if a "soft" fade still reads as flicker after this; and the ~313-mutation full re-render per switch (memoize slides/strip) remains a perf follow-up.