### PR TITLE
ci: stamp builds with git SHA + /api/public/version for deploy verification

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout PicImpact
         uses: actions/checkout@v4
+      - name: Resolve build SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -33,4 +36,10 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/picimpact:latest
+          build-args: |
+            BUILD_SHA=${{ steps.sha.outputs.short }}
+          # Also tag with the commit so the pushed image is identifiable, and the
+          # running container reports the same value at GET /api/public/version.
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/picimpact:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/picimpact:git-${{ steps.sha.outputs.short }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,11 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+# Git commit this image was built from, passed by the build workflow. Exposed at
+# runtime via GET /api/public/version so a deploy's running commit is verifiable.
+ARG BUILD_SHA=unknown
+ENV BUILD_SHA=${BUILD_SHA}
+
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 

--- a/app/api/[[...route]]/route.ts
+++ b/app/api/[[...route]]/route.ts
@@ -5,6 +5,7 @@ import route from '~/hono'
 import download from '~/hono/open/download'
 import images from '~/hono/open/images'
 import cameraLens from '~/hono/open/camera-lens'
+import version from '~/hono/open/version'
 
 const app = new Hono().basePath('/api')
 
@@ -13,6 +14,7 @@ app.route('/v1', route)
 app.route('/public/download', download)
 app.route('/public/images', images)
 app.route('/public/camera-lens', cameraLens)
+app.route('/public/version', version)
 app.notFound((c) => {
   return c.text('not found', 404)
 })

--- a/hono/open/version.ts
+++ b/hono/open/version.ts
@@ -1,0 +1,18 @@
+import 'server-only'
+
+import { Hono } from 'hono'
+import { ok } from '~/hono/_lib/response'
+
+const app = new Hono()
+
+// Public deployment marker. Returns the git commit the running image was built
+// from (`BUILD_SHA`, injected as a Docker build-arg by the build-main workflow).
+// Lets a deploy be verified at a glance — `curl /api/public/version` reports the
+// commit actually running — instead of guessing whether `:latest` is the branch
+// HEAD (which has repeatedly caused half-deploy confusion). Falls back to
+// "unknown" for local/dev builds where the arg isn't set.
+app.get('/', (c) => {
+  return ok(c, { sha: process.env.BUILD_SHA ?? 'unknown' })
+})
+
+export default app


### PR DESCRIPTION
## Why

Several recent rounds were lost to **not knowing what was actually deployed** — a manual build run before the latest commit was pushed, a stale `:latest` pull, and the #534-vs-#535 mixup. The only way to tell what was live was hand-inspecting rendered DOM classes. This makes the deployed commit verifiable at a glance.

## What

- **build-main workflow**: resolve the short commit SHA, pass it as a `BUILD_SHA` build-arg, and tag the pushed image `:git-<sha>` alongside `:latest` (so the image is identifiable by commit, not just `latest`).
- **Dockerfile**: accept `ARG BUILD_SHA` (default `unknown`) and set it as a runtime env in the runner stage.
- **GET `/api/public/version`** (hono public route): returns `{ "code": 200, "data": { "sha": "<commit>" } }`.

## Usage

After a deploy:

```
curl -s https://photos.manjusaka.me/api/public/version
# { "data": { "sha": "b880071..." }, ... }
```

Compare to the branch HEAD you intended to ship — if they differ, the deploy didn't take (rebuild/repull) **before** spending time debugging behaviour.

## Scope

- Independent of any feature work (workflow + Dockerfile + one new public route). No app behaviour change. Local/dev builds without the arg report `"unknown"`.
- Public, unauthenticated, no sensitive data (just the commit short SHA, which is already public on GitHub).