### PR TITLE
fix(detail): stop switch/load flicker — pin image height, letterbox blur, keep tone panel (on top of #535)

### DIFF
--- a/components/album/progressive-image.tsx
+++ b/components/album/progressive-image.tsx
@@ -174,11 +174,27 @@ export default function ProgressiveImage(
   }
 
   return (
-    <div className="relative">
+    // `sm:h-full` is REQUIRED here, not just on the <img>. The images below use
+    // `sm:h-full` (height:100%) so they stay a constant height (= the fixed #533
+    // slide box) and letterbox via object-contain instead of resizing per aspect
+    // ratio. height:100% only resolves if EVERY ancestor up to the fixed-height
+    // slide also has a definite height — this wrapper sits between the slide and
+    // the <img>, so without `sm:h-full` it collapses to height:auto and the
+    // <img>'s `h-full` falls back to the image's content height (≈607px landscape,
+    // ≈1366px portrait → resizes/overflows on every switch = the flicker). `sm:`
+    // matches the slide/container breakpoint; mobile (<sm) stays content-sized.
+    <div className="relative sm:h-full">
       {/* 预览图 - 在高清图未加载完成时显示 */}
       <Activity mode={highResImageLoaded ? 'hidden' : 'visible'}>
         <MotionImage
-          className="object-contain md:max-h-[90vh] cursor-pointer"
+          className="object-contain w-full sm:h-full cursor-pointer"
+          // next/image derives the blur placeholder's `background-size` from
+          // `style.objectFit` (get-img-props: `backgroundSize = imgStyle.objectFit`),
+          // NOT the className. Without this it defaults to `cover`, so the blur fills
+          // the fixed 90vh box while the real image letterboxes via object-contain —
+          // a visible "blur fills → image shrinks" jump at load (worst for portraits).
+          // Setting objectFit here makes the blur letterbox the same way → smooth load.
+          style={{ objectFit: 'contain' }}
           src={previewDisplaySource}
           overrideSrc={previewDisplaySource}
           placeholder="blur"
@@ -218,7 +234,7 @@ export default function ProgressiveImage(
         <>
           <Activity mode={highResImageLoaded && !showFullScreenViewer ? 'visible' : 'hidden'}>
             <img
-              className="object-contain md:max-h-[90vh] cursor-pointer"
+              className="object-contain w-full sm:h-full cursor-pointer"
               src={highResImageUrl}
               width={props.width}
               height={props.height}

--- a/components/album/tone-analysis.tsx
+++ b/components/album/tone-analysis.tsx
@@ -217,7 +217,12 @@ export default function ToneAnalysis({ imageUrl, className = '' }: Readonly<Tone
     return labels[type]
   }
 
-  if (loading) {
+  // Only show the spinner on the very first analysis. On a photo switch we keep
+  // the previous tone values rendered until the new ones are computed — collapsing
+  // to this short spinner on every switch shrank the section and shifted the whole
+  // info panel's layout (the rows below jumped up then back) = the panel "flicker"
+  // on switch. Mirrors the histogram chart, which keeps its previous canvas.
+  if (loading && !toneData) {
     return (
       <div className={cn('flex items-center justify-center py-2', className)}>
         <div className="animate-spin text-sm text-muted-foreground">⟳</div>


### PR DESCRIPTION
## Summary

Rebuilt on top of **#535** (which removed the preview fade animation). #535 alone didn't fix the dominant detail-view flicker because it kept `object-contain md:max-h-[90vh]` and didn't touch the info panel. This adds the remaining **verified** fixes (supersedes #534, which was based on pre-#535 main and conflicted):

1. **Image height pinned** — `<img>` (preview + high-res) `md:max-h-[90vh]` → `object-contain w-full sm:h-full`, and the ProgressiveImage root wrapper `relative` → `relative sm:h-full` so the `height:100%` chain resolves (container `sm:h-[90vh]` → viewport → slide → **wrapper** → img). The img element stays a constant 90vh for every aspect instead of resizing ~607↔1366px and overflowing on each switch. Verified live: injecting the wrapper height made the slide img go **607 → 810px**.

2. **Blur placeholder letterboxed** — `style={{ objectFit: 'contain' }}` on the preview image. next/image derives the blur's `background-size` from `style.objectFit` (`get-img-props.js`: `backgroundSize = imgStyle.objectFit`), not the className — without it the blur filled the fixed box via `cover` while the real image letterboxed smaller = a load flash (worst for portraits). Confirmed live (was `background-size: cover`).

3. **Tone analysis kept on switch** — `if (loading)` → `if (loading && !toneData)`. It returned a spinner unconditionally, so each switch collapsed the tone section and shifted the whole info panel's layout (rows below jumped up/back) = "info panel flashes on switch". Mirrors the histogram guard from #532, which was never applied to tone analysis.

## Not touched / not regressed
- #535's removal of the preview fade animation is **kept** (no `initial/animate/transition` re-added).
- #530 `createPortal` and #532 `MemoWebGLImageViewer` are intact (zoom-blank / zoom-load-flicker not regressed).
- #521 tone-analysis LRU cache + debounce untouched (only the loading gate changed).

## Verification plan
Deploy this branch HEAD → I confirm deployed == HEAD on live (img constant 810 across aspects + tone doesn't collapse on switch) → Manjusaka real-device verifies switch + load → Impl walks the height chain + measures the panel on switch.
