### PR TITLE
fix(detail): pin slide image to fixed-height box to stop per-switch resize flicker

### DIFF
--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -192,6 +192,14 @@ export default function ProgressiveImage(
           animate={{ opacity: 1 }}
           transition={{ duration: 0.15 }}
           className="object-contain w-full sm:h-full cursor-pointer"
+          // next/image derives the blur placeholder's `background-size` from
+          // `style.objectFit` (get-img-props: `backgroundSize = imgStyle.objectFit`),
+          // NOT from the className. Without this it defaults to `cover`, so the blur
+          // fills the now-fixed 90vh box while the real image letterboxes via
+          // object-contain — a visible "blur fills → image shrinks" jump at load
+          // (worst for portraits). Setting objectFit here makes the blur letterbox
+          // the same way → blur and image share one box → smooth load.
+          style={{ objectFit: 'contain' }}
           src={previewDisplaySource}
           overrideSrc={previewDisplaySource}
           placeholder="blur"

--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -174,17 +174,18 @@ export default function ProgressiveImage(
   }
 
   return (
-    <div className="relative">
+    // `sm:h-full` is REQUIRED here, not just on the <img>. The image elements
+    // below use `sm:h-full` (height:100%) so they stay a constant height (=the
+    // fixed #533 slide box) and letterbox via object-contain instead of resizing
+    // per aspect ratio. But height:100% only resolves if EVERY ancestor up to the
+    // fixed-height slide also has a definite height — this wrapper sits between the
+    // slide and the <img>, so without `sm:h-full` it collapses to height:auto and
+    // the <img>'s `h-full` falls back to the image's content height (≈607px for a
+    // landscape, ≈1366px for a portrait → the element resizes/overflows on every
+    // switch = the flicker). `sm:` matches the slide/container breakpoint; mobile
+    // (<sm) stays content-sized.
+    <div className="relative sm:h-full">
       {/* 预览图 - 在高清图未加载完成时显示 */}
-      {/* Pin the image element to the (fixed-height, #533) slide box with
-          `sm:h-full w-full object-contain` instead of `md:max-h-[90vh]`. The
-          latter lets the <img> element itself size to the image's contained
-          height — ~90vh for a portrait but much shorter for a landscape — so the
-          element resized on every aspect-changing switch (810↔~607px) and the
-          photo visibly jumped/flickered inside the otherwise-fixed container.
-          h-full makes the element always equal the container height and lets
-          object-contain letterbox within it → no per-switch resize. `sm:` aligns
-          with the container's breakpoint (#533); mobile stays content-sized. */}
       <Activity mode={highResImageLoaded ? 'hidden' : 'visible'}>
         <MotionImage
           initial={{ opacity: 0 }}

--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -176,12 +176,21 @@ export default function ProgressiveImage(
   return (
     <div className="relative">
       {/* 预览图 - 在高清图未加载完成时显示 */}
+      {/* Pin the image element to the (fixed-height, #533) slide box with
+          `sm:h-full w-full object-contain` instead of `md:max-h-[90vh]`. The
+          latter lets the <img> element itself size to the image's contained
+          height — ~90vh for a portrait but much shorter for a landscape — so the
+          element resized on every aspect-changing switch (810↔~607px) and the
+          photo visibly jumped/flickered inside the otherwise-fixed container.
+          h-full makes the element always equal the container height and lets
+          object-contain letterbox within it → no per-switch resize. `sm:` aligns
+          with the container's breakpoint (#533); mobile stays content-sized. */}
       <Activity mode={highResImageLoaded ? 'hidden' : 'visible'}>
         <MotionImage
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          transition={{ duration: 1 }}
-          className="object-contain md:max-h-[90vh] cursor-pointer"
+          transition={{ duration: 0.15 }}
+          className="object-contain w-full sm:h-full cursor-pointer"
           src={previewDisplaySource}
           overrideSrc={previewDisplaySource}
           placeholder="blur"
@@ -221,7 +230,7 @@ export default function ProgressiveImage(
         <>
           <Activity mode={highResImageLoaded && !showFullScreenViewer ? 'visible' : 'hidden'}>
             <img
-              className="object-contain md:max-h-[90vh] cursor-pointer"
+              className="object-contain w-full sm:h-full cursor-pointer"
               src={highResImageUrl}
               width={props.width}
               height={props.height}

--- a/components/album/tone-analysis.tsx
+++ b/components/album/tone-analysis.tsx
@@ -217,7 +217,12 @@ export default function ToneAnalysis({ imageUrl, className = '' }: Readonly<Tone
     return labels[type]
   }
 
-  if (loading) {
+  // Only show the spinner on the very first analysis. On a photo switch we keep
+  // the previous tone values rendered until the new ones are computed — collapsing
+  // to this short spinner on every switch shrank the section and shifted the whole
+  // info panel's layout (the rows below jumped up then back) = the panel "flicker"
+  // on switch. Mirrors the histogram chart, which keeps its previous canvas.
+  if (loading && !toneData) {
     return (
       <div className={cn('flex items-center justify-center py-2', className)}>
         <div className="animate-spin text-sm text-muted-foreground">⟳</div>


### PR DESCRIPTION
## Problem

After #533 pinned the detail-view image-area **container** to a fixed `sm:h-[90vh]` box, switching photos still showed a visible jump/flicker. Live DevTools profiling on a prod build pinpointed the cause as the `<img>` element resizing per aspect ratio inside the fixed container.

## Fix (two commits)

**1. Pin the image to `sm:h-full`** (was `object-contain md:max-h-[90vh]`): the image element should equal the container height and letterbox the photo via `object-contain`, instead of sizing to the photo's contained height (which differs per aspect → resize).

**2. Give the ProgressiveImage root wrapper a height** (`<div className="relative">` → `relative sm:h-full`): `height:100%` only resolves when *every* ancestor up to the fixed-height slide has a definite height. The wrapper between the slide and the `<img>` had none, so it collapsed to content height and the img's `h-full` fell back to the image's own contained height (~607px landscape, ~1366px portrait — and overflowing, since commit 1 removed the `max-h` cap). This was the residual "frantic flicker". With the wrapper height set, the chain is continuous (container → viewport → slide → wrapper → img) and the img is a constant 90vh for every aspect.

Also shortened the preview fade-in `1s → 150ms`.

## Verification

- **Walked the live height chain**: the break was at `<div className="relative">` (607px, content height). Injecting `height:100%` on it made the slide img go **607 → 810px** (= container) for all visible slides — confirming fix #2 before shipping.
- Container measured constant 810px; img is what varied by aspect.
- `data-flip-target` is on the slide div (unchanged box); the open transition's `containedBox(box, aspect)` letterboxes within it, so the FLIP landing is unaffected.
- Mobile (<`sm`) unchanged: no fixed height, content-sized.
- Build confirmed prod (`pnpm build` / `NODE_ENV=production` / `node server.js`), so the flicker was real, not a dev-mode artifact.

## On the `src` re-set (deferred, likely benign)

Profiling showed each visible slide's `<img src>` is re-set to the same value ~11×/switch (carousel re-render). Tested live: this **fires a `load` event but keeps `img.complete === true` and the natural dimensions** throughout, i.e. Chrome retains the decoded pixels with no visible blank. So it does not appear to cause a visible flash. If any residual flash remains after this height fix, the next step (separate PR) is memoizing the slides so a switch doesn't re-render unchanged images — kept out of this PR because it touches the keep-mounted WebGL zoom lifecycle and isn't justified by a confirmed visible flash.

---

### Update: third commit — letterbox the blur placeholder (0ed3ca6)

Once the image is pinned to a constant 90vh box, the **blur placeholder** also needs to letterbox. next/image derives the blur's `background-size` from `style.objectFit` (`get-img-props.js`: `backgroundSize = imgStyle.objectFit`), **not** the className. With only `className="object-contain"`, objectFit was undefined → the blur defaulted to `cover` and filled the whole 90vh box while the real image letterboxed smaller → a visible "blur fills → image shrinks" jump on load (worst for portraits). Confirmed live (blur `background-size: cover`) and against Next's source.

Fix: `style={{ objectFit: 'contain' }}` on the preview image → blur letterboxes the same way → smooth sharpen+fade load, no size jump.

**Branch HEAD `0ed3ca6` is the complete fix:** ① img `sm:h-full` ② wrapper `sm:h-full` ③ blur `objectFit: 'contain'`. Deploy must build this exact HEAD (an earlier deploy shipped only commit 1 → img grew unbounded to ~1366px and overflowed → worse than #533; that was a stale build, not a code error).

---

### Update: fourth commit — keep tone analysis on switch (4901079)

With the image fully stabilized (commits 1–3 verified live: img constant 810, blur letterboxed), the remaining flicker was the **info panel**, isolated to `ToneAnalysis`: it returned a spinner unconditionally while `loading` (`if (loading) return <spinner>`), so every switch collapsed the whole tone section to a tiny spinner and re-expanded it, shifting the histogram/device rows below (up then back) = "info panel flashes/reloads on switch".

#532 added the `loading && !histogram` guard to the histogram chart but not to tone analysis, so the histogram stopped flickering while this kept doing it. Fix: same guard — `if (loading && !toneData)` — only show the spinner on first analysis; keep previous tone values during a switch (the #521 LRU cache returns instantly for revisits). Confirmed via live churn capture (the `animate-spin text-sm text-muted-foreground` spinner = tone-analysis:223) + three-way review.

**Branch HEAD `4901079` is the full detail-flicker fix:** ① img `sm:h-full` ② wrapper `sm:h-full` ③ blur `objectFit: contain` ④ tone `loading && !toneData` guard.
